### PR TITLE
Support wp.Uploader changes in plupload. Fixes #41

### DIFF
--- a/js/plupload.js
+++ b/js/plupload.js
@@ -1,17 +1,17 @@
 jQuery(document).ready(function($) {
 	liveblog.uploader = new wp.Uploader({
 
-	    /* Selectors */
+		/* Selectors */
 		browser:   '#liveblog-messages',
-	    dropzone:  '#liveblog-form-entry',
+		dropzone:  '#liveblog-form-entry',
 
-	    /* Callbacks */
-	    success  : function( attachment ) {
-			$( '#liveblog-form-entry'     ).val( $('#liveblog-form-entry' ).val() + '<img src="' + attachment.url + '" />' );
-			$( '#liveblog-messages' ).html( attachment.filename + ' Finished' );
+		/* Callbacks */
+		success  : function( attachment ) {
+			$( '#liveblog-form-entry'     ).val( $('#liveblog-form-entry' ).val() + '<img src="' + attachment.attributes.url + '" />' );
+			$( '#liveblog-messages' ).html( attachment.attributes.filename + ' Finished' );
 			$( '#liveblog-actions'        ).removeClass( 'uploading' );
-	    },
- 
+		},
+
 		error    : function ( reason ) {
 			$( '#liveblog-messages' ).html( reason );
 		},
@@ -20,8 +20,8 @@ jQuery(document).ready(function($) {
 			$( '#liveblog-actions' ).addClass( 'uploading' );
 		},
 
-		progress : function( up, file ) {
-			$( '#liveblog-messages' ).html( "Uploading: " + file.name + ' ' + file.percent + '%' );
+		progress : function( up ) {
+			$( '#liveblog-messages' ).html( "Uploading: " + up.attributes.file.name + ' ' + up.attributes.file.percent + '%' );
 		},
 
 		complete : function() {


### PR DESCRIPTION
The objects passed to `success` and `progress` as arguments have changed.  The callbacks have been updated to reflect those changes.

See #41
