### PR TITLE
Fixes issue with IE8 not displaying new liveblog post notifications.

### DIFF
--- a/js/liveblog.js
+++ b/js/liveblog.js
@@ -264,7 +264,7 @@ var liveblog = {};
 	};
 
 	liveblog.current_timestamp = function() {
-		return Math.floor( Date.now() / 1000 );
+		return Math.floor( new Date().getTime() / 1000 );
 	};
 
 	liveblog.server_timestamp_from_xhr = function(xhr) {


### PR DESCRIPTION
<strong>Date.now() is not supported in IE8 and breaks auto notification of new liveblog posts. However, Date().getTime() is supported.</strong>

Fixes issue <a href="https://github.com/Automattic/liveblog/issues/44">#44</a>.

Tested and confirmed working in IE8 now, as well as:
- Chrome v. 22.0.1229.94 m
- Firefox v. 16.0.1
- IE 9.0.8112.16421
