### PR TITLE
Allow easier customization of live blog entries without requiring template modifications

### DIFF
--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -99,10 +99,7 @@ class WPCOM_Liveblog_Entry {
 
 		$entry = $this->get_fields_for_render();
 
-		// used to ensure that no keys are unset
-		$empty_entry = array_fill_keys( array_keys( $entry ), '' );
 		$entry = apply_filters( 'liveblog_entry_template_variables', $entry );
-		$entry = wp_parse_args( $entry, $empty_entry );
 
 		return WPCOM_Liveblog::get_template_part( 'liveblog-single-entry.php', $entry );
 	}


### PR DESCRIPTION
- Add `WPCOM_Liveblog_Entry::get_entry` to consistently retrieve an entry.
- Add `liveblog_entry_template_variables filter` to allow easy modification of values used by the template.
