### PR TITLE
Add additional javascript init event, provide way to format timestamps easier

### DIFF
--- a/js/liveblog.js
+++ b/js/liveblog.js
@@ -16,13 +16,17 @@ window.liveblog = {};
 				liveblog.queue.flush();
 			}
 		},
-		updateTimes: function() {
+		updateTimes: function() {        
+			var self = this;
 			this.$('.liveblog-entry').each(function() {
 				var $entry = $(this),
 					timestamp = $entry.data('timestamp'),
-					human = moment.unix(timestamp).fromNow();
+					human = self.formatTimestamp(timestamp);
 				$('.liveblog-meta-time a', $entry).text(human);
 			});
+		},
+		formatTimestamp: function(timestamp) {
+			return moment.unix(timestamp).fromNow();
 		}
 	});
 
@@ -128,6 +132,7 @@ window.liveblog = {};
 		liveblog.fixedNag = new liveblog.FixedNagView();
 		liveblog.entriesContainer = new liveblog.EntriesView();
 		liveblog.titleBarCount = new liveblog.TitleBarCountView();
+		liveblog.$events.trigger( 'after-views-init' );
 
 		liveblog.init_moment_js();
 


### PR DESCRIPTION
Trigger after-views-init after views are loaded, but before anything else happens.
Move timestamp formatting to its own function to allow easy overrides (during after-views-init).

This allows a user to customize the output of an entry timestamp output. As seen below, entries in the past 60 minutes are shown with relative time, while older entries are formatted as as H:MMmeridiem.
![mixed-timestamps](https://f.cloud.github.com/assets/715247/90931/6162ac86-6588-11e2-8ac4-b0b1820edd61.png)
### Example Code

``` php
<?php
add_action('wp_enqueue_scripts', function() {
  /**
   * Enqueue x-liveblog-extras.js to modify our timestamps
   * Use wp_enqueue_script to ensure that our script always loads after the liveblog script
   */
  if( class_exists('WPCOM_Liveblog') && WPCOM_Liveblog::is_liveblog_post() ) {
    wp_enqueue_script( 'x-liveblog-extras', get_bloginfo('template_directory') .'/js/x-liveblog-extras.js', array(WPCOM_Liveblog::key), '1.0', true );
  }
});
/**
 * Add two new variables to be used when formatting timestamps
 *
 */
function x_liveblog_settings($settings) {
  $settings['x_humanTimeThreshold'] = 15; // time in minutes
  $settings['x_timeFormat'] = 'h:mmA'; // new format
  return $settings;
}
add_filter( 'liveblog_settings', 'x_liveblog_settings' );

```

``` javascript
// contents of /js/x-liveblog-extras.js
if( liveblog ) {
  jQuery(liveblog.$events).on( 'after-views-init', function() {
    if( !liveblog_settings.x_humanTimeThreshold )
      liveblog_settings.x_humanTimeThreshold = 15;

    if( !liveblog_settings.x_timeFormat )
      liveblog_settings.x_timeFormat = 'h:mmA';

    liveblog.entriesContainer.formatTimestamp = function(timestamp) {
      var now = moment().unix();
      if( (moment().unix() - timestamp)/60 > liveblog_settings.x_humanTimeThreshold ) {
        return moment.unix(timestamp).format( liveblog_settings.x_timeFormat );
      } else {
        return moment.unix(timestamp).fromNow();
      }
      return time;
    };
  });
}
```
