### PR TITLE
First check DOING_AJAX in is_entries_ajax_request

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -394,6 +394,9 @@ final class WPCOM_Liveblog {
 	 * @return bool
 	 */
 	private static function is_entries_ajax_request() {
+		if ( ! defined( 'DOING_AJAX' ) || ! DOING_AJAX )
+			return false;
+		
 		return (bool) get_query_var( self::url_endpoint );
 	}
 


### PR DESCRIPTION
If DOING_AJAX is not true, it's not an ajax request.
This also fixes the unit tests because get_query_var
doesn't get called.

Fixes #122
