### PR TITLE
We don't want Liveblog added to other loops

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -650,6 +650,12 @@ final class WPCOM_Liveblog {
 	 */
 	 public static function add_liveblog_to_content( $content ) {
 
+		// We don't want to add the liveblog to other loops
+		// on the same page
+		if ( ! self::is_viewing_liveblog_post() ) {
+			return $content;
+		}
+
 		$liveblog_output  = '<div id="liveblog-container" class="'. self::$post_id .'">';
 		$liveblog_output .= self::get_editor_output();
 		$liveblog_output .= '<div id="liveblog-update-spinner"></div>';


### PR DESCRIPTION
When using more than one loop on a single post, Liveblog inserts itself into every post on the page, not just the live blog posts.

This PR adds a check to ensure it only adds itself to the liveblog post and no others.