### PR TITLE
Link to author page instead of url of user

### DIFF
--- a/templates/liveblog-single-entry.php
+++ b/templates/liveblog-single-entry.php
@@ -2,10 +2,14 @@
 	<header class="liveblog-meta">
 		<span class="liveblog-author-avatar"><?php echo $avatar_img; ?></span>
 		<span class="liveblog-author-name">
-		<?php if( current_user_can('editor') || current_user_can('administrator') ) {   
-			the_author_posts_link();
-		 } else { 
-			echo $author_link; ?>
+		<?php
+			$user = wp_get_current_user();
+			$allowed_roles = array('editor', 'administrator', 'author');
+			if( array_intersect($allowed_roles, $user->roles ) ) {
+	
+				the_author_posts_link();
+			 } else { 
+				echo $author_link; ?>
 		<?php } ?>
 		</span>
 		<span class="liveblog-meta-time"><a href="#liveblog-entry-<?php echo $entry_id; ?>"><span class="date"><?php echo $entry_date; ?></span><span class="time"><?php echo $entry_time; ?></span></a></span>


### PR DESCRIPTION
With the change the link in the Liveblog header will point to the author page when it is an author, editor or administrator.
