### PR TITLE
Bump to version 1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ If you'd like to check out the code and contribute, [join us on github](https://
 
 ## Changelog
 
+### 1.4.1
+
+* Bump tested tag to 4.2.2.
+* Added Composer support!
+
 ### 1.4
 
 * Rich-text editing!

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 * Contributors: [automattic](http://profiles.wordpress.org/automattic), [nbachiyski](http://profiles.wordpress.org/nbachiyski), [batmoo](http://profiles.wordpress.org/batmoo), [johnjamesjacoby](http://profiles.wordpress.org/johnjamesjacoby), [philipjohn](http://profiles.wordpress.org/philipjohn)
 * Tags: liveblog
 * Requires at least: 3.5
-* Tested up to: 4.1.1
-* Stable tag: 1.4
+* Tested up to: 4.2.2
+* Stable tag: 1.4.1
 * License: GPLv2 or later
 * License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/liveblog.php
+++ b/liveblog.php
@@ -4,7 +4,7 @@
  * Plugin Name: Liveblog
  * Plugin URI: http://wordpress.org/extend/plugins/liveblog/
  * Description: Blogging: at the speed of live.
- * Version:     1.4
+ * Version:     1.4.1
  * Author:      WordPress.com VIP, Automattic
  * Author URI: http://vip.wordpress.com/
  * Text Domain: liveblog

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: automattic, nbachiyski, batmoo, johnjamesjacoby
 Tags: liveblog
 Requires at least: 3.5
-Tested up to: 4.1.1
-Stable tag: 1.4
+Tested up to: 4.2.2
+Stable tag: 1.4.1
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
Bump to 1.4.1 with the addition of Composer support.

Revise tested tag to 4.2.2.