### PR TITLE
Missing end slash breaks comment classes locally

### DIFF
--- a/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php
@@ -166,7 +166,7 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Hashtags extends WPCOM_Liveblog_Entry_
 		if ( WPCOM_Liveblog::key == $comment->comment_type ) {
 
 			// Grab all the prefixed classes applied.
-			preg_match_all( '/(?<!\w)'.preg_quote( $this->class_prefix ).'(\w\-?)+', $comment->comment_content, $terms );
+			preg_match_all( '/(?<!\w)'.preg_quote( $this->class_prefix ).'(\w\-?)+/', $comment->comment_content, $terms );
 
 			// Append the first class to the classes array.
 			$classes = array_merge( $classes, $terms[0] );


### PR DESCRIPTION
Creates a PHP warning, and throws out all class for each entry