### PR TITLE
Key Events compatible lazyloading

### DIFF
--- a/classes/class-wpcom-liveblog-entry-query.php
+++ b/classes/class-wpcom-liveblog-entry-query.php
@@ -139,4 +139,35 @@ class WPCOM_Liveblog_Entry_Query {
 
 		return $result;
 	}
+
+	/**
+	 * Returns the Liveblog entries between the two given (optional) timestamps.
+	 *
+	 * @param int $max_timestamp Maximum timestamp for the Liveblog entries.
+	 * @param int $min_timestamp Minimum timestamp for the Liveblog entries.
+	 *
+	 * @return WPCOM_Liveblog_Entry[]
+	 */
+	public function get_for_lazyloading( $max_timestamp, $min_timestamp ) {
+
+		$entries = $this->get_all();
+		if ( ! $entries ) {
+			return array();
+		}
+
+		if ( $max_timestamp ) {
+			foreach ( $entries as $key => $entry ) {
+				$timestamp = $entry->get_timestamp();
+
+				if (
+					( $max_timestamp && $timestamp >= $max_timestamp )
+					|| ( $min_timestamp && $timestamp <= $min_timestamp )
+				) {
+					unset( $entries[ $key ] );
+				}
+			}
+		}
+
+		return $entries;
+	}
 }

--- a/classes/class-wpcom-liveblog-lazyloader.php
+++ b/classes/class-wpcom-liveblog-lazyloader.php
@@ -57,7 +57,7 @@ class WPCOM_Liveblog_Lazyloader {
 	public static function late_load() {
 
 		if ( has_action( 'init', 'Lazyload_Liveblog_Entries' ) ) {
-			if ( is_admin() ) {
+			if ( is_admin() && current_user_can( 'activate_plugins' ) ) {
 				add_action( 'admin_notices', array( __CLASS__, 'admin_notices' ) );
 			}
 

--- a/classes/class-wpcom-liveblog-lazyloader.php
+++ b/classes/class-wpcom-liveblog-lazyloader.php
@@ -138,7 +138,7 @@ class WPCOM_Liveblog_Lazyloader {
 			$number = $number_of_default_entries;
 		}
 
-		$args['number'] = $number;
+		$args['number'] = (int) $number;
 
 		return $args;
 	}
@@ -163,7 +163,7 @@ class WPCOM_Liveblog_Lazyloader {
 		wp_enqueue_script( $handle, plugins_url( $path, $plugin_path ), array( 'liveblog' ), filemtime( $temp ), true );
 		wp_localize_script( $handle, 'liveblogLazyloaderSettings', array(
 			'loadMoreButtonText' => esc_html__( 'Load more entries&hellip;', 'liveblog' ),
-			'numberOfEntries'    => self::$number_of_entries,
+			'numberOfEntries'    => (int) self::$number_of_entries,
 		) );
 	}
 }

--- a/classes/class-wpcom-liveblog-lazyloader.php
+++ b/classes/class-wpcom-liveblog-lazyloader.php
@@ -84,7 +84,11 @@ class WPCOM_Liveblog_Lazyloader {
 		 *
 		 * @param int $number_of_entries Number of Liveblog entries.
 		 */
-		self::$number_of_entries = (int) apply_filters( 'liveblog_number_of_entries', self::$number_of_entries );
+		$number_of_entries = (int) apply_filters( 'liveblog_number_of_entries', self::$number_of_entries );
+		// TODO: Limit number of entries to some not yet defined maximum value.
+		if ( $number_of_entries > 0 ) {
+			self::$number_of_entries = $number_of_entries;
+		}
 
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_script' ) );
 

--- a/classes/class-wpcom-liveblog-lazyloader.php
+++ b/classes/class-wpcom-liveblog-lazyloader.php
@@ -137,7 +137,7 @@ class WPCOM_Liveblog_Lazyloader {
 		 *
 		 * @param int $number_of_default_entries Number of initially displayed Liveblog entries.
 		 */
-		$number = (int) apply_filters( 'number_of_default_entries', 10 );
+		$number = (int) apply_filters( 'number_of_default_entries', $number_of_default_entries );
 		if ( $number < 0 ) {
 			$number = $number_of_default_entries;
 		}

--- a/classes/class-wpcom-liveblog-lazyloader.php
+++ b/classes/class-wpcom-liveblog-lazyloader.php
@@ -80,14 +80,13 @@ class WPCOM_Liveblog_Lazyloader {
 		}
 
 		/**
-		 * Filters the number of Liveblog entries used both for initial display, and lazyloading.
+		 * Filters the number of Liveblog entries used for lazyloading.
 		 *
 		 * @param int $number_of_entries Number of Liveblog entries.
 		 */
-		$number_of_entries = (int) apply_filters( 'liveblog_number_of_entries', self::$number_of_entries );
-		// TODO: Limit number of entries to some not yet defined maximum value.
+		$number_of_entries = min( apply_filters( 'liveblog_number_of_entries', self::$number_of_entries ), 100 );
 		if ( $number_of_entries > 0 ) {
-			self::$number_of_entries = $number_of_entries;
+			self::$number_of_entries = (int) $number_of_entries;
 		}
 
 		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_script' ) );
@@ -137,7 +136,7 @@ class WPCOM_Liveblog_Lazyloader {
 		 *
 		 * @param int $number_of_default_entries Number of initially displayed Liveblog entries.
 		 */
-		$number = (int) apply_filters( 'number_of_default_entries', $number_of_default_entries );
+		$number = apply_filters( 'number_of_default_entries', $number_of_default_entries );
 		if ( $number < 0 ) {
 			$number = $number_of_default_entries;
 		}

--- a/classes/class-wpcom-liveblog-lazyloader.php
+++ b/classes/class-wpcom-liveblog-lazyloader.php
@@ -166,8 +166,8 @@ class WPCOM_Liveblog_Lazyloader {
 		$temp = plugin_dir_path( $plugin_path ) . $path;
 		wp_enqueue_script( $handle, plugins_url( $path, $plugin_path ), array( 'liveblog' ), filemtime( $temp ), true );
 		wp_localize_script( $handle, 'liveblogLazyloaderSettings', array(
-			'loadMoreButtonText' => esc_html__( 'Load more entries&hellip;', 'liveblog' ),
-			'numberOfEntries'    => (int) self::$number_of_entries,
+			'loadMoreText'    => __( 'Load more entries&hellip;', 'liveblog' ),
+			'numberOfEntries' => (int) self::$number_of_entries,
 		) );
 	}
 }

--- a/classes/class-wpcom-liveblog-lazyloader.php
+++ b/classes/class-wpcom-liveblog-lazyloader.php
@@ -52,11 +52,14 @@ class WPCOM_Liveblog_Lazyloader {
 	 */
 	private static function is_robot() {
 
-		if ( ! isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
-			return false;
+		// Variant determiner for caches.
+		if ( function_exists( 'vary_cache_on_function' ) ) {
+			vary_cache_on_function(
+				'return isset( $_SERVER[\'HTTP_USER_AGENT\'] ) && preg_match( \'/bot|crawl|slurp|spider/i\', $_SERVER[\'HTTP_USER_AGENT\'] );'
+			);
 		}
 
-		return (bool) preg_match( '/bot|crawl|slurp|spider/i', $_SERVER['HTTP_USER_AGENT'] );
+		return isset( $_SERVER['HTTP_USER_AGENT'] ) && preg_match( '/bot|crawl|slurp|spider/i', $_SERVER['HTTP_USER_AGENT'] );
 	}
 
 	/**

--- a/classes/class-wpcom-liveblog-lazyloader.php
+++ b/classes/class-wpcom-liveblog-lazyloader.php
@@ -1,0 +1,140 @@
+<?php
+
+/**
+ * Class WPCOM_Liveblog_Lazyloader
+ *
+ * Handles lazyloading of Liveblog entries.
+ */
+class WPCOM_Liveblog_Lazyloader {
+
+	/**
+	 * @var bool
+	 */
+	private static $enabled = true;
+
+	/**
+	 * @var int
+	 */
+	protected static $number_of_entries = 5;
+
+	/**
+	 * Checks if the lazyload feature is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_enabled() {
+
+		return self::$enabled;
+	}
+
+	/**
+	 * Returns the number of Liveblog entries used both for initial display, and lazyloading.
+	 *
+	 * @return int
+	 */
+	public static function get_number_of_entries() {
+
+		return self::$number_of_entries;
+	}
+
+	/**
+	 * Called by WPCOM_Liveblog::load(), defers partloading to when Liveblog has been initialized.
+	 *
+	 * @return void
+	 */
+	public static function load() {
+
+		add_action( 'after_liveblog_init', array( __CLASS__, 'late_load' ) );
+	}
+
+	/**
+	 * Wires up the lazyload functions.
+	 *
+	 * @wp-hook after_liveblog_init
+	 *
+	 * @return void
+	 */
+	public static function late_load() {
+
+		if ( has_action( 'init', 'Lazyload_Liveblog_Entries' ) ) {
+			if ( is_admin() ) {
+				add_action( 'admin_notices', array( __CLASS__, 'admin_notices' ) );
+			}
+
+			// Disable the Lazyload Liveblog Entries plugin.
+			remove_action( 'init', 'Lazyload_Liveblog_Entries' );
+		}
+
+		/**
+		 * Enables/Disables the lazyload feature for Liveblog entries.
+		 *
+		 * @param bool $enabled Enable the lazyload feature for Liveblog entries?
+		 */
+		self::$enabled = (bool) apply_filters( 'liveblog_enable_lazyloader', self::$enabled );
+		if ( ! self::$enabled ) {
+			return;
+		}
+
+		/**
+		 * Filters the number of Liveblog entries used both for initial display, and lazyloading.
+		 *
+		 * @param int $number_of_entries Number of Liveblog entries.
+		 */
+		self::$number_of_entries = (int) apply_filters( 'liveblog_number_of_entries', self::$number_of_entries );
+
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_script' ) );
+
+		add_filter( 'liveblog_display_archive_query_args', array( __CLASS__, 'display_archive_query_args' ), 20 );
+	}
+
+	/**
+	 * Renders lazyloading-specific admin notices.
+	 *
+	 * @wp-hook admin_notices
+	 *
+	 * @return void
+	 */
+	public static function admin_notices() {
+
+		echo WPCOM_Liveblog::get_template_part( 'lazyload-notice.php', array( 'plugin' => 'Lazyload Liveblog Entries' ) );
+	}
+
+	/**
+	 * Limits the initially displayed Liveblog entries.
+	 *
+	 * @param array $args Query args.
+	 *
+	 * @return array
+	 */
+	public static function display_archive_query_args( $args ) {
+
+		$args['number'] = self::$number_of_entries;
+
+		return $args;
+	}
+
+	/**
+	 * Enqueues the lazyload script file.
+	 *
+	 * @wp-hook wp_enqueue_scripts
+	 *
+	 * @return void
+	 */
+	public static function enqueue_script() {
+
+		if ( ! WPCOM_Liveblog::is_viewing_liveblog_post() ) {
+			return;
+		}
+
+		$handle = 'liveblog-lazyloader';
+		$path = 'js/liveblog-lazyloader.js';
+		$plugin_path = dirname( __FILE__ );
+		$temp = plugin_dir_path( $plugin_path ) . $path;
+		wp_enqueue_script( $handle, plugins_url( $path, $plugin_path ), array( 'liveblog' ), filemtime( $temp ), true );
+		wp_localize_script( $handle, 'liveblogLazyloaderSettings', array(
+			'loadMoreButtonText' => esc_html__( 'Load more entries&hellip;', 'liveblog' ),
+			'numberOfEntries'    => self::$number_of_entries,
+			'url'                => get_permalink() . WPCOM_Liveblog::url_endpoint . '/lazyload/',
+		) );
+	}
+}

--- a/classes/class-wpcom-liveblog-lazyloader.php
+++ b/classes/class-wpcom-liveblog-lazyloader.php
@@ -114,7 +114,7 @@ class WPCOM_Liveblog_Lazyloader {
 	}
 
 	/**
-	 * Enqueues the lazyload script file.
+	 * Enqueues the lazyloader script file.
 	 *
 	 * @wp-hook wp_enqueue_scripts
 	 *
@@ -134,7 +134,6 @@ class WPCOM_Liveblog_Lazyloader {
 		wp_localize_script( $handle, 'liveblogLazyloaderSettings', array(
 			'loadMoreButtonText' => esc_html__( 'Load more entries&hellip;', 'liveblog' ),
 			'numberOfEntries'    => self::$number_of_entries,
-			'url'                => get_permalink() . WPCOM_Liveblog::url_endpoint . '/lazyload/',
 		) );
 	}
 }

--- a/classes/class-wpcom-liveblog-lazyloader.php
+++ b/classes/class-wpcom-liveblog-lazyloader.php
@@ -38,7 +38,7 @@ class WPCOM_Liveblog_Lazyloader {
 	}
 
 	/**
-	 * Called by WPCOM_Liveblog::load(), defers partloading to when Liveblog has been initialized.
+	 * Called by WPCOM_Liveblog::load(), defers loading to when Liveblog has been initialized.
 	 *
 	 * @return void
 	 */

--- a/classes/class-wpcom-liveblog-lazyloader.php
+++ b/classes/class-wpcom-liveblog-lazyloader.php
@@ -126,7 +126,19 @@ class WPCOM_Liveblog_Lazyloader {
 	 */
 	public static function display_archive_query_args( $args ) {
 
-		$args['number'] = self::$number_of_entries;
+		$number_of_default_entries = 10;
+
+		/**
+		 * Filters the number of initially displayed Liveblog entries.
+		 *
+		 * @param int $number_of_default_entries Number of initially displayed Liveblog entries.
+		 */
+		$number = (int) apply_filters( 'number_of_default_entries', 10 );
+		if ( $number < 0 ) {
+			$number = $number_of_default_entries;
+		}
+
+		$args['number'] = $number;
 
 		return $args;
 	}

--- a/classes/class-wpcom-liveblog-lazyloader.php
+++ b/classes/class-wpcom-liveblog-lazyloader.php
@@ -71,6 +71,10 @@ class WPCOM_Liveblog_Lazyloader {
 		 * @param bool $enabled Enable the lazyload feature for Liveblog entries?
 		 */
 		self::$enabled = (bool) apply_filters( 'liveblog_enable_lazyloader', self::$enabled );
+		if ( self::$enabled && self::is_robot() ) {
+			// No lazyloading for robots.
+			self::$enabled = false;
+		}
 		if ( ! self::$enabled ) {
 			return;
 		}
@@ -97,6 +101,20 @@ class WPCOM_Liveblog_Lazyloader {
 	public static function admin_notices() {
 
 		echo WPCOM_Liveblog::get_template_part( 'lazyload-notice.php', array( 'plugin' => 'Lazyload Liveblog Entries' ) );
+	}
+
+	/**
+	 * Checks if the current "visitor" is a robot.
+	 *
+	 * @return bool
+	 */
+	public static function is_robot() {
+
+		if ( ! isset( $_SERVER['HTTP_USER_AGENT'] ) ) {
+			return false;
+		}
+
+		return (bool) preg_match( '/bot|crawl|slurp|spider/i', $_SERVER['HTTP_USER_AGENT'] );
 	}
 
 	/**

--- a/css/liveblog.css
+++ b/css/liveblog.css
@@ -603,3 +603,13 @@ a.liveblog-form-entry::-webkit-input-placeholder {
 	padding-left: 20px;
 	display: inline-block;
 }
+
+/* =Load More Buttons
+-------------------------------------------------------------- */
+
+.liveblog-load-more {
+	display: block;
+	margin: 1em 0;
+	padding: 2em 0;
+	width: 100%;
+}

--- a/js/liveblog-lazyloader.js
+++ b/js/liveblog-lazyloader.js
@@ -22,7 +22,7 @@
 			lazyloader.entrySets = [];
 
 			$.get( liveblog_settings.endpoint_url + 'lazyload', {}, function( response ) {
-				if ( ! response.entries.length ) {
+				if ( ! response.entries || ! response.entries.length ) {
 					$( '.liveblog-load-more' ).remove();
 				} else {
 					lazyloader.entrySets[0] = response.entries;
@@ -85,7 +85,7 @@
 
 		renderEntries: function() {
 			var $this = $( this ),
-				setIndex = $this.data( 'set-index' ) || 0;
+				setIndex = $this.data( 'set-index' );
 			$.each( lazyloader.entrySets[ setIndex ].slice( 0, settings.numberOfEntries ), function( i, entry ) {
 				$this.before( $( entry.html ) );
 			} );

--- a/js/liveblog-lazyloader.js
+++ b/js/liveblog-lazyloader.js
@@ -1,4 +1,4 @@
-/* global jQuery, liveblog, liveblogLazyloaderSettings */
+/* global jQuery, liveblog, liveblog_settings, liveblogLazyloaderSettings */
 ( function ( $, settings ) {
 	"use strict";
 
@@ -21,7 +21,7 @@
 		fetchEntries: function() {
 			lazyloader.entrySets = [];
 
-			$.get( settings.url, {}, function( response ) {
+			$.get( liveblog_settings.endpoint_url + 'lazyload', {}, function( response ) {
 				if ( ! response.entries.length ) {
 					$( '.liveblog-load-more' ).remove();
 				} else {

--- a/js/liveblog-lazyloader.js
+++ b/js/liveblog-lazyloader.js
@@ -77,7 +77,7 @@
 			lazyloader.entrySets[ setIndex ] = lazyloader.entrySets[ setIndex ].slice( 0, entryIndex );
 
 			var $button = $( '<button />' );
-			$button.addClass( 'liveblog-load-more' ).data( 'set-index', newSetIndex ).text( settings.loadMoreText );
+			$button.addClass( 'liveblog-load-more' ).attr( 'data-set-index', newSetIndex ).text( settings.loadMoreText );
 			liveblog.$entry_container.find( '.liveblog-load-more[data-set-index="' + setIndex + '"]' ).after( $button );
 
 			return newSetIndex;

--- a/js/liveblog-lazyloader.js
+++ b/js/liveblog-lazyloader.js
@@ -1,0 +1,103 @@
+/* global jQuery, liveblog, liveblogLazyloaderSettings */
+( function ( $, settings ) {
+	"use strict";
+
+	var lazyloader = {
+
+		initialize: function() {
+			if ( ! liveblog.$entry_container.length ) {
+				return;
+			}
+
+			lazyloader.fetchEntries();
+
+			if ( liveblog.$key_entry_container.length ) {
+				liveblog.$key_entry_container.on( 'click', 'a', lazyloader.clickKeyEventLink );
+			}
+
+			liveblog.$entry_container.on( 'click', '.liveblog-load-more', lazyloader.renderEntries );
+		},
+
+		fetchEntries: function() {
+			lazyloader.entrySets = [];
+
+			$.get( settings.url, {}, function( response ) {
+				if ( ! response.entries.length ) {
+					$( '.liveblog-load-more' ).remove();
+				} else {
+					lazyloader.entrySets[0] = response.entries;
+				}
+			} );
+		},
+
+		clickKeyEventLink: function() {
+			var $this = $( this );
+			if ( $( $this.attr( 'href' ) ).length ) {
+				return;
+			}
+
+			var entryID = $this.data( 'entry-id' );
+			if ( ! entryID ) {
+				return;
+			}
+
+			var setIndex = lazyloader.findEntrySet( entryID );
+			if ( setIndex === -1 ) {
+				return;
+			}
+
+			var $button = liveblog.$entry_container.find( '.liveblog-load-more[data-set-index="' + setIndex + '"]' );
+			lazyloader.renderEntries.call( $button );
+		},
+
+		findEntrySet: function( entryID ) {
+			var newSetIndex = -1;
+
+			$.each( lazyloader.entrySets, function( setIndex, entries ) {
+				$.each( entries, function( entryIndex, entry ) {
+					if ( entry.id != entryID || newSetIndex !== -1 ) {
+						return;
+					}
+
+					if ( entryIndex > 0 ) {
+						newSetIndex = lazyloader.splitEntrySet( setIndex, entryIndex );
+					} else {
+						newSetIndex = setIndex;
+					}
+				} );
+			} );
+
+			return newSetIndex;
+		},
+
+		splitEntrySet: function( setIndex, entryIndex ) {
+			var newSetIndex = lazyloader.entrySets.length;
+
+			lazyloader.entrySets[ newSetIndex ] = lazyloader.entrySets[ setIndex ].slice( entryIndex );
+			lazyloader.entrySets[ setIndex ] = lazyloader.entrySets[ setIndex ].slice( 0, entryIndex );
+
+			liveblog.$entry_container.find( '.liveblog-load-more[data-set-index="' + setIndex + '"]' )
+				.after( $( '<button class="liveblog-load-more">' ).attr( 'data-set-index', newSetIndex ).html( settings.loadMoreButtonText ) );
+
+			return newSetIndex;
+		},
+
+		renderEntries: function() {
+			var $this = $( this ),
+				setIndex = $this.data( 'set-index' ) || 0;
+			$.each( lazyloader.entrySets[ setIndex ].slice( 0, settings.numberOfEntries ), function( i, entry ) {
+				$this.before( $( entry.html ) );
+			} );
+
+			lazyloader.entrySets[ setIndex ] = lazyloader.entrySets[ setIndex ].slice( settings.numberOfEntries );
+			if ( lazyloader.entrySets[ setIndex ].length ) {
+				$this.blur();
+			} else {
+				$this.remove();
+			}
+		}
+	};
+
+	$( lazyloader.initialize );
+
+} )( jQuery, liveblogLazyloaderSettings );

--- a/js/liveblog-lazyloader.js
+++ b/js/liveblog-lazyloader.js
@@ -1,100 +1,311 @@
 /* global jQuery, liveblog, liveblog_settings, liveblogLazyloaderSettings */
-( function ( $, settings ) {
-	"use strict";
+( function( $, settings ) {
+	'use strict';
 
 	var lazyloader = {
 
+		/**
+		 * Initializes properties, fetches the first entries, and attaches event handlers.
+		 */
 		initialize: function() {
-			if ( ! liveblog.$entry_container.length ) {
-				return;
-			}
+			lazyloader.entrySets = [];
 
+			lazyloader.setBusy();
 			lazyloader.fetchEntries();
+
+			liveblog.$entry_container.on( 'click', '.liveblog-load-more', lazyloader.clickLoadMoreButton );
 
 			if ( liveblog.$key_entry_container.length ) {
 				liveblog.$key_entry_container.on( 'click', 'a', lazyloader.clickKeyEventLink );
 			}
-
-			liveblog.$entry_container.on( 'click', '.liveblog-load-more', lazyloader.renderEntries );
 		},
 
-		fetchEntries: function() {
-			lazyloader.entrySets = [];
+		/**
+		 * Sets the internal busy state, and disables the load more buttons.
+		 */
+		setBusy: function() {
+			liveblog.$entry_container.find( '.liveblog-load-more' ).attr( 'disabled', 'disabled' );
 
-			$.get( liveblog_settings.endpoint_url + 'lazyload', {}, function( response ) {
+			lazyloader.busy = true;
+		},
+
+		/**
+		 * Unsets the internal busy state, and enables the load more buttons.
+		 */
+		setUnbusy: function() {
+			lazyloader.busy = false;
+
+			liveblog.$entry_container.find( '.liveblog-load-more' ).removeAttr( 'disabled' );
+		},
+
+		/**
+		 * Returns the inernal busy state.
+		 * @returns {boolean}
+		 */
+		isBusy: function() {
+			return lazyloader.busy;
+		},
+
+		/**
+		 * Fetches the next entries for the entry set with the given index.
+		 * @param {number} [setIndex=0] - The index of an entry set.
+		 */
+		fetchEntries: function( setIndex ) {
+			setIndex = setIndex || 0;
+
+			// Instantiate now to avoid a collision after the AJAX request.
+			lazyloader.entrySets[ setIndex ] = [];
+
+			var $button = lazyloader.getButton( setIndex );
+			if ( ! $button.length ) {
+				return;
+			}
+
+			var $previousEntry = $button.prev( '.liveblog-entry' ),
+				$nextEntry = $button.next( '.liveblog-entry' ),
+				maxTimestamp = 0,
+				minTimestamp = 0,
+				url = liveblog_settings.endpoint_url + 'lazyload/';
+
+			if ( $previousEntry.length ) {
+				maxTimestamp = parseInt( $previousEntry.data( 'timestamp' ) ) || 0;
+			}
+
+			if ( $nextEntry.length ) {
+				minTimestamp = parseInt( $nextEntry.data( 'timestamp' ) ) || 0;
+			}
+
+			if ( maxTimestamp || minTimestamp ) {
+				url = url + maxTimestamp + '/' + minTimestamp + '/';
+			}
+
+			var data = {
+				index: setIndex
+			};
+			$.get( url, data, function( response ) {
+				var index = response.index;
+
+				var $button = lazyloader.getButton( index );
+
 				if ( ! response.entries || ! response.entries.length ) {
-					$( '.liveblog-load-more' ).remove();
+					$button.remove();
 				} else {
-					lazyloader.entrySets[0] = response.entries;
+					$button.blur();
+
+					lazyloader.entrySets[ index ] = response.entries;
+				}
+
+				lazyloader.setUnbusy();
+			} );
+		},
+
+		/**
+		 * Returns the button with the given entry set index.
+		 * @param {number} index - The index of an entry set.
+		 * @returns {HTMLElement} - The button HTML element.
+		 */
+		getButton: function( index ) {
+			return liveblog.$entry_container.find( '.liveblog-load-more[data-set-index="' + index + '"]' );
+		},
+
+		/**
+		 * Triggers rendering of the according entries.
+		 */
+		clickLoadMoreButton: function() {
+			lazyloader.setBusy();
+
+			lazyloader.renderEntries( $( this ).data( 'set-index' ) );
+		},
+
+		/**
+		 * Renders the entries in the entry set with the given ID, and fetches new entries for it.
+		 * @param {number} setIndex - The index of an entry set.
+		 */
+		renderEntries: function( setIndex ) {
+			var $button = lazyloader.getButton( setIndex );
+			if ( ! $button.length ) {
+				return;
+			}
+
+			$.each( lazyloader.entrySets[ setIndex ], function( i, entry ) {
+				if ( entry.html ) {
+					$button.before( $( entry.html ) );
 				}
 			} );
+
+			// Convert the timestamps of the newly inserted entries into human time diffed timestamps.
+			liveblog.entriesContainer.updateTimes();
+
+			lazyloader.fetchEntries( setIndex );
 		},
 
-		clickKeyEventLink: function() {
-			var $this = $( this );
-			if ( $( $this.attr( 'href' ) ).length ) {
+		/**
+		 * Fetches the entry for the according Key Event, if necessary, and renders it.
+		 * @param {event} e - The event.
+		 */
+		clickKeyEventLink: function( e ) {
+			if ( lazyloader.isBusy() ) {
+				e.preventDefault();
+
 				return;
 			}
+
+			var $this = $( this );
+
+			if ( $( $this.attr( 'href' ) ).length ) {
+
+				// The according element is already in the DOM, so there's nothing to do.
+				return;
+			}
+
+			lazyloader.setBusy();
 
 			var entryID = $this.data( 'entry-id' );
-			if ( ! entryID ) {
-				return;
-			}
 
 			var setIndex = lazyloader.findEntrySet( entryID );
-			if ( setIndex === -1 ) {
-				return;
-			}
+			if ( setIndex >= 0 ) {
+				lazyloader.renderEntries( setIndex );
+			} else {
 
-			var $button = liveblog.$entry_container.find( '.liveblog-load-more[data-set-index="' + setIndex + '"]' );
-			lazyloader.renderEntries.call( $button );
+				// The according entry could not be found in the entry sets, so fetch it first.
+				lazyloader.fetchAndRenderKeyEventEntry( entryID );
+			}
 		},
 
+		/**
+		 * Returns the index of the entry set that contains the entry with the given ID.
+		 * @param {number} entryID - The ID of an entry.
+		 * @returns {number} - The index of the entry set that contains the entry with the given ID.
+		 */
 		findEntrySet: function( entryID ) {
-			var newSetIndex = -1;
+			var foundIndex = -1;
 
 			$.each( lazyloader.entrySets, function( setIndex, entries ) {
-				$.each( entries, function( entryIndex, entry ) {
-					if ( entry.id != entryID || newSetIndex !== -1 ) {
-						return;
-					}
+				var entryIndex = lazyloader.findEntry( entryID, entries );
+				if ( entryIndex >= 0 ) {
+					foundIndex = ( 0 === entryIndex ) ? setIndex : lazyloader.splitEntrySet( setIndex, entryIndex );
 
-					if ( entryIndex > 0 ) {
-						newSetIndex = lazyloader.splitEntrySet( setIndex, entryIndex );
-					} else {
-						newSetIndex = setIndex;
-					}
-				} );
+					// Leave the loop.
+					return false;
+				}
 			} );
 
-			return newSetIndex;
+			return foundIndex;
 		},
 
+		/**
+		 * Returns the index of the entry with the given ID in the given entries.
+		 * @param {number} entryID - The ID of the entry that is to be found.
+		 * @param {Object[]} entries - The entry objects that are searched for the entry with the given ID.
+		 * @param {string} entries[].id - The ID of the entry.
+		 * @returns {number} - The index of the entry that is to be found.
+		 */
+		findEntry: function( entryID, entries ) {
+			var foundIndex = -1;
+
+			$.each( entries, function( entryIndex, entry ) {
+				if ( entry.id == entryID ) {
+					foundIndex = entryIndex;
+
+					// Leave the loop.
+					return false;
+				}
+			} );
+
+			return foundIndex;
+		},
+
+		/**
+		 * Splits the entry set with the given index at the given entry index.
+		 * @param {number} setIndex - The index of the entry set that is to be split.
+		 * @param {number} entryIndex - The index of the entry where the entry set is to be split at.
+		 * @returns {number} - The new entry set index.
+		 */
 		splitEntrySet: function( setIndex, entryIndex ) {
 			var newSetIndex = lazyloader.entrySets.length;
 
 			lazyloader.entrySets[ newSetIndex ] = lazyloader.entrySets[ setIndex ].slice( entryIndex );
 			lazyloader.entrySets[ setIndex ] = lazyloader.entrySets[ setIndex ].slice( 0, entryIndex );
 
-			var $button = $( '<button />' );
-			$button.addClass( 'liveblog-load-more' ).attr( 'data-set-index', newSetIndex ).text( settings.loadMoreText );
-			liveblog.$entry_container.find( '.liveblog-load-more[data-set-index="' + setIndex + '"]' ).after( $button );
+			var $button = lazyloader.getButton( setIndex );
+			if ( $button.length ) {
+				$button.after( lazyloader.createButton( newSetIndex ) );
+			}
 
 			return newSetIndex;
 		},
 
-		renderEntries: function() {
-			var $this = $( this ),
-				setIndex = $this.data( 'set-index' );
-			$.each( lazyloader.entrySets[ setIndex ].slice( 0, settings.numberOfEntries ), function( i, entry ) {
-				$this.before( $( entry.html ) );
+		/**
+		 * Returns a newly created button for the given entry set index.
+		 * @param {number} index - The index of the entry set for which the button is to be created.
+		 * @returns {HTMLElement} - The button HTML element.
+		 */
+		createButton: function( index ) {
+			var $button = $( '<button />' );
+			$button.addClass( 'liveblog-load-more' ).attr( 'data-set-index', index ).text( settings.loadMoreText );
+
+			return $button;
+		},
+
+		/**
+		 * Fetches and renders the Key Event entry with the given ID.
+		 * @param {number} entryID - The ID of the Key Event entry that is to be rendered.
+		 */
+		fetchAndRenderKeyEventEntry: function( entryID ) {
+			var newSetIndex = lazyloader.entrySets.length;
+
+			// Instantiate now to avoid a collision after the AJAX request.
+			lazyloader.entrySets[ newSetIndex ] = [];
+
+			var data = {
+				index: newSetIndex
+			};
+			$.get( liveblog_settings.endpoint_url + 'entry/' + entryID, data, function( response ) {
+				if ( ! response.entries ) {
+					return;
+				}
+
+				var index = response.index;
+
+				lazyloader.entrySets[ index ] = response.entries;
+
+				lazyloader.insertKeyEventButton( index, response.previousTimestamp, response.nextTimestamp );
+
+				lazyloader.renderEntries( index );
+
+				$( 'html, body' ).animate( {
+					scrollTop: $( window.location.hash ).offset().top
+				}, 200 );
+			} );
+		},
+
+		/**
+		 * Creates a new button and inserts it at the correct location into the DOM wrt. the given timestamps.
+		 * @param {number} index - The index of an entry set.
+		 * @param {number} previousTimestamp - The timestamp of the entry immediately before the Key Event entry.
+		 * @param {number} nextTimestamp - The timestamp of the entry immediately after the Key Event entry.
+		 */
+		insertKeyEventButton: function( index, previousTimestamp, nextTimestamp ) {
+			var $button;
+
+			liveblog.$entry_container.find( '.liveblog-load-more' ).each( function() {
+				var $this = $( this ),
+					$previousEntry = $this.prev( '.liveblog-entry' ),
+					$nextEntry = $this.next( '.liveblog-entry' );
+
+				if (
+					$previousEntry.data( 'timestamp' ) >= nextTimestamp
+					&& ( ! $nextEntry.length || $nextEntry.data( 'timestamp' ) <= previousTimestamp )
+				) {
+					$button = $this;
+
+					// Leave the loop.
+					return false;
+				}
 			} );
 
-			lazyloader.entrySets[ setIndex ] = lazyloader.entrySets[ setIndex ].slice( settings.numberOfEntries );
-			if ( lazyloader.entrySets[ setIndex ].length ) {
-				$this.blur();
-			} else {
-				$this.remove();
+			if ( $button && $button.length ) {
+				$button.after( lazyloader.createButton( index ) );
 			}
 		}
 	};

--- a/js/liveblog-lazyloader.js
+++ b/js/liveblog-lazyloader.js
@@ -76,8 +76,9 @@
 			lazyloader.entrySets[ newSetIndex ] = lazyloader.entrySets[ setIndex ].slice( entryIndex );
 			lazyloader.entrySets[ setIndex ] = lazyloader.entrySets[ setIndex ].slice( 0, entryIndex );
 
-			liveblog.$entry_container.find( '.liveblog-load-more[data-set-index="' + setIndex + '"]' )
-				.after( $( '<button class="liveblog-load-more">' ).attr( 'data-set-index', newSetIndex ).html( settings.loadMoreButtonText ) );
+			var $button = $( '<button />' );
+			$button.addClass( 'liveblog-load-more' ).data( 'set-index', newSetIndex ).text( settings.loadMoreText );
+			liveblog.$entry_container.find( '.liveblog-load-more[data-set-index="' + setIndex + '"]' ).after( $button );
 
 			return newSetIndex;
 		},

--- a/templates/lazyload-notice.php
+++ b/templates/lazyload-notice.php
@@ -1,0 +1,12 @@
+<div class="error">
+<p>
+<?php
+printf(
+	/* translators: 1: plugin name, 2: plugins page URL */
+	__( 'Please <a href="%2$s">deactivate the %1$s plugin</a> as Liveblog itself comes now with built-in lazyloading.', 'liveblog' ),
+	$plugin,
+	admin_url( 'plugins.php?plugin_status=active' )
+);
+?>
+</p>
+</div>

--- a/templates/liveblog-key-single-list.php
+++ b/templates/liveblog-key-single-list.php
@@ -1,5 +1,5 @@
 <li class="<?php echo esc_attr( $css_classes ); ?>" data-timestamp="<?php echo esc_attr( $timestamp ); ?>">
-	<a href="#liveblog-entry-<?php echo esc_attr( $entry_id ); ?>">
+	<a href="#liveblog-entry-<?php echo esc_attr( $entry_id ); ?>" data-entry-id="<?php echo esc_attr( $entry_id ); ?>">
 		<?php echo WPCOM_Liveblog_Entry_Key_Events::get_formatted_content( $content, $post_id ); ?>
 	</a>
 	<?php if ( WPCOM_Liveblog::current_user_can_edit_liveblog() ) { ?>

--- a/templates/liveblog-key-single-timeline.php
+++ b/templates/liveblog-key-single-timeline.php
@@ -1,5 +1,5 @@
 <li class="<?php echo esc_attr( $css_classes ); ?>" data-timestamp="<?php echo esc_attr( $timestamp ); ?>">
-	<a class="link" href="#liveblog-entry-<?php echo esc_attr( $entry_id ); ?>">
+	<a class="link" href="#liveblog-entry-<?php echo esc_attr( $entry_id ); ?>" data-entry-id="<?php echo esc_attr( $entry_id ); ?>">
 		<span class="date liveblog-time-update"><?php echo esc_html( $entry_date ); ?> - <?php echo esc_html( $entry_time ); ?></span>
 		<span class="title"><?php echo WPCOM_Liveblog_Entry_Key_Events::get_formatted_content($content, $post_id); ?></span>
 	</a>

--- a/templates/liveblog-loop.php
+++ b/templates/liveblog-loop.php
@@ -12,6 +12,12 @@
 
 	<?php endforeach; ?>
 
+	<?php if ( WPCOM_Liveblog_Lazyloader::is_enabled() ) : ?>
+
+		<button class="liveblog-load-more" data-set-index="0"><?php esc_html_e( 'Load more entries&hellip;', 'liveblog' ); ?></button>
+
+	<?php endif; ?>
+
 	<div id="liveblog-fixed-nag">
 		<a href="#">
 		</a>


### PR DESCRIPTION
Hi there.

This pull request realizes user-driven lazyloading of Liveblog entries:
* displays a (filterable) number of entries on page load;
* fetch other entries via AJAX;
* on button click, display more entries;
* fully capable of working with (not yet displayed) Key Events;
* filters:
  * `liveblog_enable_lazyloader`, enable/disable lazyloading;
  * `liveblog_number_of_entries`, number of entries (for initial display, and lazyloading);
* disables _Lazyload Liveblog Entries_ plugin as it would collide with the built-in lazyloading.