### PR TITLE
Return false if there is no post global

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -378,6 +378,9 @@ final class WPCOM_Liveblog {
 		}
 		if ( empty( $post_id ) ) {
 			global $post;
+			if ( ! $post ){
+				return false;
+			}
 			$post_id = $post->ID;
 		}
 		$state = get_post_meta( $post_id, self::key, true );


### PR DESCRIPTION
`get_liveblog_state`, when in the admin, always assumes there is a global `$post` object set, which isn't the case quite often.

Without groking the overall internals of when this function is called, etc, returning out when it is not set fixes #220.