### PR TITLE
Add widget to display a list of key events

### DIFF
--- a/classes/class-wpcom-liveblog-entry-key-events-widget.php
+++ b/classes/class-wpcom-liveblog-entry-key-events-widget.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Class WPCOM_Liveblog_Entry_Key_Events_Widget
+ *
+ * Class to create a widget that displays a list of key events.
+ * This widget is just a wrapper for the shortcode
+ * [liveblog_key_events].
+ */
+class WPCOM_Liveblog_Entry_Key_Events_Widget extends WP_Widget {
+
+	/**
+	 * Called by WPCOM_Liveblog::load(), it attaches the
+	 * widget.
+	 */
+	public static function load() {
+		add_action( 'widgets_init', array( __CLASS__, 'widgets_init' ) );
+	}
+
+	/**
+	 * Registers the widget
+	 */
+	public static function widgets_init() {
+		register_widget( __CLASS__ );
+	}
+
+	/**
+	 * Configure widget
+	 */
+	public function __construct() {
+		$widget_ops = array(
+			'class_name' => 'liveblog-key-events-widget',
+			'description' => __( 'A list of key events displayed when the user is viewing a Liveblog post.', 'liveblog' ),
+		);
+
+		parent::__construct(
+			'liveblog-key-events-widget',
+			__( 'Liveblog Key Events Widget', 'liveblog' ),
+			$widget_ops
+		);
+	}
+
+	/**
+	 * Output the list of key events for the current post.
+	 *
+	 * @param array $args
+	 * @param array $instance
+	 *
+	 * @return void
+	 */
+	public function widget( $args, $instance ) {
+		$shortcode_output = WPCOM_Liveblog_Entry_Key_Events::shortcode( array( 'title' => false ) );
+
+		if ( is_null( $shortcode_output ) ) {
+			// Don't display the widget if there are no key events to show.
+			return;
+		}
+
+		echo $args['before_widget'];
+
+		if ( ! empty( $instance['title'] ) ) {
+			echo $args['before_title'] . apply_filters( 'widget_title', $instance['title'] ) . $args['after_title'];
+		}
+
+		echo $shortcode_output;
+		echo $args['after_widget'];
+	}
+
+	/**
+	 * Back-end form to display widget options (.
+	 *
+	 * @param array $instance Previously saved values from database.
+	 *
+	 * @return void
+	 */
+	public function form( $instance ) {
+		$title = ! empty( $instance['title'] ) ? $instance['title'] : '';
+		?>
+		<p>
+			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php esc_html_e( 'Title:', 'liveblog' ); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>">
+		</p>
+		<p class="description">
+			<?php esc_html_e( 'Note: the number of key events displayed in the widget is defined in the Liveblog configuration inside each post.', 'liveblog' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Sanitize widget form values as they are saved.
+	 *
+	 * @param array $new_instance Values just sent to be saved.
+	 * @param array $old_instance Previously saved values from database.
+	 *
+	 * @return array Updated safe values to be saved.
+	 */
+	public function update( $new_instance, $old_instance ) {
+		$instance = array();
+		$instance['title'] = ( ! empty( $new_instance['title'] ) ) ? sanitize_text_field( $new_instance['title'] ) : '';
+
+		return $instance;
+	}
+}

--- a/liveblog.php
+++ b/liveblog.php
@@ -78,6 +78,7 @@ final class WPCOM_Liveblog {
 		self::register_embed_handlers();
 
 		WPCOM_Liveblog_Entry_Key_Events::load();
+		WPCOM_Liveblog_Entry_Key_Events_Widget::load();
 		WPCOM_Liveblog_Entry_Extend::load();
 		WPCOM_Liveblog_Lazyloader::load();
 	}
@@ -111,6 +112,7 @@ final class WPCOM_Liveblog {
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry.php' );
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-query.php' );
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-key-events.php' );
+		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-key-events-widget.php' );
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-extend.php' );
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-extend-feature.php' );
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php' );


### PR DESCRIPTION
I have created a first version of the widget to display a list of key events (issue #224). It is a simple wrapper around [liveblog_key_events] shortcode and its single parameter is the widget title. The number of key events shown is controlled by the Liveblog post configuration. This is a screenshot of the widget form:

![Widget form](https://raw.githubusercontent.com/rodrigoprimo/liveblog/gh-pages/widget-form.png)

And here a screenshot of the widget displaying key entries when the user is viewing a Liveblog post:

![Widget form](https://raw.githubusercontent.com/rodrigoprimo/liveblog/gh-pages/widget.png)

It would be great to have general comments or suggestions on this first version since I'm still familiarizing myself with this plugin. Besides that, I have two specific questions to ask:

* The issue description (#224) suggests the use of do_shortcode() inside the widget. I decided to call WPCOM_Liveblog_Entry_Key_Events::shortcode() directly as it is more straightforward and AFAIK there are no drawbacks. Am I missing something?

* I like unit tests and I'm happy to see that they are becoming more popular in the WP community in recent years. It was great to see that Liveblog has its own tests. But the problem is that I'm not sure if it is worth writing unit tests for something like a widget. On one hand, it is always great to have your code covered by tests. On the other hand, a widget basically outputs HTML and I tend to think that it is hard to setup and maintain tests for this kind of code. What do you guys usually do in situations like this?