### PR TITLE
Add widget to display a list of key events

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The command system has one inbuilt command:
 
 `/key`: Which defines an entry to a key event, it adds the meta key to entry `liveblog_key_entry`. A key event can be styled using the `.type-key` class.
 
-To display a key event box you can add the `[liveblog_key_events]` shortcode in your theme, e.g. in the sidebar. Entries used with the key command will be inserted to both this box and the main feed. It also acts an anchor system to jump to parts of the main feed. It's not necessary to include the shortcode for the /key command to be enabled.
+To display a key event box you can add the `[liveblog_key_events]` shortcode in your theme, e.g. in the sidebar, or you can use the Liveblog Key Events widget. Entries used with the key command will be inserted to both this box and the main feed. It also acts an anchor system to jump to parts of the main feed. It's not necessary to include the shortcode for the /key command to be enabled.
 
 An example of using the key command would be an author writing the following in the New Entry box:
 

--- a/classes/class-wpcom-liveblog-entry-key-events-widget.php
+++ b/classes/class-wpcom-liveblog-entry-key-events-widget.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Class WPCOM_Liveblog_Entry_Key_Events_Widget
+ *
+ * Class to create a widget that displays a list of key events.
+ * This widget is just a wrapper for the shortcode
+ * [liveblog_key_events].
+ */
+class WPCOM_Liveblog_Entry_Key_Events_Widget extends WP_Widget {
+
+	/**
+	 * Called by WPCOM_Liveblog::load(), it attaches the
+	 * widget.
+	 */
+	public static function load() {
+		add_action( 'widgets_init', array( __CLASS__, 'widgets_init' ) );
+	}
+
+	/**
+	 * Registers the widget
+	 */
+	public static function widgets_init() {
+		register_widget( __CLASS__ );
+	}
+
+	/**
+	 * Configure widget
+	 */
+	public function __construct() {
+		$widget_ops = array(
+			'class_name' => 'liveblog-key-events-widget',
+			'description' => __( 'A list of key events displayed when the user is viewing a Liveblog post.', 'liveblog' ),
+		);
+
+		parent::__construct(
+			'liveblog-key-events-widget',
+			__( 'Liveblog Key Events Widget', 'liveblog' ),
+			$widget_ops
+		);
+	}
+
+	/**
+	 * Output the list of key events for the current post.
+	 *
+	 * @param array $args
+	 * @param array $instance
+	 *
+	 * @return void
+	 */
+	public function widget( $args, $instance ) {
+		$shortcode_output = WPCOM_Liveblog_Entry_Key_Events::shortcode( array( 'title' => false ) );
+
+		if ( is_null( $shortcode_output ) ) {
+			// Don't display the widget if there are no key events to show.
+			return;
+		}
+
+		echo $args['before_widget'];
+
+		if ( ! empty( $instance['title'] ) ) {
+			echo $args['before_title'] . apply_filters( 'widget_title', $instance['title'] ) . $args['after_title'];
+		}
+
+		echo $shortcode_output;
+		echo $args['after_widget'];
+	}
+
+	/**
+	 * Back-end form to display widget options (.
+	 *
+	 * @param array $instance Previously saved values from database.
+	 *
+	 * @return void
+	 */
+	public function form( $instance ) {
+		$title = ! empty( $instance['title'] ) ? $instance['title'] : '';
+		?>
+		<p>
+			<label for="<?php echo $this->get_field_id( 'title' ); ?>"><?php esc_html_e( 'Title:', 'liveblog' ); ?></label>
+			<input class="widefat" id="<?php echo $this->get_field_id( 'title' ); ?>" name="<?php echo $this->get_field_name( 'title' ); ?>" type="text" value="<?php echo esc_attr( $title ); ?>">
+		</p>
+		<p class="description">
+			<?php esc_html_e( 'Note: the number of key events displayed in the widget is defined in the Liveblog configuration inside each post.', 'liveblog' ); ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Sanitize widget form values as they are saved.
+	 *
+	 * @param array $new_instance Values just sent to be saved.
+	 * @param array $old_instance Previously saved values from database.
+	 *
+	 * @return array Updated safe values to be saved.
+	 */
+	public function update( $new_instance, $old_instance ) {
+		$instance = array();
+		$instance['title'] = ( ! empty( $new_instance['title'] ) ) ? sanitize_text_field( $new_instance['title'] ) : '';
+
+		return $instance;
+	}
+}

--- a/languages/liveblog.pot
+++ b/languages/liveblog.pot
@@ -1,227 +1,350 @@
-# Copyright (C) 2014 Liveblog
+# Copyright (C) 2016 Liveblog
 # This file is distributed under the same license as the Liveblog package.
 msgid ""
 msgstr ""
-"Project-Id-Version: Liveblog 1.3\n"
-"Report-Msgid-Bugs-To: http://wordpress.org/support/plugin/liveblog\n"
-"POT-Creation-Date: 2014-02-24 12:32:22+00:00\n"
+"Project-Id-Version: Liveblog 1.5\n"
+"Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/liveblog\n"
+"POT-Creation-Date: 2016-01-15 19:14:37+00:00\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"PO-Revision-Date: 2014-MO-DA HO:MI+ZONE\n"
+"PO-Revision-Date: 2016-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 
-#: classes/class-wpcom-liveblog-entry.php:147
-#: classes/class-wpcom-liveblog-entry.php:181
+#: classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php:247
+msgctxt "taxonomy general name"
+msgid "Hashtags"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php:248
+msgctxt "taxonomy singular name"
+msgid "Hashtag"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php:249
+msgid "Search Hashtags"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php:250
+msgid "All Hashtags"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php:251
+msgid "Parent Hashtag"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php:252
+msgid "Parent Hashtag:"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php:253
+msgid "Edit Hashtag"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php:254
+msgid "Update Hashtag"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php:255
+msgid "Add New Hashtag"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php:256
+msgid "New Hashtag"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php:257
+msgid "Hashtags"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-key-events-widget.php:33
+msgid ""
+"A list of key events displayed when the user is viewing a Liveblog post."
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-key-events-widget.php:38
+msgid "Liveblog Key Events Widget"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-key-events-widget.php:80
+msgid "Title:"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-key-events-widget.php:84
+msgid ""
+"Note: the number of key events displayed in the widget is defined in the "
+"Liveblog configuration inside each post."
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-key-events.php:203
+msgid "Template:"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-key-events.php:204
+msgid "Format:"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-key-events.php:205
+msgid ""
+"Set template for key events shortcode, select a format and restrict most "
+"recent shown."
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-key-events.php:206
+msgid "Limit"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry-key-events.php:207
+msgid "Save"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry.php:151
+#: classes/class-wpcom-liveblog-entry.php:186
+#: classes/class-wpcom-liveblog-entry.php:202
 msgid "Missing entry ID"
 msgstr ""
 
-#: classes/class-wpcom-liveblog-entry.php:213
+#: classes/class-wpcom-liveblog-entry.php:205
+msgid "Key event not deleted"
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry.php:229
 msgid "Error posting entry"
 msgstr ""
 
-#: classes/class-wpcom-liveblog-entry.php:217
-#: classes/class-wpcom-liveblog-entry.php:235
+#: classes/class-wpcom-liveblog-entry.php:233
+#: classes/class-wpcom-liveblog-entry.php:251
 msgid "Error retrieving comment"
 msgstr ""
 
-#: classes/class-wpcom-liveblog-entry.php:226
+#: classes/class-wpcom-liveblog-entry.php:242
 msgid "Missing entry argument: %s"
 msgstr ""
 
-#: classes/class-wpcom-liveblog-entry.php:239
+#: classes/class-wpcom-liveblog-entry.php:255
 msgid "Error retrieving user"
 msgstr ""
 
-#: liveblog.php:296
+#: classes/class-wpcom-liveblog-lazyloader.php:190
+#: templates/liveblog-loop.php:17
+msgid "Load more entries&hellip;"
+msgstr ""
+
+#: liveblog.php:313
 msgid "A timestamp is missing. Correct URL: <permalink>/liveblog/<from>/</to>/"
 msgstr ""
 
-#: liveblog.php:435
+#: liveblog.php:458
 msgid "Invalid entry crud_action: %s"
 msgstr ""
 
-#: liveblog.php:470
+#: liveblog.php:602
 msgid "Unknown liveblog action"
 msgstr ""
 
-#: liveblog.php:494 liveblog.php:569
+#: liveblog.php:628 liveblog.php:708
 msgid "Error {error-code}: {error-message}"
 msgstr ""
 
-#: liveblog.php:495 liveblog.php:570
+#: liveblog.php:629 liveblog.php:709
 msgid "Error: {error-message}"
 msgstr ""
 
-#: liveblog.php:515
+#: liveblog.php:649
 msgid "%s ago"
 msgstr ""
 
-#: liveblog.php:516
+#: liveblog.php:650
 msgid "a few seconds"
 msgstr ""
 
-#: liveblog.php:517
+#: liveblog.php:651
 msgid "a minute"
 msgstr ""
 
-#: liveblog.php:518
+#: liveblog.php:652
 msgid "%d minutes"
 msgstr ""
 
-#: liveblog.php:519
+#: liveblog.php:653
 msgid "an hour"
 msgstr ""
 
-#: liveblog.php:520
+#: liveblog.php:654
 msgid "%d hours"
 msgstr ""
 
-#: liveblog.php:521
+#: liveblog.php:655
 msgid "a day"
 msgstr ""
 
-#: liveblog.php:522
+#: liveblog.php:656
 msgid "%d days"
 msgstr ""
 
-#: liveblog.php:523
+#: liveblog.php:657
 msgid "a month"
 msgstr ""
 
-#: liveblog.php:524
+#: liveblog.php:658
 msgid "%d months"
 msgstr ""
 
-#: liveblog.php:525
+#: liveblog.php:659
 msgid "a year"
 msgstr ""
 
-#: liveblog.php:526
+#: liveblog.php:660
 msgid "%d years"
 msgstr ""
 
-#: liveblog.php:568
-msgid "Do you really want do delete this entry? There is no way back."
+#: liveblog.php:706
+msgid "Do you really want to delete this entry? There is no way back."
 msgstr ""
 
-#: liveblog.php:571
+#: liveblog.php:707
+msgid "Do you want to delete this key entry?"
+msgstr ""
+
+#: liveblog.php:710
 msgid "Liveblog: {number} new update"
 msgstr ""
 
-#: liveblog.php:572
+#: liveblog.php:711
 msgid "Liveblog: {number} new updates"
 msgstr ""
 
-#: liveblog.php:573
+#: liveblog.php:712
 msgid "Provide URL for link:"
 msgstr ""
 
-#: liveblog.php:577
+#: liveblog.php:715
+msgid "term-"
+msgstr ""
+
+#: liveblog.php:716
+msgid "type-alert"
+msgstr ""
+
+#: liveblog.php:717
+msgid "type-key"
+msgstr ""
+
+#: liveblog.php:721
 msgid "Loading preview…"
 msgstr ""
 
-#: liveblog.php:578
+#: liveblog.php:722
 msgid "New Entry"
 msgstr ""
 
-#: liveblog.php:579
+#: liveblog.php:723
 msgid "Publish Update"
 msgstr ""
 
-#: liveblog.php:580
+#: liveblog.php:724
 msgid "Edit Entry"
 msgstr ""
 
-#: liveblog.php:581
+#: liveblog.php:725
 msgid "Update"
 msgstr ""
 
-#: liveblog.php:601
+#: liveblog.php:745
 msgid "Allowed Files"
 msgstr ""
 
-#. #-#-#-#-#  liveblog.pot (Liveblog 1.3)  #-#-#-#-#
+#. #-#-#-#-#  liveblog.pot (Liveblog 1.5)  #-#-#-#-#
 #. Plugin Name of the plugin/theme
-#: liveblog.php:719 liveblog.php:797
+#: liveblog.php:880 liveblog.php:963
 msgid "Liveblog"
 msgstr ""
 
-#: liveblog.php:735
+#: liveblog.php:896
 msgid "Enable"
 msgstr ""
 
-#: liveblog.php:736
+#: liveblog.php:897
 msgid ""
 "Enables liveblog on this post. Posting tools are enabled for editors, "
 "visitors get the latest updates."
 msgstr ""
 
-#: liveblog.php:736
+#: liveblog.php:897
 msgid ""
 "There is an <strong>enabled</strong> liveblog on this post. <a href=\"%s"
 "\">Visit the liveblog &rarr;</a>"
 msgstr ""
 
-#: liveblog.php:737
+#: liveblog.php:898
 msgid "Archive"
 msgstr ""
 
-#: liveblog.php:738
+#: liveblog.php:899
 msgid ""
 "Archives the liveblog on this post. Visitors still see the liveblog entries, "
 "but posting tools are hidden."
 msgstr ""
 
-#: liveblog.php:738
+#: liveblog.php:899
 msgid ""
 "There is an <strong>archived</strong> liveblog on this post. <a href=\"%s"
 "\">Visit the liveblog archive &rarr;</a>"
 msgstr ""
 
-#: liveblog.php:744
+#: liveblog.php:905
 msgid "This is a normal WordPress post, without a liveblog."
 msgstr ""
 
-#: liveblog.php:800
+#: liveblog.php:908
+msgid "Settings have been successfully updated."
+msgstr ""
+
+#: liveblog.php:966
 msgid "Liveblog (archived)"
 msgstr ""
 
-#: liveblog.php:830
+#: liveblog.php:996
 msgid "Filter liveblogs"
 msgstr ""
 
-#: liveblog.php:831
+#: liveblog.php:997
 msgid "Any liveblogs"
 msgstr ""
 
-#: liveblog.php:832
+#: liveblog.php:998
 msgid "Enabled liveblogs"
 msgstr ""
 
-#: liveblog.php:833
+#: liveblog.php:999
 msgid "Archived liveblogs"
 msgstr ""
 
-#: liveblog.php:834
+#: liveblog.php:1000
 msgid "No liveblogs"
 msgstr ""
 
-#: liveblog.php:901
+#: liveblog.php:1067
 msgid "Cheatin', uh?"
 msgstr ""
 
-#: liveblog.php:912
+#: liveblog.php:1078
 msgid "Sorry, we could not authenticate you."
+msgstr ""
+
+#. translators: 1: plugin name, 2: plugins page URL
+#: templates/lazyload-notice.php:6
+msgid ""
+"Please <a href=\"%2$s\">deactivate the %1$s plugin</a> as Liveblog itself "
+"comes now with built-in lazyloading."
 msgstr ""
 
 #: templates/liveblog-form.php:9
 msgid "Preview"
 msgstr ""
 
-#: templates/liveblog-form.php:13 templates/liveblog-form.php:31
-#: templates/liveblog-form.php:33
+#: templates/liveblog-form.php:13 templates/liveblog-form.php:30
 msgid "Remember: keep it short! To insert an image, drag and drop it here."
 msgstr ""
 
@@ -285,11 +408,11 @@ msgstr ""
 msgid "Remove formatting"
 msgstr ""
 
-#: templates/liveblog-form.php:40
+#: templates/liveblog-form.php:37
 msgid "Cancel"
 msgstr ""
 
-#: templates/liveblog-form.php:41 templates/liveblog-single-entry.php:12
+#: templates/liveblog-form.php:38 templates/liveblog-single-entry.php:12
 msgid "Delete"
 msgstr ""
 

--- a/liveblog.php
+++ b/liveblog.php
@@ -78,6 +78,7 @@ final class WPCOM_Liveblog {
 		self::register_embed_handlers();
 
 		WPCOM_Liveblog_Entry_Key_Events::load();
+		WPCOM_Liveblog_Entry_Key_Events_Widget::load();
 		WPCOM_Liveblog_Entry_Extend::load();
 		WPCOM_Liveblog_Lazyloader::load();
 	}
@@ -111,6 +112,7 @@ final class WPCOM_Liveblog {
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry.php' );
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-query.php' );
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-key-events.php' );
+		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-key-events-widget.php' );
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-extend.php' );
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-extend-feature.php' );
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php' );


### PR DESCRIPTION
I have created a first version of the widget to display a list of key events (issue #224). It is a simple wrapper around [liveblog_key_events] shortcode and its single parameter is the widget title. The number of key events shown is controlled by the Liveblog post configuration. This is a screenshot of the widget form:

![Widget form](https://raw.githubusercontent.com/rodrigoprimo/liveblog/gh-pages/widget-form.png)

And here a screenshot of the widget displaying key entries when the user is viewing a Liveblog post:

![Widget form](https://raw.githubusercontent.com/rodrigoprimo/liveblog/gh-pages/widget.png)

It would be great to have general comments or suggestions on this first version since I'm still familiarizing myself with this plugin. Besides that, I have two specific questions to ask:

* The issue description (#224) suggests the use of do_shortcode() inside the widget. I decided to call WPCOM_Liveblog_Entry_Key_Events::shortcode() directly as it is more straightforward and AFAIK there are no drawbacks. Am I missing something?

* I like unit tests and I'm happy to see that they are becoming more popular in the WP community in recent years. It was great to see that Liveblog has its own tests. But the problem is that I'm not sure if it is worth writing unit tests for something like a widget. On one hand, it is always great to have your code covered by tests. On the other hand, a widget basically outputs HTML and I tend to think that it is hard to setup and maintain tests for this kind of code. What do you guys usually do in situations like this?