### PR TITLE
Restore embedded videos that went missing after 1.5 upgrade

### DIFF
--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -110,15 +110,15 @@ class WPCOM_Liveblog_Entry {
 	public static function render_content( $content, $comment = false ) {
 		global $wp_embed;
 
+		$content = wp_kses_post( $content );
+
 		if ( apply_filters( 'liveblog_entry_enable_embeds', true ) ) {
 			if ( get_option( 'embed_autourls' ) )
 				$content = $wp_embed->autoembed( $content );
 			$content = do_shortcode( $content );
 		}
 
-		$content = apply_filters( 'comment_text', $content, $comment );
-
-		return $content;
+		return apply_filters( 'comment_text', $content, $comment );
 	}
 
 	/**

--- a/templates/liveblog-single-entry.php
+++ b/templates/liveblog-single-entry.php
@@ -5,7 +5,9 @@
 		<span class="liveblog-meta-time"><a href="#liveblog-entry-<?php echo absint( $entry_id ); ?>"><span class="date"><?php echo esc_html( $entry_date ); ?></span><span class="time"><?php echo esc_html( $entry_time ); ?></span></a></span>
 	</header>
 	<div class="liveblog-entry-text" data-original-content="<?php echo esc_attr( $original_content ); ?>">
-		<?php echo wp_kses_post( $content ); ?>
+		<?php
+			echo $content; /* escaped earlier with wp_kses_post in WPCOM_Liveblog_Entry::render_content() */
+		 ?>
 	</div>
 <?php if ( $is_liveblog_editable ): ?>
 	<ul class="liveblog-entry-actions">


### PR DESCRIPTION
Moved `wp_kses_post` before `auto embed` and `do_shortcode` so it does not strip html code introduced by those functions.

Fixes #235