### PR TITLE
Add tags to allow embedded video playback. 

### DIFF
--- a/t/test-entry.php
+++ b/t/test-entry.php
@@ -77,6 +77,17 @@ class Test_Entry extends WP_UnitTestCase {
 		$this->assertNull( $query->get_by_id( $entry->get_id() ) );
 	}
 
+	function test_user_input_sanity_check() {
+		$user_input  = "<iframe></iframe>";
+		$user_input .= "<script></script>";
+		$user_input .= "<applet></applet>";
+		$user_input .= "<embed></embed>";
+		$user_input .= "<object></object>";
+		$content = array( 'post_id' => 1, 'content' => $user_input );
+		$live_blog_entry = $this->insert_entry( $content );
+		$this->assertEmpty( $live_blog_entry->get_content() );
+	}
+
 	static function set_liveblog_hook_fired() {
 		$GLOBALS['liveblog_hook_fired'] = true;
 	}

--- a/templates/liveblog-single-entry.php
+++ b/templates/liveblog-single-entry.php
@@ -5,7 +5,7 @@
 		<span class="liveblog-meta-time"><a href="#liveblog-entry-<?php echo absint( $entry_id ); ?>"><span class="date"><?php echo esc_html( $entry_date ); ?></span><span class="time"><?php echo esc_html( $entry_time ); ?></span></a></span>
 	</header>
 	<div class="liveblog-entry-text" data-original-content="<?php echo esc_attr( $original_content ); ?>">
-		<?php echo wp_kses_post( $content ); ?>
+		<?php echo wp_kses( $content, $allowed_tags_for_entry ); ?>
 	</div>
 <?php if ( $is_liveblog_editable ): ?>
 	<ul class="liveblog-entry-actions">


### PR DESCRIPTION
As per discussion in #235 new expanded array of allowed html tags was created. It is used in template with `wp_kses` to filter post text. It is basically `wp_kses_post` + additional tags.
`iframe` was needed for embedded online content and `source` for local content.

Fixes #235