### PR TITLE
Feature/fix post global variable

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -372,24 +372,25 @@ final class WPCOM_Liveblog {
 	/**
 	 * One of: 'enable', 'archive', false.
 	 */
-	public static function get_liveblog_state( $post_id = null ) {
-		if ( ! is_single() && ! is_admin() ) {
-			return false;
-		}
-		if ( empty( $post_id ) ) {
-			global $post;
-			if ( ! $post ){
-				return false;
-			}
-			$post_id = $post->ID;
-		}
-		$state = get_post_meta( $post_id, self::key, true );
-		// backwards compatibility with older values
-		if ( 1 == $state ) {
-			$state = 'enable';
-		}
-		return $state;
-	}
+	 public static function get_liveblog_state( $post_id = null ) {
+ 		if ( ! is_single() && ! is_admin() ) {
+ 			return false;
+ 		}
+ 		if ( empty( $post_id ) ) {
+ 			$this_post = get_post();
+
+ 			if ( null !== $this_post ) {
+ 				$post_id = $this_post->ID;
+ 			}
+ 		}
+ 		$state = get_post_meta( $post_id, self::key, true );
+ 		//echo 'State: ' . print_r( $state, true );
+ 		// backwards compatibility with older values
+ 		if ( 1 == $state ) {
+ 			$state = 'enable';
+ 		}
+ 		return $state;
+ 	}
 
 	/** Private _is_ Methods **************************************************/
 

--- a/liveblog.php
+++ b/liveblog.php
@@ -378,6 +378,9 @@ final class WPCOM_Liveblog {
 		}
 		if ( empty( $post_id ) ) {
 			global $post;
+			if ( ! $post ){
+				return false;
+			}
 			$post_id = $post->ID;
 		}
 		$state = get_post_meta( $post_id, self::key, true );

--- a/templates/liveblog-key-admin.php
+++ b/templates/liveblog-key-admin.php
@@ -12,7 +12,7 @@
 			<option <?php if ( $format == $current_key_format ): ?> selected="selected" <?php endif; ?> value="<?php echo esc_attr( $format ) ?>"><?php echo esc_html( ucwords( str_replace( '-', ' ', $format ) ) ); ?></option>
 		<?php endforeach; ?>
 	</select>
-	<label for"liveblog-key-limit"><?php echo esc_html( $key_limit ); ?></label>
+	<label for="liveblog-key-limit"><?php echo esc_html( $key_limit ); ?></label>
 	<input id="liveblog-key-limit" type="text" name="liveblog-key-limit" value="<?php echo esc_attr( $current_key_limit ); ?>" />
 	<button type="button" class="button button-primary liveblog-key-template-save" value="liveblog-key-template-save"><?php echo esc_html( $key_button ); ?></button>
 </p>


### PR DESCRIPTION
Plugin was throwing notices of trying to get property of a non-object on $post as it was not defined when it was being referenced. Move to get_post() resolved this on local, dev, and stage environments and get_post is safer in general that direct access to the global.

https://wordpressvip.zendesk.com/hc/en-us/requests/53450