### PR TITLE
Updated deduping logic for replaced entries to work properly with lazy loading

### DIFF
--- a/classes/class-wpcom-liveblog-entry-query.php
+++ b/classes/class-wpcom-liveblog-entry-query.php
@@ -40,7 +40,20 @@ class WPCOM_Liveblog_Entry_Query {
 	 * @param array $args the same args for the core `get_comments()`
 	 */
 	public function get_all( $args = array() ) {
-		return self::remove_replaced_entries( $this->get( $args ) );
+		// Due to liveblog lazy loading, duplicate entries may be displayed
+		// if we actually pass the 'number' argument to get_comments
+		// in this class.
+		//
+		// We don't want to remove the parameter entirely for backwards compatibility
+		// since this is a public method, but we need instead to handle it as part
+		// of remove_replaced_entries after we retrieve the entire result set.
+		$number = 0;
+		if ( isset( $args['number'] ) ) {
+			$number = intval( $args['number'] );
+			unset( $args['number'] );
+		}
+
+		return self::remove_replaced_entries( $this->get( $args ), $number );
 	}
 
 	public function count( $args = array() ) {
@@ -115,17 +128,23 @@ class WPCOM_Liveblog_Entry_Query {
 		return array_map( array( 'WPCOM_Liveblog_Entry', 'from_comment' ), $comments );
 	}
 
-	public static function remove_replaced_entries( $entries = array() ) {
-
-		if ( empty( $entries ) )
+	public static function remove_replaced_entries( $entries = array(), $number = 0 ) {
+		if ( empty( $entries ) ) {
 			return $entries;
+		}
 
 		$entries_by_id = self::assoc_array_by_id( $entries );
 
 		foreach ( (array) $entries_by_id as $id => $entry ) {
-			if ( !empty( $entry->replaces ) && isset( $entries_by_id[$entry->replaces] ) ) {
-				unset( $entries_by_id[$id] );
+			if ( ! empty( $entry->replaces ) && isset( $entries_by_id[ $entry->replaces ] ) ) {
+				unset( $entries_by_id[ $id ] );
 			}
+		}
+
+		// If a number of entries is set and we have more than that amount of entries,
+		// return just that slice.
+		if ( $number > 0 && count( $entries_by_id ) > $number ) {
+			$entries_by_id = array_slice( $entries_by_id, 0, $number );
 		}
 
 		return $entries_by_id;


### PR DESCRIPTION
Upon testing this, I noticed that liveblogs with edited entries were showing duplicates. It appears the logic in `remove_replaced_entries` was never updated when lazy loading was introduced. What's happening is that it's only searching the last X entries loaded for replaced entries, but not the entire result set. This leads to duplicates and (worse) old versions of entries becoming visible.

The only way to do this properly given the new logic is to not rely upon the `number` argument for `get_comments` and instead always fetch the full result set and handle deduping in PHP.