### PR TITLE
Auto load formatted tweets when new posts are either auto loaded at t…

### DIFF
--- a/js/liveblog-lazyloader.js
+++ b/js/liveblog-lazyloader.js
@@ -131,6 +131,8 @@
 				if ( entry.html ) {
 					$button.before( $( entry.html ) );
 				}
+
+				twttr.widgets.load( document.getElementById( 'liveblog-entry-' + entry.id ) );
 			} );
 
 			// Convert the timestamps of the newly inserted entries into human time diffed timestamps.

--- a/js/liveblog.js
+++ b/js/liveblog.js
@@ -305,8 +305,10 @@ window.liveblog = window.liveblog || {};
 		var $entry = liveblog.get_entry_by_id( new_entry.id );
 		if ('new' === new_entry.type && !$entry.length) {
 			liveblog.add_entry( new_entry, duration );
+			twttr.widgets.load( document.getElementById( 'liveblog-entry-' + new_entry.id ) );
 		} else if ('update' === new_entry.type && $entry.length) {
 			liveblog.update_entry( $entry, new_entry );
+			twttr.widgets.load( document.getElementById( 'liveblog-entry-' + new_entry.id ) );
 		} else if ('delete' === new_entry.type && $entry.length) {
 			liveblog.delete_entry( $entry );
 		}

--- a/js/twitter-timeline.js
+++ b/js/twitter-timeline.js
@@ -1,0 +1,10 @@
+/* jshint ignore:start */
+!function(d,s,id){
+	var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';
+	if(!d.getElementById(id)){
+		js=d.createElement(s);
+		js.id=id;js.src=p+"://platform.twitter.com/widgets.js";
+		fjs.parentNode.insertBefore(js,fjs);
+	}
+}(document,"script","twitter-wjs");
+/* jshint ignore:end */

--- a/liveblog.php
+++ b/liveblog.php
@@ -705,6 +705,12 @@ final class WPCOM_Liveblog {
 			wp_enqueue_script( 'jquery.spin', plugins_url( 'js/jquery.spin.js', __FILE__ ), array( 'jquery', 'spin' ), '1.3' );
 		}
 
+		if ( wp_script_is( 'jetpack-twitter-timeline', 'registered' ) ) {
+			wp_enqueue_script( 'jetpack-twitter-timeline' );
+		} else {
+			wp_enqueue_script( 'liveblog-twitter-timeline', plugins_url( 'js/twitter-timeline.js', __FILE__ ), false, '1.5, true' );
+		}
+
 		wp_localize_script( self::key, 'liveblog_settings',
 			apply_filters( 'liveblog_settings', array(
 				'permalink'              => get_permalink(),


### PR DESCRIPTION
…he top of the timeline or lazy loaded when paginated

Otherwise, tweets load as plain text until the page is manually refreshed and lazy loaded tweets never get formatted.