### PR TITLE
Restore the relative date feature in the liveblog.

### DIFF
--- a/templates/liveblog-single-entry.php
+++ b/templates/liveblog-single-entry.php
@@ -2,7 +2,7 @@
 	<header class="liveblog-meta">
 		<span class="liveblog-author-avatar"><?php echo wp_kses_post( $avatar_img ); ?></span>
 		<span class="liveblog-author-name"><?php echo wp_kses_post( $author_link ); ?></span>
-		<span class="liveblog-meta-time"><a href="#liveblog-entry-<?php echo absint( $entry_id ); ?>"><span class="date"><?php echo esc_html( $entry_date ); ?></span><span class="time"><?php echo esc_html( $entry_time ); ?></span></a></span>
+		<span class="liveblog-meta-time"><a href="#liveblog-entry-<?php echo absint( $entry_id ); ?>" class="liveblog-time-update"><span class="date"><?php echo esc_html( $entry_date ); ?></span><span class="time"><?php echo esc_html( $entry_time ); ?></span></a></span>
 	</header>
 	<div class="liveblog-entry-text" data-original-content="<?php echo esc_attr( $original_content ); ?>">
 		<?php echo wp_kses( $content, $allowed_tags_for_entry ); ?>


### PR DESCRIPTION
The changes in https://github.com/Automattic/liveblog/commit/a25f2d03d9de457adb379a277265e952e3136fab broke the relative date feature in standard liveblog as the template used in the liveblog does not contain the `liveblog-time-update` class which is now used for selecting the HTML element which should bear the relative time display in https://github.com/Automattic/liveblog/blob/master/js/liveblog.js#L25

This commit adds the class to the appropriate `a` element and thus restores the functionality.

Fixes #33 