### PR TITLE
Allow template overrides from child themes

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -882,7 +882,10 @@ final class WPCOM_Liveblog {
 		ob_start();
 		extract( $template_variables );
 		$theme_template = get_template_directory() . '/liveblog/' . ltrim( $template_name, '/' );
-		if ( file_exists( $theme_template ) ) {
+		$child_theme_template = get_stylesheet_directory() . '/liveblog/' . ltrim( $template_name, '/' );
+		if ( file_exists( $child_theme_template ) ) {
+			include( $child_theme_template );
+		} else if ( file_exists( $theme_template ) ) {
 			include( $theme_template );
 		} else if( self::$custom_template_path && file_exists( self::$custom_template_path . '/' . $template_name ) ) {
 			include( self::$custom_template_path . '/' . $template_name );


### PR DESCRIPTION
Right now, Liveblog allows template overrides placed in theme's liveblog directory to parent themes only. Checking the child theme's directory first allows creators of the child themes to easily override parent theme's templates as well as the liveblog default ones.

Fixes #253