### PR TITLE
Adding localisation to pluploads.js

### DIFF
--- a/js/plupload.js
+++ b/js/plupload.js
@@ -3,8 +3,9 @@ jQuery(document).ready(function($) {
 
 		/* Selectors */
 		// @todo selctors need to be class-based and the upload.dropzone needs to be used to select the current message and container
-		browser: '#liveblog-messages',
-		dropzone: '#liveblog-container',
+		browser: liveblog_plupload.browser ? liveblog_plupload.browser : undefined,
+		dropzone: liveblog_plupload.dropzone ? liveblog_plupload.dropzone : undefined,
+		container: liveblog_plupload.container ? liveblog_plupload.container : undefined,
 
 		/* Callbacks */
 		success  : function( upload ) {

--- a/liveblog.php
+++ b/liveblog.php
@@ -694,7 +694,14 @@ final class WPCOM_Liveblog {
 				wp_enqueue_script( 'editor' );
 			}
 			wp_enqueue_script( 'liveblog-publisher', plugins_url( 'js/liveblog-publisher.js', __FILE__ ), array( self::key ), self::version, true );
-			wp_enqueue_script( 'liveblog-plupload', plugins_url( 'js/plupload.js', __FILE__ ), array( self::key, 'wp-plupload', 'jquery' ) );
+			
+			wp_register_script( 'liveblog-plupload', plugins_url( 'js/plupload.js', __FILE__ ), array( self::key, 'wp-plupload', 'jquery' ) );
+			wp_localize_script( 'liveblog-plupload', 'liveblog_plupload', apply_filters( 'liveblog_plupload_localize', array(
+				'browser' => '#liveblog-messages',
+				'dropzone' => '#liveblog-container',
+				'container' => false,
+			) ) );
+			wp_enqueue_script( 'liveblog-plupload' );
 			self::add_default_plupload_settings();
 		}
 


### PR DESCRIPTION
Since the Liveblog's plupload implementation is not setting a custom container option, the default one (document.body) is being used.

This may introduce some issues for certain themes since the plupload container's css position is being set to relative.

This commit is adding `liveblog_plupload_localize` filter which can be used for changing the dropzone, browser and container options inside js/plupload.js