### PR TITLE
Fixes oembed links which are not working properly when publishing from

### DIFF
--- a/classes/class-wpcom-liveblog-entry-extend.php
+++ b/classes/class-wpcom-liveblog-entry-extend.php
@@ -30,6 +30,7 @@ class WPCOM_Liveblog_Entry_Extend {
 	    add_action( 'wp_enqueue_scripts',           array( __CLASS__, 'enqueue_scripts' ) );
 	    add_filter( 'liveblog_before_insert_entry', array( __CLASS__, 'strip_input' ), 1 );
 	    add_filter( 'liveblog_before_update_entry', array( __CLASS__, 'strip_input' ), 1 );
+		add_filter( 'liveblog_before_insert_entry', array( __CLASS__, 'fix_links_wrapped_in_div' ), 1 );
 
 	    // Allow the features to be seperated in multiple ways: via spaces,
 	    // pipes or commas. This line explodes via spaces and pipes then
@@ -130,5 +131,19 @@ class WPCOM_Liveblog_Entry_Extend {
 
         return $entry;
     }
+
+	/**
+	 * Replaces div wrapping oembedable links with p for core to pick those up
+	 *
+	 * The div wrapping links which would otherwise would be on their own line
+	 * is coming from Webkit browser's contenteditable
+	 *
+	 * $param array Liveblog entry
+	 * @return array
+	*/
+	public static function fix_links_wrapped_in_div( $entry ) {
+		$entry['content'] = preg_replace( '|(<div(?: [^>]*)?>\s*)(https?://[^\s<>"]+)(\s*<\/div>)|i', '<p>${2}</p>', $entry['content'] );
+		return $entry;
+	}
 
 }


### PR DESCRIPTION
Chrome or Safari

contenteditable attribute in Chrome and Safari is wrapping new lines to `<div>` elements and thus links which otherwise would be standing on their own line are being wrapped in `<div>` and are not being picked up by autoembed feature of WordPress since it only takes into account links either standing on a line on their own, or wrapped in `<p>` element.

This commit is adding a new callback for `liveblog_before_insert_entry` filter which uses the same regular expression as core does for identifying link wrapped in `<p>` element (just is using div instead of p).

The preg_replace replaces the `<div>` element for `<p>` and core's autoembed feature then picks those links without issues.