### PR TITLE
Adding a new class for properly handling Instagram oembeds in previews

### DIFF
--- a/classes/class-wpcom-liveblog-entry-instagram-oembed.php
+++ b/classes/class-wpcom-liveblog-entry-instagram-oembed.php
@@ -1,0 +1,81 @@
+<?php
+
+/**
+ * Class WPCOM_Liveblog_Entry_Instagram_oEmbed
+ *
+ * This addresses the issues with Instagram oEmbeds in Liveblog
+ */
+class WPCOM_Liveblog_Entry_Instagram_oEmbed {
+
+	/**
+	 * Called by WPCOM_Liveblog::load(),
+	 * it registers the initial filter
+	 */
+	public static function load() {
+
+		add_filter( 'liveblog_entry_enable_embeds', array( __CLASS__, 'register_filters' ) );
+
+	}
+
+	/**
+	 * Register the filters just in time - when we are about to return HTML in endpoint
+	 */
+	public static function register_filters( $return ) {
+		
+		add_filter( 'embed_oembed_html', array( __CLASS__, 'filter_oembed_html' ), 10, 4 );
+		//Deregister the filter as soon as it is no longer needed
+		add_filter( 'comment_text', array( __CLASS__, 'unregister_filters' ), 0, 1 );
+		return $return;
+	}
+
+	/** 
+	 * Deregister the filter we added
+	 */
+	public static function unregister_filters( $return ) {
+		remove_filter( 'embed_oembed_html', array( __CLASS__, 'filter_oembed_html' ) );
+		return $return;
+	}
+
+	/**
+	 * Filter the oEmbed HTML only if instagram is the provider
+	 */
+	public static function filter_oembed_html( $html, $url, $attr, $post_ID ) {
+
+		$oembed = _wp_oembed_get_object();
+		$provider = $oembed->get_provider( $url );
+		if ( false !== strpos( 'instagr.am' ) || false !== strpos( 'instagram.com' ) ) {
+			$html = self::instagram_handler( $html, $url, $attr, $post_ID );
+		}
+
+		return $html;
+
+	}
+
+	/**
+	 * The custom modifications themselves
+	 *
+	 * This method is removing the default script and attaches it's own
+	 */
+	public static function instagram_handler( $html, $url, $attr, $post_ID ) {
+		$instagram_script_uri = '//platform.instagram.com/en_US/embeds.js';
+		$dom = new DOMDocument();
+		$dom->loadHTML( $html, LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD );
+		$script = $dom->getElementsByTagName( 'script' );
+
+		$new_script = $dom->createElement( 'script', '(function( $ ){ if ( undefined === window.instgrm ) { $.getScript( '.wp_json_encode( $instagram_script_uri ).' ); } $(".instagram-media a").each( function(){ if ( -1 === $(this).attr("href").indexOf("instagr") ) { $(this).replaceWith( $(this).text() ) } } ); window.instgrm.Embeds.process(); })(jQuery);' );
+		$new_script->setAttribute( 'type', 'text/javascript' );
+
+		if ( false === empty( $script ) ) {
+			foreach( $script as $item ) {
+				if ( $instagram_script_uri === $item->getAttribute('src') ) {
+					$parent = $item->parentNode;
+					$item->parentNode->removeChild($item);
+					$parent->appendChild( $new_script );
+					break;
+				}
+			}
+		}
+		$html = $dom->saveHTML();
+		return $html;
+	}
+}

--- a/liveblog.php
+++ b/liveblog.php
@@ -82,6 +82,7 @@ final class WPCOM_Liveblog {
 		WPCOM_Liveblog_Entry_Extend::load();
 		WPCOM_Liveblog_Lazyloader::load();
 		WPCOM_Liveblog_Socketio_Loader::load();
+		WPCOM_Liveblog_Entry_Instagram_oEmbed::load();
 	}
 
 	public static function add_custom_post_type_support( $query ) {
@@ -122,6 +123,7 @@ final class WPCOM_Liveblog {
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-extend-feature-authors.php' );
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-lazyloader.php' );
 		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-socketio-loader.php' );
+		require( dirname( __FILE__ ) . '/classes/class-wpcom-liveblog-entry-instagram-oembed.php' );
 
 		// Manually include ms.php theme-side in multisite environments because
 		// we need its filesize and available space functions.


### PR DESCRIPTION
Since the WordPress is calling the `make_clickable` function in terms of the `comment_text` filter, Instagram oEmbedes containing a plaintext link are not being properly initialised as Instagram's JS expects only a single `a` element inside the `blockquote`.

This commit is programmatically removing the script element using DomDocument and is appending a custom one, which 1) load the original script only if it has not been loaded before 2) initialise the Instagram oEmbed manually (as a side effect this fixes the issue with Instagram oEmbeds not properly working when clicking the preview button multiple times).