### PR TITLE
Fix the oEmbeddable links wrapped in div also on preview and update

### DIFF
--- a/classes/class-wpcom-liveblog-entry-extend.php
+++ b/classes/class-wpcom-liveblog-entry-extend.php
@@ -31,6 +31,8 @@ class WPCOM_Liveblog_Entry_Extend {
 	    add_filter( 'liveblog_before_insert_entry', array( __CLASS__, 'strip_input' ), 1 );
 	    add_filter( 'liveblog_before_update_entry', array( __CLASS__, 'strip_input' ), 1 );
 		add_filter( 'liveblog_before_insert_entry', array( __CLASS__, 'fix_links_wrapped_in_div' ), 1 );
+		add_filter( 'liveblog_before_update_entry', array( __CLASS__, 'fix_links_wrapped_in_div' ), 1 );
+		add_filter( 'liveblog_before_preview_entry', array( __CLASS__, 'fix_links_wrapped_in_div' ), 1 );
 
 	    // Allow the features to be seperated in multiple ways: via spaces,
 	    // pipes or commas. This line explodes via spaces and pipes then


### PR DESCRIPTION
The original issue with oEmbeds fixed in #259 is also present during previews and updates

This commit hooks the very same function to two more filters - liveblog_before_update_entry and liveblog_before_preview_entry