### PR TITLE
Adding the `liveblog_ajax_request` action

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -310,6 +310,13 @@ final class WPCOM_Liveblog {
 			}
 		}
 
+		/**
+		 * Fires just before the Liveblog's ajax request is handled by one of the methods
+		 *
+		 * @param string $response_method The name of the method used for handling the request.
+		 */
+		do_action( 'liveblog_ajax_request', $response_method );
+
 		self::$response_method();
 
 	}


### PR DESCRIPTION
Some custom extensions for the Liveblog plugin might need to add special treatment for AJAX responses (eg.: inlining scripts as they can't use standard enququeing)

This commit adds new `liveblog_ajax_request` action which provides the $response_method param holding the name of Liveblog's method which will be used for processing the request.

This action is triggered just before the method is processed and allows developers to hook their own function calls which needs to run before the request is processed.