### PR TITLE
Initial implementation of AMP support

### DIFF
--- a/classes/class-wpcom-liveblog-entry-instagram-oembed.php
+++ b/classes/class-wpcom-liveblog-entry-instagram-oembed.php
@@ -21,14 +21,14 @@ class WPCOM_Liveblog_Entry_Instagram_oEmbed {
 	 * Register the filters just in time - when we are about to return HTML in endpoint
 	 */
 	public static function register_filters( $return ) {
-		
+
 		add_filter( 'oembed_fetch_url', array( __CLASS__, 'add_omitscript_arg' ), 10, 3 );
 		add_filter( 'embed_oembed_html', array( __CLASS__, 'add_custom_script' ), 10, 4 );
 		add_filter( 'comment_text', array( __CLASS__, 'unregister_filters' ), 0, 1 );
 		return $return;
 	}
 
-	/** 
+	/**
 	 * Deregister the filter we added
 	 */
 	public static function unregister_filters( $return ) {
@@ -56,8 +56,16 @@ class WPCOM_Liveblog_Entry_Instagram_oEmbed {
 	}
 
 	private static function is_instagram_provider( $url ) {
-		$wp_oembed = _wp_oembed_get_object();
-		$provider = $wp_oembed->get_provider( $url );
-		return ( 'https://api.instagram.com/oembed' === $provider );
+
+		$provider = false;
+
+		if ( class_exists( 'WP_oEmbed' ) ) {
+			$wp_oembed = new WP_oEmbed();
+			$provider = $wp_oembed->get_provider( $url );
+			$provider = ( 'https://api.instagram.com/oembed' === $provider );
+		}
+
+		return $provider;
+
 	}
 }

--- a/classes/class-wpcom-liveblog-entry-query.php
+++ b/classes/class-wpcom-liveblog-entry-query.php
@@ -46,14 +46,14 @@ class WPCOM_Liveblog_Entry_Query {
 		//
 		// We don't want to remove the parameter entirely for backwards compatibility
 		// since this is a public method, but we need instead to handle it as part
-		// of remove_replaced_entries after we retrieve the entire result set.
+		// of remove_replaced_deleted_entries after we retrieve the entire result set.
 		$number = 0;
 		if ( isset( $args['number'] ) ) {
 			$number = intval( $args['number'] );
 			unset( $args['number'] );
 		}
 
-		return self::remove_replaced_entries( $this->get( $args ), $number );
+		return self::remove_replaced_deleted_entries( $this->get( $args ), $number );
 	}
 
 	public function count( $args = array() ) {
@@ -102,7 +102,7 @@ class WPCOM_Liveblog_Entry_Query {
 			}
 		}
 
-		return self::remove_replaced_entries( $entries_between );
+		return self::remove_replaced_deleted_entries( $entries_between );
 	}
 
 	public function has_any() {
@@ -120,6 +120,15 @@ class WPCOM_Liveblog_Entry_Query {
 		return $all_entries_asc;
 	}
 
+	/**
+	 * Get deleted entries for a specific post.
+	 *
+	 * @return array The deleted entries IDs.
+	 */
+	public function get_deleted_entries() {
+		return ( array ) get_post_meta( $this->post_id, WPCOM_Liveblog_Entry::deleted_meta_key );
+	}
+
 	public static function entries_from_comments( $comments = array() ) {
 
 		if ( empty( $comments ) )
@@ -128,7 +137,7 @@ class WPCOM_Liveblog_Entry_Query {
 		return array_map( array( 'WPCOM_Liveblog_Entry', 'from_comment' ), $comments );
 	}
 
-	public static function remove_replaced_entries( $entries = array(), $number = 0 ) {
+	public static function remove_replaced_deleted_entries( $entries = array(), $number = 0 ) {
 		if ( empty( $entries ) ) {
 			return $entries;
 		}
@@ -136,9 +145,12 @@ class WPCOM_Liveblog_Entry_Query {
 		$entries_by_id = self::assoc_array_by_id( $entries );
 
 		foreach ( (array) $entries_by_id as $id => $entry ) {
+
+			// Removed replaced entries
 			if ( ! empty( $entry->replaces ) && isset( $entries_by_id[ $entry->replaces ] ) ) {
 				unset( $entries_by_id[ $id ] );
 			}
+
 		}
 
 		// If a number of entries is set and we have more than that amount of entries,

--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -172,6 +172,12 @@ class WPCOM_Liveblog_Entry {
 			$content = do_shortcode( $content );
 		}
 
+		// The force_balance_tags filter breaks the format AMP
+		// expects for oEmbed elements so we need to remove it.
+		if ( WPCOM_Liveblog::is_amp() ) {
+			remove_filter( 'comment_text', 'force_balance_tags', 25 );
+		}
+
 		return apply_filters( 'comment_text', $content, $comment );
 	}
 

--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -201,24 +201,19 @@ class WPCOM_Liveblog_Entry {
 	/**
 	 * Deletes an existing entry
 	 *
-	 * Inserts a new entry, which replaces the original entry.
+	 * Marks an entry as deleted so it doesn't show in the stream.
 	 *
 	 * @param array $args The entry properties: entry_id (which entry to delete), post_id, user (current user object)
-	 * @return WPCOM_Liveblog_Entry|WP_Error The newly inserted entry, which replaces the original
 	 */
 	public static function delete( $args ) {
 		if ( !$args['entry_id'] ) {
 			return new WP_Error( 'entry-delete', __( 'Missing entry ID', 'liveblog' ) );
 		}
-		$args['content'] = '';
-		$comment = self::insert_comment( $args );
-		if ( is_wp_error( $comment ) ) {
-			return $comment;
-		}
-		do_action( 'liveblog_delete_entry', $comment->comment_ID, $args['post_id'] );
-		add_comment_meta( $comment->comment_ID, self::replaces_meta_key, $args['entry_id'] );
+
+		do_action( 'liveblog_delete_entry', $args['entry_id'], $args['post_id'] );
 		wp_delete_comment( $args['entry_id'] );
-		$entry = self::from_comment( $comment );
+
+		$entry = self::from_comment( $args['entry_id'] );
 		return $entry;
 	}
 

--- a/js/liveblog-publisher.js
+++ b/js/liveblog-publisher.js
@@ -342,7 +342,7 @@
 			return this.$entry_text.data('original-content');
 		},
 		get_id_for_ajax_request: function() {
-			return this.$entry.attr('id').replace('liveblog-entry-', '');
+			return this.$entry.data('entry-id');
 		},
 		render: function() {
 			this.render_template();
@@ -410,7 +410,7 @@
 
 	liveblog.publisher.delete_click = function( e ) {
 		e.preventDefault();
-		var id = $( e.target ).closest( '.liveblog-entry' ).attr( 'id' ).replace( 'liveblog-entry-', '' );
+		var id = $( e.target ).closest( '.liveblog-entry' ).data( 'entry-id' );
 		if ( !id ) {
 			return;
 		}

--- a/js/liveblog.js
+++ b/js/liveblog.js
@@ -294,7 +294,7 @@ window.liveblog = window.liveblog || {};
 	};
 
 	liveblog.get_entry_by_id = function( id ) {
-		return $('.liveblog-entry-class-' + id );
+		return $( '#liveblog-entry-' + id );
 	};
 
 	liveblog.display_entry = function( new_entry, duration ) {

--- a/templates/liveblog-key-single-list.php
+++ b/templates/liveblog-key-single-list.php
@@ -1,4 +1,4 @@
-<li class="<?php echo esc_attr( $css_classes ); ?>" data-timestamp="<?php echo esc_attr( $timestamp ); ?>">
+<li class="<?php echo esc_attr( $css_classes ); ?>" data-sort-time="<?php echo esc_attr( $timestamp ); ?>">
 	<a href="#liveblog-entry-<?php echo esc_attr( $entry_id ); ?>" data-entry-id="<?php echo esc_attr( $entry_id ); ?>">
 		<?php echo WPCOM_Liveblog_Entry_Key_Events::get_formatted_content( $content, $post_id ); ?>
 	</a>

--- a/templates/liveblog-key-single-timeline.php
+++ b/templates/liveblog-key-single-timeline.php
@@ -1,4 +1,4 @@
-<li class="<?php echo esc_attr( $css_classes ); ?>" data-timestamp="<?php echo esc_attr( $timestamp ); ?>">
+<li class="<?php echo esc_attr( $css_classes ); ?>" data-sort-time="<?php echo esc_attr( $timestamp ); ?>">
 	<a class="link" href="#liveblog-entry-<?php echo esc_attr( $entry_id ); ?>" data-entry-id="<?php echo esc_attr( $entry_id ); ?>">
 		<span class="date liveblog-time-update"><?php echo esc_html( $entry_date ); ?> - <?php echo esc_html( $entry_time ); ?></span>
 		<span class="title"><?php echo WPCOM_Liveblog_Entry_Key_Events::get_formatted_content($content, $post_id); ?></span>

--- a/templates/liveblog-loop-amp.php
+++ b/templates/liveblog-loop-amp.php
@@ -1,0 +1,27 @@
+<?php if ( $show_archived_message ): ?>
+<div class="liveblog-archived-message">
+	<?php printf( __( '<strong>This liveblog is archived.</strong> If you need to publish new updates or edit or delete the old ones, you need to <a href="%s">enable it first</a>.' , 'liveblog'), esc_url( get_edit_post_link() ) . '#liveblog' ); ?>
+</div>
+<?php endif; ?>
+
+<amp-live-list layout="container" data-poll-interval="<?php echo esc_attr( $amp_poll_interval ); ?>" data-max-items-per-page="<?php echo esc_attr( $amp_items_per_page ); ?>" id="amp-live-list-entries">
+
+	<button update on="tap:amp-live-list-entries.update" class="liveblog-load-more"><?php esc_html_e( 'Load more entries&hellip;', 'liveblog' ); ?></button>
+
+	<div items>
+
+		<?php foreach ( (array) $entries as $entry ) : ?>
+
+			<?php echo $entry->render(); ?>
+
+		<?php endforeach; ?>
+
+		<?php foreach ( (array) $deleted_entries as $entry_id ) : ?>
+
+			<div id="liveblog-entry-<?php echo esc_attr( $entry_id ); ?>" data-sort-time="<?php echo current_time( 'timestamp' ); ?>" data-tombstone></div>
+
+		<?php endforeach; ?>
+
+	</div>
+
+</amp-live-list>

--- a/templates/liveblog-loop.php
+++ b/templates/liveblog-loop.php
@@ -1,6 +1,6 @@
 <?php if ( $show_archived_message ): ?>
 <div class="liveblog-archived-message">
-	<?php printf( __( '<strong>This liveblog is archived.</strong> If you need to publish new updates or edit or delete the old ones, you need to <a href="%s">enable it first</a>.' , 'liveblog'), get_edit_post_link() . '#liveblog' ); ?>
+	<?php printf( __( '<strong>This liveblog is archived.</strong> If you need to publish new updates or edit or delete the old ones, you need to <a href="%s">enable it first</a>.' , 'liveblog'), esc_url( get_edit_post_link() ) . '#liveblog' ); ?>
 </div>
 <?php endif; ?>
 

--- a/templates/liveblog-single-entry.php
+++ b/templates/liveblog-single-entry.php
@@ -1,4 +1,11 @@
-<div id="liveblog-entry-<?php echo esc_attr( $entry_id ); ?>" class="<?php echo esc_attr( $css_classes ); ?>" data-timestamp="<?php echo esc_attr( $timestamp ); ?>">
+<div
+	id="liveblog-entry-<?php echo esc_attr( $original_entry ); ?>"
+	data-entry-id="<?php echo esc_attr( $entry_id ); ?>"
+	data-timestamp="<?php echo esc_attr( $timestamp ); ?>"
+	class="<?php echo esc_attr( $css_classes ); ?>"
+	data-sort-time="<?php echo esc_attr( $timestamp ); ?>"
+	<?php if ( $updated_timestamp ) : ?> data-update-time="<?php echo esc_attr( $updated_timestamp ); ?>" <?php endif; ?>
+>
 	<header class="liveblog-meta">
 		<span class="liveblog-author-avatar"><?php echo wp_kses_post( $avatar_img ); ?></span>
 		<span class="liveblog-author-name"><?php echo wp_kses_post( $author_link ); ?></span>
@@ -7,9 +14,9 @@
 	<div class="liveblog-entry-text" data-original-content="<?php echo esc_attr( $original_content ); ?>">
 		<?php echo $content; ?>
 	</div>
-<?php if ( $is_liveblog_editable ): ?>
-	<ul class="liveblog-entry-actions">
-		<li><button class="liveblog-entry-edit button-secondary"><?php esc_html_e( 'Edit', 'liveblog' ); ?></button><button class="liveblog-entry-delete button-secondary"><?php esc_html_e( 'Delete', 'liveblog' ); ?></button></li>
-	</ul>
-<?php endif; ?>
+	<?php if ( $is_liveblog_editable ): ?>
+		<ul class="liveblog-entry-actions">
+			<li><button class="liveblog-entry-edit button-secondary"><?php esc_html_e( 'Edit', 'liveblog' ); ?></button><button class="liveblog-entry-delete button-secondary"><?php esc_html_e( 'Delete', 'liveblog' ); ?></button></li>
+		</ul>
+	<?php endif; ?>
 </div>


### PR DESCRIPTION
Fixes #246

I started to work on AMP support for the liveblog plugin, my main goal is to try not edit template files unless absolutely necessary to keep them maintainable and not just add an extra AMP version of every single template, here's some input into my decisions:

- Added `is_amp` helper function to check AMP request, since I'm using it in a few places I figured it would be easier than checking with `function_exists...` everywhere.
- I hid the frontend liveblog editing capabilities using existing functions rather than removing the markup from the template.
- Made poll interval and items per page configurable with filters.
- For AMP live lists each entry needs a `data-sort-time` attribute with a timestamp, I noticed the single entry template has a `data-timestamp` attribute but it doesn't seem to be used anywhere, I renamed this to avoid duplication and having to mess with templates.
- Added simple styling borrowing from the current "Leave comment" button styles, might be worth making the update button fixed positioned so it's easily accesible.

Updating and deleting entries is a bit more complicated because of the way liveblog deals with these kind of entries:

- To support live updating entries we need to keep the same entry id and add a `data-update-time` attribute with the updated timestamp. I changed this so if a post is updated it'll take the timestamp of the original entry as the `data-sort-time` and the timestamp of the new entry as `data-update-time`, also the id attribute will always reference the original entry id.
- Deletions are trickier and I'm still looking into it, what I'm thinking is to change the `remove_replaced_deleted_entries` function so it doesn't unset deleted entries and display and empty `div` with the required `data-tombstone` attr and the entry id.