### PR TITLE
Fix WYSIWYG icons getting cropped in MAC OS

### DIFF
--- a/css/liveblog.css
+++ b/css/liveblog.css
@@ -149,9 +149,9 @@ a.liveblog-form-entry::-webkit-input-placeholder {
 	position: relative;
 	margin: 1px;
 	border: solid 1px rgba(0, 0, 0, 0.0);
-	padding: 2px 1px;
-	width: 20px;
-	height: 20px;
+	padding: 1px;
+	width: 24px;
+	height: 24px;
 	line-height: 20px;
 	cursor: pointer;
 }


### PR DESCRIPTION
Fixes #275

Increased wrapper element size to let full icon show.

| Before | After |
| --- | --- |
| ![before](https://cloud.githubusercontent.com/assets/661330/20464244/3a88bda6-af3c-11e6-93cd-ce516a472977.png) | ![after](https://cloud.githubusercontent.com/assets/661330/20464246/4acaed7e-af3c-11e6-9fcd-21a0713bc95c.png) |


