### PR TITLE
Fix for unwanted "load more" button

### DIFF
--- a/classes/class-wpcom-liveblog-entry-instagram-oembed.php
+++ b/classes/class-wpcom-liveblog-entry-instagram-oembed.php
@@ -21,14 +21,14 @@ class WPCOM_Liveblog_Entry_Instagram_oEmbed {
 	 * Register the filters just in time - when we are about to return HTML in endpoint
 	 */
 	public static function register_filters( $return ) {
-		
+
 		add_filter( 'oembed_fetch_url', array( __CLASS__, 'add_omitscript_arg' ), 10, 3 );
 		add_filter( 'embed_oembed_html', array( __CLASS__, 'add_custom_script' ), 10, 4 );
 		add_filter( 'comment_text', array( __CLASS__, 'unregister_filters' ), 0, 1 );
 		return $return;
 	}
 
-	/** 
+	/**
 	 * Deregister the filter we added
 	 */
 	public static function unregister_filters( $return ) {
@@ -56,8 +56,16 @@ class WPCOM_Liveblog_Entry_Instagram_oEmbed {
 	}
 
 	private static function is_instagram_provider( $url ) {
-		$wp_oembed = _wp_oembed_get_object();
-		$provider = $wp_oembed->get_provider( $url );
-		return ( 'https://api.instagram.com/oembed' === $provider );
+
+		$provider = false;
+
+		if ( class_exists( 'WP_oEmbed' ) ) {
+			$wp_oembed = new WP_oEmbed();
+			$provider = $wp_oembed->get_provider( $url );
+			$provider = ( 'https://api.instagram.com/oembed' === $provider );
+		}
+
+		return $provider;
+
 	}
 }

--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -172,9 +172,12 @@ class WPCOM_Liveblog_Entry {
 	 * @return WPCOM_Liveblog_Entry|WP_Error The newly inserted entry, which replaces the original
 	 */
 	public static function update( $args ) {
-		if ( !$args['entry_id'] ) {
-			return new WP_Error( 'entry-delete', __( 'Missing entry ID', 'liveblog' ) );
+		if ( ! $args['entry_id'] ) {
+			return new WP_Error( 'entry-update', __( 'Missing entry ID', 'liveblog' ) );
 		}
+
+		// Store the original entry.
+		$original_entry = $args;
 
 		// always use the original author for the update entry, otherwise until refresh
 		// users will see the user who editd the entry as  the author
@@ -184,8 +187,18 @@ class WPCOM_Liveblog_Entry {
 		}
 
 		// Remove the entry ID so that we don't update the original entry.
-		$original_entry_id = $args['entry_id'];
 		unset( $args['entry_id'] );
+
+		// We need to preserve the time form the original entry, otherwise the
+		// new replacement entry will go to the top of the liveblog.
+		$original_comment = get_comment( $original_entry['entry_id'] );
+		if ( is_null( $original_comment ) ) {
+			return new WP_Error( 'entry_update', esc_html__( "Couldn't grab original comment", 'liveblog' ) );
+		}
+
+		// Copy the original date to the new args.
+		$args['comment_date'] = $original_comment->comment_date;
+		$args['comment_date_gmt'] = $original_comment->comment_date_gmt;
 
 		// Create a new entry, with the new content.
         $args = apply_filters( 'liveblog_before_update_entry', $args );
@@ -195,14 +208,15 @@ class WPCOM_Liveblog_Entry {
 		}
 
 		// Mark the new entry as replacing the old one.
-		add_comment_meta( $new_comment->comment_ID, self::replaces_meta_key, $original_entry_id );
+		add_comment_meta( $new_comment->comment_ID, self::replaces_meta_key, $original_entry['entry_id'] );
 
-		// Mark the original entry comment as trash.
+		// Mark the original entry comment as trash, and delete.
 		do_action( 'liveblog_update_entry', $new_comment->comment_ID, $args['post_id'] );
 		wp_update_comment( array(
-			'comment_ID'      => $original_entry_id,
+			'comment_ID'      => $original_entry['entry_id'],
 			'comment_approved' => 'liveblog_trashed',
 		) );
+		self::delete( $original_entry );
 
 		// Grab the WPCOM_Liveblog_Entry for the new comment and return for display.
 		$entry = self::from_comment( $new_comment );
@@ -244,17 +258,28 @@ class WPCOM_Liveblog_Entry {
 		if ( is_wp_error( $valid_args ) ) {
 			return $valid_args;
 		}
-		$new_comment_id = wp_insert_comment( array(
+
+		// Establish the new comment data.
+		$new_comment_args = array(
 			'comment_post_ID'      => $args['post_id'],
 			'comment_content'      => wp_filter_post_kses( $args['content'] ),
 			'comment_approved'     => 'liveblog',
 			'comment_type'         => 'liveblog',
 			'user_id'              => $args['user']->ID,
-
 			'comment_author'       => $args['user']->display_name,
 			'comment_author_email' => $args['user']->user_email,
 			'comment_author_url'   => $args['user']->user_url,
-		) );
+		);
+
+		// Check if we're forcing the time.
+		if ( isset( $args['comment_date'] ) && isset( $args['comment_date_gmt'] ) ) {
+			$new_comment_args['comment_date'] = $args['comment_date'];
+			$new_comment_args['comment_date_gmt'] = $args['comment_date_gmt'];
+		}
+
+		// Insert the new comment.
+		$new_comment_id = wp_insert_comment( $new_comment_args );
+
 		wp_cache_delete( 'liveblog_entries_asc_' . $args['post_id'], 'liveblog' );
 		if ( empty( $new_comment_id ) || is_wp_error( $new_comment_id ) ) {
 			return new WP_Error( 'comment-insert', __( 'Error posting entry', 'liveblog' ) );

--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -212,24 +212,19 @@ class WPCOM_Liveblog_Entry {
 	/**
 	 * Deletes an existing entry
 	 *
-	 * Inserts a new entry, which replaces the original entry.
+	 * Marks an entry as deleted so it doesn't show in the stream.
 	 *
 	 * @param array $args The entry properties: entry_id (which entry to delete), post_id, user (current user object)
-	 * @return WPCOM_Liveblog_Entry|WP_Error The newly inserted entry, which replaces the original
 	 */
 	public static function delete( $args ) {
-		if ( !$args['entry_id'] ) {
+		if ( ! $args['entry_id'] ) {
 			return new WP_Error( 'entry-delete', __( 'Missing entry ID', 'liveblog' ) );
 		}
-		$args['content'] = '';
-		$comment = self::insert_comment( $args );
-		if ( is_wp_error( $comment ) ) {
-			return $comment;
-		}
-		do_action( 'liveblog_delete_entry', $comment->comment_ID, $args['post_id'] );
-		add_comment_meta( $comment->comment_ID, self::replaces_meta_key, $args['entry_id'] );
+
+		do_action( 'liveblog_delete_entry', $args['entry_id'], $args['post_id'] );
 		wp_delete_comment( $args['entry_id'] );
-		$entry = self::from_comment( $comment );
+
+		$entry = self::from_comment( $args['entry_id'] );
 		return $entry;
 	}
 


### PR DESCRIPTION
There is a bug where the "load more entries" button shows when there are no more entries to show in the liveblog. This PR fixes that/

## Steps to reproduce;

* Create a liveblog
* Add 1 event
* Delete that events
* Open the Liveblog in incognito mode and you should see no entries and a "load more" button
* Clicking "load more entries" does nothing because there are no entries

## Cause:

When deleting the entry, the delete method in Liveblog was assuming we were doing an update operation, and creating a new entry to replace the deleted one. This new entry was empty, so ignored, and the deleted entry wasn't properly deleted. This meant the AJAX handler didn't return an empty array, making the button appear.

## Fix:

The delete method now actually deletes the entry. A side effect of the fix was to make edited entries to be moved to the top of the liveblog, so another fix was added to make sure that the replacement entry keeps the same timestamp as it's original entry.

This also fixes a fatal error related to using a private core function.