### PR TITLE
Contenteditable divs in Chrome

### DIFF
--- a/js/liveblog-publisher.js
+++ b/js/liveblog-publisher.js
@@ -161,6 +161,13 @@
 				},
 				'lineBreak': function() {
 					if ( isChrome || isSafari ) {
+						return e.shiftKey && e.keyCode === 13;
+					}
+
+					return;
+				},
+				'paragraphBreak': function() {
+					if ( isChrome || isSafari ) {
 						return e.keyCode === 13;
 					}
 
@@ -224,6 +231,10 @@
 			if (command === 'lineBreak') {
 				command = 'insertHTML';
 				value   = "<br><br>";
+			}
+			if (command === 'paragraphBreak') {
+				command = 'insertHTML';
+				value   = "<br><br><br>";
 			}
 			document.execCommand( command, false, value );
 		},

--- a/js/liveblog-publisher.js
+++ b/js/liveblog-publisher.js
@@ -4,9 +4,11 @@
 		return;
 	}
 
-	var isFirefox = typeof InstallTrigger !== 'undefined';
-	var isIE = /*@cc_on!@*/false || !!document.documentMode;
-	var isEdge = !isIE && !!window.StyleMedia;
+	var isFirefox = typeof InstallTrigger !== 'undefined',
+		isIE      = /*@cc_on!@*/false || !!document.documentMode,
+		isEdge    = !isIE && !!window.StyleMedia,
+		isChrome  = !!window.chrome && !!window.chrome.webstore,
+		isSafari  = Object.prototype.toString.call(window.HTMLElement).indexOf('Constructor') > 0 || (function (p) { return p.toString() === "[object SafariRemoteNotification]"; })(!window['safari'] || safari.pushNotification);
 
 	liveblog.InsertEntryView = Backbone.View.extend({
 		tagName: 'div',
@@ -158,11 +160,11 @@
 					return cmd_ctrl_key && e.keyCode === 220  /* backslash */;
 				},
 				'lineBreak': function() {
-					if ( isFirefox || isEdge || isIE ) {
-						return;
+					if ( isChrome || isSafari ) {
+						return e.keyCode === 13;
 					}
 
-					return e.keyCode === 13;
+					return;
 				}
 			};
 			found_command = false;

--- a/js/liveblog-publisher.js
+++ b/js/liveblog-publisher.js
@@ -152,6 +152,14 @@
 				},
 				'removeFormat': function () {
 					return cmd_ctrl_key && e.keyCode === 220  /* backslash */;
+				},
+				'lineBreak': function() {
+					var isFirefox = typeof InstallTrigger !== 'undefined';
+					if ( isFirefox ) {
+						return;
+					}
+
+					return e.keyCode === 13;
 				}
 			};
 			found_command = false;
@@ -208,7 +216,10 @@
 					command = 'unlink';
 				}
 			}
-
+			if (command === 'lineBreak') {
+				command = 'insertHTML';
+				value   = "<br><br>";
+			}
 			document.execCommand( command, false, value );
 		},
 

--- a/js/liveblog-publisher.js
+++ b/js/liveblog-publisher.js
@@ -158,7 +158,7 @@
 					return cmd_ctrl_key && e.keyCode === 220  /* backslash */;
 				},
 				'lineBreak': function() {
-					if ( isFirefox || isEdge  || isIE ) {
+					if ( isFirefox || isEdge || isIE ) {
 						return;
 					}
 

--- a/js/liveblog-publisher.js
+++ b/js/liveblog-publisher.js
@@ -160,18 +160,10 @@
 					return cmd_ctrl_key && e.keyCode === 220  /* backslash */;
 				},
 				'lineBreak': function() {
-					if ( isChrome || isSafari ) {
-						return e.shiftKey && e.keyCode === 13;
-					}
-
-					return;
+					return e.shiftKey && e.keyCode === 13;
 				},
 				'paragraphBreak': function() {
-					if ( isChrome || isSafari ) {
-						return e.keyCode === 13;
-					}
-
-					return;
+					return e.keyCode === 13;
 				}
 			};
 			found_command = false;
@@ -229,12 +221,23 @@
 				}
 			}
 			if (command === 'lineBreak') {
-				command = 'insertHTML';
-				value   = "<br><br>";
+				if ( isChrome || isSafari ) {
+					command = 'insertHTML';
+					value   = "<br><br>";
+				} else {
+					command = 'insertText';
+					value   = "\n";
+				}
 			}
 			if (command === 'paragraphBreak') {
-				command = 'insertHTML';
-				value   = "<br><br><br>";
+				if ( isChrome || isSafari ) {
+					command = 'insertHTML';
+					value   = '<br><br><br>';
+				} else {
+					document.execCommand( 'insertText', false, "\n" );
+					command = 'insertHTML';
+					value   = '<br>';
+				}
 			}
 			document.execCommand( command, false, value );
 		},

--- a/js/liveblog-publisher.js
+++ b/js/liveblog-publisher.js
@@ -4,6 +4,10 @@
 		return;
 	}
 
+	var isFirefox = typeof InstallTrigger !== 'undefined';
+	var isIE = /*@cc_on!@*/false || !!document.documentMode;
+	var isEdge = !isIE && !!window.StyleMedia;
+
 	liveblog.InsertEntryView = Backbone.View.extend({
 		tagName: 'div',
 		className: 'liveblog-form',
@@ -154,8 +158,7 @@
 					return cmd_ctrl_key && e.keyCode === 220  /* backslash */;
 				},
 				'lineBreak': function() {
-					var isFirefox = typeof InstallTrigger !== 'undefined';
-					if ( isFirefox ) {
+					if ( isFirefox || isEdge  || isIE ) {
 						return;
 					}
 


### PR DESCRIPTION
In Chrome (OS X and Windows 8 tested) and Safari, lines after the first are wrapped in a div. e.g.

if you enter

```
a
b
c
```

you get

```
a
<div>b</div>
<div>c</div>
```

This results in unexpected HTML when published. First line gets `p` tags, but the divs stick around.

While in some cases the issue can be worked around (#259, #265), it may be better to get to the root problem.

This pull request makes Chrome and Safari insert 2 breaks (`<br /><br />`) on enter which results in predictable spacing. Instead of the divs, you'd get

```
<p>a<br>
b<br>
c</p>
```

Which is the same as Firefox currently gets.

- linebreak fix: http://stackoverflow.com/questions/18552336/prevent-contenteditable-adding-div-on-enter-chrome
- browser detection: http://stackoverflow.com/questions/9847580/how-to-detect-safari-chrome-ie-firefox-and-opera-browser
- https://bugs.chromium.org/p/chromium/issues/detail?id=84936

_edit: spelling_