### PR TITLE
Remove PHP 5.2 tests from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,6 @@ language: php
 matrix:
 
     include:
-        # Current $required_php_version for WordPress: 5.2.4
-        # aliased to 5.2.17
-        - php: '5.2'
-          env: WP_VERSION=latest
         # aliased to a recent 5.6.x version
         - php: '5.6'
           env:


### PR DESCRIPTION
Namespaces aren't supported in 5.2 so the tests fail.