### PR TITLE
users can edit more than 1x now and reloaded page will show

### DIFF
--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -94,7 +94,7 @@ class WPCOM_Liveblog_Entry {
 	}
 
 	public function get_fields_for_render() {
-		$entry_id     = $this->comment->comment_ID;
+		$entry_id     = $this->replaces ? $this->replaces : $this->comment->comment_ID;
 		$post_id      = $this->comment->comment_post_ID;
 		$avatar_size  = apply_filters( 'liveblog_entry_avatar_size', self::default_avatar_size );
 		$comment_text = get_comment_text( $entry_id );


### PR DESCRIPTION
As per #243, users cannot edit an entry more than once on the same page session because it will only save once (ergo, the first edit).  Problem was in rendering html, since ajax was correctly.

Credits to @trepmal for really delving into it to figure the root cause.  

This also fixes #177 and #241 going forward. 