### PR TITLE
Retroactively fixes incorrect entries on for archived Liveblogs

### DIFF
--- a/classes/class-wpcom-liveblog-entry-query.php
+++ b/classes/class-wpcom-liveblog-entry-query.php
@@ -35,6 +35,25 @@ class WPCOM_Liveblog_Entry_Query {
 	}
 
 	/**
+	 * Query the database for all edited liveblog entries associated with $post_id
+	 *
+	 * @param array $args the same args for the core `get_comments()`.
+	 * @return array array of `WPCOM_Liveblog_Entry` objects with the found entries
+	 */
+	public function get_all_edits( $args = array() ) {
+		$defaults = array(
+			'orderby' 	=> 'comment_date_gmt',
+			'order'   	=> 'ASC',
+			'meta_key'  => 'liveblog_replaces',
+			'status'	=> 'liveblog'
+		);
+
+		$args     = wp_parse_args( $args, $defaults );
+		$comments = get_comments( $args );
+
+		return self::entries_from_comments( $comments );
+	}
+	/**
 	 * Get all of the liveblog entries
 	 *
 	 * @param array $args the same args for the core `get_comments()`

--- a/classes/class-wpcom-liveblog-wp-cli.php
+++ b/classes/class-wpcom-liveblog-wp-cli.php
@@ -11,6 +11,105 @@ class WPCOM_Liveblog_WP_CLI extends WP_CLI_Command {
 		$readme = $this->markdownify_headings( $readme );
 		echo $readme;
 	}
+	
+	/**
+	 * Fix wp_commentmeta table so archived liveblog posts comments display properly.
+	 *
+	 * @subcommand fix-archive
+	*/
+	public function fix_archive() {
+		global $wpdb;
+
+		// find all liveblogs
+		$posts = new WP_Query( array(
+									'order'    => 'ASC',
+									'orderby'  => 'ID',
+									'meta_key' => 'liveblog' 
+									) );
+
+		foreach( $posts->posts as $post ) {
+			$post_id = $post->ID;
+
+			// get all entries that have been edited in the liveblog
+			$entries_query = new WPCOM_Liveblog_Entry_Query( $post_id, WPCOM_Liveblog::key );
+			$edit_entries = $entries_query->get_all_edits( array( 'post_id' => $post_id ) );			
+			// find correct comment_ids to replace incorrect meta_values
+			$correct_ids_array = $wpdb->get_results(
+				$wpdb->prepare(
+				"SELECT comment_id FROM $wpdb->comments
+				 WHERE comment_post_id = %d AND comment_id NOT IN 
+				 ( SELECT $wpdb->commentmeta.comment_id FROM $wpdb->commentmeta
+				   INNER JOIN $wpdb->comments 
+				   ON $wpdb->comments.comment_id = $wpdb->commentmeta.comment_id
+				   WHERE comment_post_id = %d )
+				 ORDER BY comment_id ASC", $post_id, $post_id )
+				);
+			$correct_ids = wp_list_pluck( $correct_ids_array, 'comment_id' );
+
+			// replace incorrect meta_value with correct one
+			foreach( $edit_entries as $edit_entry ) {
+				$entry_id = $edit_entry->get_id();
+
+				// look for replaces property in $correct_ids 
+				if ( in_array( $edit_entry->replaces, $correct_ids ) ) {
+					continue;
+				}
+				else {
+					for ( $i = 0; $i <= count( $correct_ids ) - 1; $i++ )
+					{		
+						// replace with correct meta_value
+						if ( $correct_ids[$i] < $entry_id ) {
+
+							$wpdb->update(
+								$wpdb->commentmeta,
+								array( 'meta_value' => $correct_ids[$i] ),
+								array( 'comment_id' => $entry_id )
+								);
+						}
+					}
+				}
+			}
+			// find comment_ids object with correct content for replacement
+			$correct_contents = $wpdb->get_results(
+				$wpdb->prepare( 
+					"SELECT comment_id, comment_content
+					 FROM $wpdb->comments
+					 WHERE comment_post_id = %d
+					 GROUP BY comment_content
+					 HAVING count(comment_content) = 2
+					 ORDER BY comment_id ASC",  $post_id )
+			);
+
+			// find comment_ids that NEED to be replaced
+			$entries_replace = $wpdb->get_results(
+				$wpdb->prepare(
+					"SELECT DISTINCT meta_value 
+					FROM $wpdb->commentmeta 
+					INNER JOIN $wpdb->comments 
+					ON $wpdb->comments.comment_id = $wpdb->commentmeta.comment_id
+					WHERE comment_post_id = %d
+					ORDER BY meta_value ASC", $post_id )
+				);
+
+			// check to make sure entry content being replaced matches available
+			if ( count( $entries_replace ) === count( $correct_contents) ) {
+				// counter
+				$replaced = 0;
+				foreach( $entries_replace as $entry_replace ) {
+					$content = $correct_contents[ $replaced ]->comment_content;
+
+					$wpdb->update(
+					 	$wpdb->comments,
+					 	array( 'comment_content' => $content ),
+					 	array( 'comment_id' => $entry_replace->meta_value )
+					 	);
+
+					$replaced++;
+				}
+			}
+		}
+		WP_CLI::line( 'Fixed all entries on all liveblog posts!' );
+	}
 
 	private function markdownify_headings( $readme ) {
 		return preg_replace_callback( '/^\s*(=+)\s*(.*?)\s*=+\s*$/m',


### PR DESCRIPTION
As per #177, this one fixes all entries retroactively with a custom wp-cli command called `fix-archive`.  

Note: Related to #297, where #297 only fixes entries going forward. 