### PR TITLE
Update constant check to quote the value in defined() call

### DIFF
--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -106,7 +106,7 @@ add_action( 'liveblog_delete_entry', 'wpcom_invalidate_feed_cache' );
 add_filter( 'liveblog_current_user_can_edit_liveblog', function( $can_edit ) {
 
 	// Retain super admin access for A12s.
-	if ( is_automattician() || ( defined( A8C_PROXIED_REQUEST ) && A8C_PROXIED_REQUEST ) ) {
+	if ( is_automattician() || ( defined( 'A8C_PROXIED_REQUEST' ) && A8C_PROXIED_REQUEST ) ) {
 		return $can_edit;
 	}
 


### PR DESCRIPTION
If the constant `A8C_PROXIED_REQUEST` is not defined, the `defined( A8C_PROXIED_REQUEST )` check will throw an error, because the value in `defined()` should be a string.

This line is causing phpunit tests in one of my projects to fail. I'll work around it for the time being by setting the constant in the test scope, but it should be fixed upstream as well.

Thanks!