### PR TITLE
Don’t force mobile devices in capture mode

### DIFF
--- a/src/react/Editor/Editor.js
+++ b/src/react/Editor/Editor.js
@@ -342,7 +342,6 @@ class EditorWrapper extends Component {
           id={this.inputId}
           onChange={this.uploadImages.bind(this)}
           accept="image/jpeg,image/gif,image/png,image/jpg"
-          capture="camera"
         />
         <Toolbar
           imageInputId={this.inputId}


### PR DESCRIPTION
I think that there is really no point of forcing camera capture on people - workflows differ.
It’s reasonable to assume people take pictures, edit them on the fly and then upload. Another scenario would be a reporter working form an iPad would be now able to upload an attachment received by Email.