### PR TITLE
Fix 2 failing PHPUnit tests

### DIFF
--- a/t/test-rest-api.php
+++ b/t/test-rest-api.php
@@ -625,7 +625,7 @@ class Test_REST_API extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 
 		// Assert forbidden response
-		$this->assertEquals( 403, $response->get_status() );
+		$this->assertTrue( $response->get_status() === 403 || $response->get_status() == 401 );
 
 	}
 
@@ -651,7 +651,7 @@ class Test_REST_API extends WP_UnitTestCase {
 		$response = $this->server->dispatch( $request );
 
 		// Assert forbidden response
-		$this->assertEquals( 403, $response->get_status() );
+		$this->assertTrue( $response->get_status() === 403 || $response->get_status() == 401 );
 
 	}
 


### PR DESCRIPTION
Allow test to return 401 or 403 as different WP versions return different results