### PR TITLE
Use get_rest_url()

### DIFF
--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -40,13 +40,13 @@ class WPCOM_Liveblog_Rest_Api {
 
 		if ( get_option( 'permalink_structure' ) ) {
 			// Pretty permalinks enabled
-			$base = '/' . rest_get_url_prefix() . '/' . self::$api_namespace . '/';
+			$url = get_rest_url( ) . self::$api_namespace . '/';
 		} else {
 			// Pretty permalinks not enabled
-			$base = '/?rest_route=/' . self::$api_namespace . '/';
+			$url = home_url( '/' ) . '/?rest_route=/' . self::$api_namespace . '/';
 		}
 
-		return home_url( $base );
+		return $url;
 
 	}
 

--- a/liveblog.php
+++ b/liveblog.php
@@ -1581,7 +1581,7 @@ final class WPCOM_Liveblog {
 	 * Checks if use_rest_api is on and the WordPress version supports it
 	 */
 	public static function use_rest_api() {
-		return apply_filters( 'liveblog_use_rest_api', self::use_rest_api && self::can_use_rest_api() );
+		return ( self::use_rest_api && self::can_use_rest_api() );
 	}
 
 	/**

--- a/liveblog.php
+++ b/liveblog.php
@@ -1581,7 +1581,7 @@ final class WPCOM_Liveblog {
 	 * Checks if use_rest_api is on and the WordPress version supports it
 	 */
 	public static function use_rest_api() {
-		return ( self::use_rest_api && self::can_use_rest_api() );
+		return apply_filters( 'liveblog_use_rest_api', self::use_rest_api && self::can_use_rest_api() );
 	}
 
 	/**


### PR DESCRIPTION
By using get_rest_url() we can leverage the existing filters there and make sure we're consistent in the usage of REST API url.