### PR TITLE
Load More Button Issue

### DIFF
--- a/classes/class-wpcom-liveblog-entry-query.php
+++ b/classes/class-wpcom-liveblog-entry-query.php
@@ -194,9 +194,17 @@ class WPCOM_Liveblog_Entry_Query {
 		}
 
 		$entries_by_id = self::assoc_array_by_id( $entries );
-
+		
+		/**
+		 * Filter Entries.
+		 *
+		 * Reason to add this filter, Lode More button not working as expected because of DELETE entries.
+		 *
+		 */
+		$entries_by_id = apply_filters( 'WPCOM_liveblog_remove_replaced_entries', $entries_by_id );
+		
 		foreach ( (array) $entries_by_id as $id => $entry ) {
-			if ( ! empty( $entry->replaces ) && isset( $entries_by_id[ $entry->replaces ] ) ) {
+			if ( ( 'delete' === $entry->get_type() ) || ( 'update' === $entry->get_type() && ! empty( $entry->replaces ) ) ) {
 				unset( $entries_by_id[ $id ] );
 			}
 		}


### PR DESCRIPTION
Load More button Issue.

Scenario 1 : 
- Create 15 to 20 entries with limit 5.
- Load the page. You will see first 5 entries ( ID's 1 - 5 ).
- Now delate all the top 5 entries which is initially loaded.
- Load the page again.
- **Expected** : Need to display next 5 ( ID's 6 to 10 ) based on the limit.
- **Observed** : No entries displayed but load more appears and onclick load more next entries were not displyed.

Scenario 2: 
- Create 20 to 30 Entries with limit 5.
- Go to the bottom of the list by clicking load more.
- After all the list is loaded i still able to see LOAD MORE button.

Scenario 3: 
- Create 20 to 30 Entries with limit 5.
- Go to the bottom of the list by clicking load more.
- Delete at least 3 to 6 entries and reload the page.
- All the entries were disappeared.

For all the above issue i have gone through the plugin code and found that
Live blog provides all the entries (in @$entries_by_id ) even if it is deleted or update or new, but no where we are filtering this deleted values from L208 below line to end of the function where it  returns even deleted entries. And upon that we provide array slice at L218 and what if we have TYPE === 'DELETED' for all in the sliced array??, which will be not shown in the frontend since we are queering based on limit this will eventually fails the load more button.