### PR TITLE
Cast liveblog rewrite version before checks

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -262,7 +262,8 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		}
 
 		public static function flush_rewrite_rules() {
-			if ( get_option( 'liveblog_rewrites_version' ) !== self::REWRITES_VERSION ) {
+			$rewrites_version = (int) get_option( 'liveblog_rewrites_version' );
+			if ( self::REWRITES_VERSION !== $rewrites_version ) {
 				flush_rewrite_rules();
 				update_option( 'liveblog_rewrites_version', self::REWRITES_VERSION );
 			}


### PR DESCRIPTION
The option is returned is a `string` and the class holds the version as an `int`. The strict check causes the version check to fail and we end up flushing rewrites every time `init` fires.

Before doing the check, cast the rewrite version option as an `int` to avoid the type mismatch.