### PR TITLE
Add minimum PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 * Contributors: [automattic](http://profiles.wordpress.org/automattic), [nbachiyski](http://profiles.wordpress.org/nbachiyski), [batmoo](http://profiles.wordpress.org/batmoo), [johnjamesjacoby](http://profiles.wordpress.org/johnjamesjacoby), [philipjohn](http://profiles.wordpress.org/philipjohn)
 * Tags: liveblog
 * Requires at least: 4.4
+* Requires PHP: 5.6
 * Tested up to: 4.9.5
 * Stable tag: 1.8.2
 * License: GPLv2 or later

--- a/readme.txt
+++ b/readme.txt
@@ -2,6 +2,7 @@
 Contributors: automattic, nbachiyski, batmoo, johnjamesjacoby
 Tags: liveblog
 Requires at least: 4.4
+Requires PHP: 5.6
 Tested up to: 4.9.5
 Stable tag: 1.8.2
 License: GPLv2 or later


### PR DESCRIPTION
We no longer support anything below PHP 5.6 but we haven't documented that. This change uses the core-specified mechanism in readme.

Helps address #446 