### PR TITLE
Fix deprecated notice about non-static function

### DIFF
--- a/classes/class-wpcom-liveblog-amp.php
+++ b/classes/class-wpcom-liveblog-amp.php
@@ -270,7 +270,7 @@ class WPCOM_Liveblog_AMP {
 	 * @param  array  $entries liveblog entries.
 	 * @param  object $request Request Object.
 	 */
-	public function set_request_last_from_entries( $entries, $request ) {
+	public static function set_request_last_from_entries( $entries, $request ) {
 		if ( false === $request->last ) {
 			$request->last = $entries['entries'][0]->id . '-' . $entries['entries'][0]->timestamp;
 		}


### PR DESCRIPTION
set_request_last_from_entries() is being called statically when the function isn't declared static, resulting in this error:

> Deprecated: Non-static method WPCOM_Liveblog_AMP::set_request_last_from_entries() should not be called statically in /liveblog/classes/class-wpcom-liveblog-amp.php on line 259

This change fixes that by declaring the function as static.