### PR TITLE
Fix 'undefined offset' error in AMP class

### DIFF
--- a/classes/class-wpcom-liveblog-amp.php
+++ b/classes/class-wpcom-liveblog-amp.php
@@ -270,8 +270,8 @@ class WPCOM_Liveblog_AMP {
 	 * @param  array  $entries liveblog entries.
 	 * @param  object $request Request Object.
 	 */
-	public function set_request_last_from_entries( $entries, $request ) {
-		if ( false === $request->last ) {
+	public static function set_request_last_from_entries( $entries, $request ) {
+		if ( false === $request->last && ! empty( $entries['entries'] ) ) {
 			$request->last = $entries['entries'][0]->id . '-' . $entries['entries'][0]->timestamp;
 		}
 


### PR DESCRIPTION
When there are no entries (i.e. a Liveblog is new, and empty) the following error happens:

> Notice: Undefined offset: 0 in /liveblog/classes/class-wpcom-liveblog-amp.php on line 275

This change fixes that by adding an additional check for an empty array.