### PR TITLE
Wider retrieval of authors for liveblog attribution

### DIFF
--- a/classes/class-wpcom-liveblog-entry-extend-feature-authors.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-authors.php
@@ -232,7 +232,7 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Authors extends WPCOM_Liveblog_Entry_E
 
 		// The args used in the get_users query.
 		$args = array(
-			'who'    => 'authors',
+			'role__in' => array( 'author', 'editor', 'contributor' ),
 			'fields' => array( 'ID', 'user_nicename', 'display_name' ),
 			'number' => 10,
 		);


### PR DESCRIPTION
Code change to retrieve contributors, editors and authors for liveblog attribution