### PR TITLE
Schema: Use @type for publisher type

### DIFF
--- a/classes/class-wpcom-liveblog-amp.php
+++ b/classes/class-wpcom-liveblog-amp.php
@@ -202,8 +202,8 @@ class WPCOM_Liveblog_AMP {
 					$publisher_name = $metadata['publisher']['name'];
 				}
 
-				if ( isset( $metadata['publisher']['type'] ) ) {
-					$publisher_organization = $metadata['publisher']['type'];
+				if ( isset( $metadata['publisher']['@type'] ) ) {
+					$publisher_organization = $metadata['publisher']['@type'];
 				}
 
 				$blog_item = (object) array(


### PR DESCRIPTION
The array key set in AMP (https://github.com/Automattic/amp-wp/blob/9bd2a05d62315738952bd95ac413b1983bf91423/includes/amp-helper-functions.php#L745) is `@type`, not `type`.

See #506.