### PR TITLE
Travis: Remove HHVM checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,12 +24,6 @@ matrix:
         # aliased to a recent 7.x version
         - php: '7.0'
           env: WP_VERSION=latest
-        # aliased to a recent hhvm version
-        - php: 'hhvm'
-          env: WP_VERSION=latest
-
-    allow_failures:
-        - php: 'hhvm'
 
 before_script:
     # Set up CodeSniffer


### PR DESCRIPTION
HHVM is moving away from PHP compatibility, so there is little point in testing against this now.

Fixes #500.