### PR TITLE
Add an option to disable the static endpoint cache 

### DIFF
--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -28,7 +28,12 @@ class WPCOM_Liveblog_Rest_Api {
 
 	public static function build_endpoint_base() {
 
-		if ( ! empty( self::$endpoint_base ) ) {
+		/**
+		 * static caching is enabled by default
+		 *
+		 * @param bool true - yes cache; false - do not cache
+		 */
+		if ( ! empty( self::$endpoint_base ) && apply_filters( 'liveblog_cache_endpoint_base', true ) ) {
 
 			// @codeCoverageIgnoreStart
 			return self::$endpoint_base;


### PR DESCRIPTION
for users who need fine-grain control over the endpoint base, this allows selective or site-wide disabling of the static cache.

This might be needed for a site that uses more than one domain, for example a different domain for wp-admin vs the front end.