### PR TITLE
AMP Pagination Fix

### DIFF
--- a/classes/class-wpcom-liveblog-amp.php
+++ b/classes/class-wpcom-liveblog-amp.php
@@ -250,6 +250,11 @@ class WPCOM_Liveblog_AMP {
 
 		$request = self::get_request_data();
 
+		// If AMP Polling request don't restrict content so it knows there is updates are available.
+		if ( self::is_amp_polling() ) {
+			$request->last = false;
+		}
+
 		if ( $request->id ) {
 			$entries  = WPCOM_Liveblog::get_entries_paged( false, false, $request->id );
 			$request  = self::set_request_last_from_entries( $entries, $request );
@@ -354,6 +359,7 @@ class WPCOM_Liveblog_AMP {
 				'page'     => $entries['page'],
 				'pages'    => $entries['pages'],
 				'links'    => self::get_pagination_links( $request, $entries['pages'], $post_id ),
+				'last'     => get_query_var( 'liveblog_last', false ),
 				'settings' => array(
 					'entries_per_page' => WPCOM_Liveblog_Lazyloader::get_number_of_entries(),
 					'refresh_interval' => WPCOM_Liveblog::get_refresh_interval(),
@@ -431,6 +437,7 @@ class WPCOM_Liveblog_AMP {
 
 		$permalink = amp_get_permalink( $post_id );
 
+		$links['base']  = self::build_paged_permalink( $permalink, 1, false );
 		$links['first'] = self::build_paged_permalink( $permalink, 1, $request->last );
 		$links['last']  = self::build_paged_permalink( $permalink, $pages, $request->last );
 
@@ -502,5 +509,18 @@ class WPCOM_Liveblog_AMP {
 	public static function get_template( $name, $variables = array() ) {
 		$template = new WPCOM_Liveblog_AMP_Template();
 		return $template->render( $name, $variables );
+	}
+
+	/**
+	 * Is this an AMP polling request.
+	 *
+	 * @return boolean AMP polling request.
+	 */
+	public static function is_amp_polling() {
+		$amp_latest_update_time = filter_input( INPUT_GET, 'amp_latest_update_time', FILTER_SANITIZE_STRING );
+		if ( ! empty( $amp_latest_update_time ) ) {
+			return true;
+		}
+		return false;
 	}
 }

--- a/templates/amp/feed.php
+++ b/templates/amp/feed.php
@@ -4,6 +4,7 @@ $post_id          = $this->get( 'post_id' );
 $links            = $this->get( 'links' );
 $page             = $this->get( 'page' );
 $pages            = $this->get( 'pages' );
+$last             = $this->get( 'last' );
 $settings         = $this->get( 'settings' );
 $entries_per_page = $settings['entries_per_page'];
 $refresh_interval = $settings['refresh_interval'];
@@ -24,7 +25,11 @@ $social           = $settings['social'];
 
 	<button id="live-list-update-button"
 		update
-		on="tap:amp-live-list-insert-blog.update"
+		<?php if ( $last === false ): ?>
+			on="tap:amp-live-list-insert-blog.update"
+		<?php else: ?>
+			on="tap: AMP.navigateTo(url='<?php echo esc_url( $links->base ); ?>')"
+		<?php endif ?>
 		class="ampstart-btn caps"><?php esc_html_e( 'You have updates' ); ?></button>
 	<div items>
 


### PR DESCRIPTION
This PR resolves the issues discussed in Issue: https://github.com/Automattic/liveblog/issues/504

When pagination is used in AMP, the update button should still be displayed and take the user back to page 1.