### PR TITLE
Fix pagination hiding of disabled buttons

### DIFF
--- a/src/react/containers/PaginationContainer.js
+++ b/src/react/containers/PaginationContainer.js
@@ -9,19 +9,22 @@ class PaginationContainer extends Component {
   render() {
     const { page, pages, getEntriesPaginated } = this.props;
 
+    const isFirstPage = (page === 1);
+    const isLastPage = (page === pages);
+
     return (
       <div className="liveblog-pagination">
         <div>
           <button
-            disabled={page === 1}
-            className="liveblog-btn liveblog-pagination-btn liveblog-pagination-first"
+            disabled={isFirstPage}
+            className={`liveblog-btn liveblog-pagination-btn liveblog-pagination-first ${isFirstPage && 'liveblog-btn--hide'}`}
             onClick={() => getEntriesPaginated(1, 'first')}
           >
             First
           </button>
           <button
-            disabled={page === 1}
-            className="liveblog-btn liveblog-pagination-btn liveblog-pagination-prev"
+            disabled={isFirstPage}
+            className={`liveblog-btn liveblog-pagination-btn liveblog-pagination-prev ${isFirstPage && 'liveblog-btn--hide'}`}
             onClick={() => getEntriesPaginated((page - 1), 'last')}
           >
             Prev
@@ -30,15 +33,15 @@ class PaginationContainer extends Component {
         <span className="liveblog-pagination-pages">{page} of {pages}</span>
         <div>
           <button
-            disabled={page === pages}
-            className="liveblog-btn liveblog-pagination-btn liveblog-pagination-next"
+            disabled={isLastPage}
+            className={`liveblog-btn liveblog-pagination-btn liveblog-pagination-next ${isLastPage && 'liveblog-btn--hide'}`}
             onClick={() => getEntriesPaginated((page + 1), 'first')}
           >
             Next
           </button>
           <button
-            disabled={page === pages}
-            className="liveblog-btn liveblog-pagination-btn liveblog-pagination-last"
+            disabled={isLastPage}
+            className={`liveblog-btn liveblog-pagination-btn liveblog-pagination-last ${isLastPage && 'liveblog-btn--hide'}`}
             onClick={() => getEntriesPaginated(pages, 'first')}
           >
             Last


### PR DESCRIPTION
Fixes: https://github.com/Automattic/liveblog/issues/522

Currently when paging through liveblog entries, there are four buttons `First, Previous, Next, Last`. The buttons are properly disabled, so when on the first page, the user can not use First & Prev buttons, and on the last page the user cannot use Next & Last. However, these buttons are still visible, which can be confusing to the user.

Adding pre-existing `liveblog-btn--hide` CSS class hides these unusable buttons when they're disabled.

Moved conditionals into constants to reduce repetitiveness and improve readability.