### PR TITLE
change package.json version from 1.9-rc2 to 1.9.0-rc2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liveblog",
   "description": "Liveblogging done right. Using WordPress",
-  "version": "1.9-rc2",
+  "version": "1.9.0-rc2",
   "author": "Automattic",
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
npm's getting angry at version number in package.json not being semver.

> npm ERR! Invalid version: "1.9-rc2"

See https://travis-ci.org/Automattic/liveblog/jobs/429331235#L680