### PR TITLE
Add support for other post types

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -59,6 +59,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		public static $auto_archive_days       = null;
 		public static $auto_archive_expiry_key = 'liveblog_autoarchive_expiry_date';
 		public static $latest_timestamp        = false;
+		public static $supported_post_types    = array();
 
 
 		/** Load Methods **********************************************************/
@@ -250,7 +251,11 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			 * Add liveblog support to the 'post' post type. This is done here so
 			 * we can possibly introduce this to other post types later.
 			 */
-			add_post_type_support( 'post', self::KEY );
+			$post_types = array( 'post' );
+			self::$supported_post_types = apply_filters( 'liveblog_modify_supported_post_types', $post_types );
+			foreach ( self::$supported_post_types as $post_type ) {
+				add_post_type_support( $post_type, self::key );
+			}
 
 			/**
 			 * Apply a Filter to Setup our Auto Archive Days.
@@ -493,14 +498,14 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		 * @return bool
 		 */
 		public static function is_viewing_liveblog_post() {
-			return (bool) ( is_single() && self::is_liveblog_post() );
+			return (bool) ( is_singular( self::$supported_post_types ) && self::is_liveblog_post() );
 		}
 
 		/**
 		 * One of: 'enable', 'archive', false.
 		 */
 		public static function get_liveblog_state( $post_id = null ) {
-			if ( ! is_single() && ! is_admin() && ! self::$is_rest_api_call ) {
+			if ( ! is_singular( self::$supported_post_types ) && ! is_admin() && ! self::$is_rest_api_call ) {
 				return false;
 			}
 			if ( empty( $post_id ) ) {


### PR DESCRIPTION
Submitting a new PR because the changes from [this PR](https://github.com/Automattic/liveblog/pull/342) were lost.

1. Added a static variable for supported post types that can be filtered with the `liveblog_modify_supported_post_types` filter in the `init()` method.
2. Addressed the feedback for `page` post type in the previous PR. 
3. Modified `get_liveblog_state()` and `is_viewing_liveblog_post()` to accommodate additional post types.