### PR TITLE
update print_liveblog_metadata() to pass parameters to get_liveblog_metadata()

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -1847,7 +1847,9 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 				return;
 			}
 
-			$metadata = WPCOM_Liveblog::get_liveblog_metadata();
+			$metadata = [];
+			global $post;
+			$metadata = self::get_liveblog_metadata( $metadata, $post );
 			if ( empty( $metadata ) ) {
 				return;
 			}


### PR DESCRIPTION
In `fix/phpcs`, we discovered that `get_liveblog_metadata()`'s method signature was missing parameters (even though they were listed in the headerdoc).

I added the parameters to the method definition and to one of the calls, but missed the `print_liveblog_metadata` call.