### PR TITLE
Applying escape validate for amp validator

### DIFF
--- a/classes/class-wpcom-liveblog-amp.php
+++ b/classes/class-wpcom-liveblog-amp.php
@@ -101,7 +101,7 @@ class WPCOM_Liveblog_AMP {
 	 * @return void
 	 */
 	public static function print_styles() {
-		echo esc_html( file_get_contents( dirname( __DIR__ ) . '/assets/amp.css' ) );
+		echo wp_kses_post( file_get_contents( dirname( __DIR__ ) . '/assets/amp.css' ) );
 	}
 
 	/**


### PR DESCRIPTION
Editora Abril's sites use Liveblog, version 1.9, and are no longer the AMP version suggested by Google for not being validated. This pull request corrects this impact.