### PR TITLE
Send the correct data to get_liveblog_metadata()

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -1850,7 +1850,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 				return;
 			}
 
-			$metadata = self::get_liveblog_metadata( array(), get_the_ID() );
+			$metadata = self::get_liveblog_metadata( array(), get_post() );
 			if ( empty( $metadata ) ) {
 				return;
 			}


### PR DESCRIPTION
Switched from `get_the_ID()` to `get_post()` in `WPCOM_Liveblog::print_liveblog_metadata()`.

`WPCOM_Liveblog::print_liveblog_metadata()` was sending a post ID to `WPCOM_Liveblog::get_liveblog_metadata()` instead of a post object causing a `Trying to get property 'ID' of non-object` error.

Fixes #557 