### PR TITLE
Add debounce to author list async box

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -1070,6 +1070,13 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 						'class_alert'                  => __( 'type-alert', 'liveblog' ),
 						'class_key'                    => __( 'type-key', 'liveblog' ),
 
+						/**
+						 * Filters the Author list debounce time, defaults to 500ms.
+						 *
+						 * @since 1.9.2
+						 *
+						 * @param int $time Author list debounce time.
+						 */
 						'author_list_debounce_time'    => apply_filters( 'liveblog_author_list_debounce_time', self::AUTHOR_LIST_DEBOUNCE_TIME ),
 					)
 				)

--- a/liveblog.php
+++ b/liveblog.php
@@ -47,6 +47,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		const RESPONSE_CACHE_MAX_AGE          = DAY_IN_SECONDS; // `Cache-Control: max-age` value for cacheable JSON responses
 		const USE_REST_API                    = true; // Use the REST API if current version is at least MIN_WP_REST_API_VERSION. Allows for easy disabling/enabling
 		const DEFAULT_IMAGE_SIZE              = 'full'; // The default image size to use when inserting media frm the media library.
+		const AUTHOR_LIST_DEBOUNCE_TIME       = 500; // This is the time ms to debounce the async author list.
 
 		/** Variables *************************************************************/
 
@@ -1068,6 +1069,8 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 						'class_term_prefix'            => __( 'term-', 'liveblog' ),
 						'class_alert'                  => __( 'type-alert', 'liveblog' ),
 						'class_key'                    => __( 'type-key', 'liveblog' ),
+
+						'author_list_debounce_time'    => apply_filters( 'liveblog_author_list_debounce_time', self::AUTHOR_LIST_DEBOUNCE_TIME ),
 					)
 				)
 			);

--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { Async } from 'react-select';
 import 'react-select/dist/react-select.css';
 import { html } from 'js-beautify';
+import { debounce } from 'lodash-es';
 
 import { EditorState, ContentState } from 'draft-js';
 
@@ -59,6 +60,8 @@ class EditorContainer extends Component {
       editorState,
       rawText: html(convertToHTML(editorState.getCurrentContent())),
     });
+
+    this.getUsers = debounce(this.getUsers.bind(this), props.config.author_list_debounce_time);
   }
 
   setReadOnly(state) {
@@ -292,7 +295,7 @@ class EditorContainer extends Component {
           labelKey="name"
           onChange={this.onSelectAuthorChange.bind(this)}
           optionComponent={AuthorSelectOption}
-          loadOptions={this.getUsers.bind(this)}
+          loadOptions={this.getUsers}
           clearable={false}
           cache={false}
         />


### PR DESCRIPTION
Added a debounce to the author list box on editor to resolve issue #417 - underscores is used for the debounce, in an ideal world we would use RxJS debounce but doesn't appear possible within React Select.

Debounce is set to 500ms but theres a filter to change that `liveblog_author_list_debounce_time`

Please note I did not include complied assets so merging is cleaner.