### PR TITLE
Fix encoding issues which affect shortcodes and hashtags

### DIFF
--- a/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php
@@ -39,6 +39,9 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Hashtags extends WPCOM_Liveblog_Entry_
 		// the generated hashtag class.
 		$this->class_prefix = apply_filters( 'liveblog_hashtag_class', $this->class_prefix );
 
+		// Set a better regex for hashtags to allow for hex values in content.
+		$this->set_regex( '~(?:(?<!\S)|>?)(?:(?<!&|&amp;))((?:' . implode( '|', $this->get_prefixes() ) . ')([0-9_\-\p{L}]*))~um' );
+
 		// This is the regex used to revert the
 		// generated hashtag html back to the
 		// raw input format (e.g #hashtag).

--- a/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php
@@ -39,8 +39,31 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Hashtags extends WPCOM_Liveblog_Entry_
 		// the generated hashtag class.
 		$this->class_prefix = apply_filters( 'liveblog_hashtag_class', $this->class_prefix );
 
-		// Set a better regex for hashtags to allow for hex values in content.
-		$this->set_regex( '~(?:(?<!\S)|>?)(?:(?<!&|&amp;))((?:' . implode( '|', $this->get_prefixes() ) . ')([0-9_\-\p{L}]*))~um' );
+		$prefixes = implode( '|', $this->get_prefixes() );
+
+		// Set a better regex for hashtags to allow for hex values in content -- see https://regex101.com/r/CLWsCo/
+		// phpcs:disable Squiz.Strings.ConcatenationSpacing.PaddingFound -- ignore indentation
+		$this->set_regex(
+			'~'
+			. '(?:'
+			.     '(?<!\S)'          // any visible character
+			. '|'
+			.     '>?'               // possible right angle bracket(s)
+			. ')'
+			. '(?:'
+			.     '(?<!'
+			.         '&'            // literal ampersand
+			.     '|'
+			.         '&amp;'        // encoded ampersand
+			.     ')'
+			. ')'
+			. '('
+			.     "(?:{$prefixes})"  // hashtag prefixes
+			.     '([0-9_\-\p{L}]*)' // 1: numerals, underscores, dashes, and any letter in any language
+			. ')'
+			. '~um'
+		);
+		// phpcs:enable
 
 		// This is the regex used to revert the
 		// generated hashtag html back to the

--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -651,7 +651,7 @@ class WPCOM_Liveblog_Rest_Api {
 	 */
 	public static function get_json_param( $param, $json ) {
 		if ( isset( $json[ $param ] ) ) {
-			return $json[ $param ];
+			return html_entity_decode( $json[ $param ] );
 		}
 		return false;
 	}


### PR DESCRIPTION
This PR resolves issues #560 and #418 

We now decode content when it hits the server using `html_entity_decode()` which fixes both shortcodes and hashtags. The hashtag regex has also been updated to handle any situation where hex code does find its way into the content.