### PR TITLE
don't fetch userdata unnecessarily

### DIFF
--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -452,7 +452,13 @@ class WPCOM_Liveblog_Entry {
 	}
 
 	public static function get_userdata_with_filter( $author_id ) {
-		return apply_filters( 'liveblog_userdata', get_userdata( $author_id ), $author_id );
+		if ( apply_filters( 'liveblog_fetch_userdata', true ) ) {
+			$userdata = get_userdata( $author_id );
+		} else {
+			$userdata = null;
+		}
+
+		return apply_filters( 'liveblog_userdata', $userdata, $author_id );
 	}
 
 	/**


### PR DESCRIPTION
If you use CoAuthors plus or similar, the results of `get_userdata()` will not be used. Disabling this call will save many database queries.

`add_filter( 'liveblog_fetch_userdata', '__return_false' );`