### PR TITLE
don't fetch avatar data when not needed

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -297,7 +297,13 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		 * @return HTML for avatar
 		 */
 		public static function get_avatar( $user_id, $size ) {
-			return apply_filters( 'liveblog_author_avatar', get_avatar( $user_id, $size ), $user_id, $size );
+			if ( apply_filters( 'liveblog_fetch_avatar_data', true ) ) {
+				$avatar_data = get_avatar( $user_id, $size );
+			} else {
+				$avatar_data = null;
+			}
+
+			return apply_filters( 'liveblog_author_avatar', $avatar_data, $user_id, $size );
 		}
 
 		/**


### PR DESCRIPTION
Related to #598. If you use CoAuthors plus or similar, the results of get_avatar() will not be used. Disabling this call will save many database queries.

`add_filter( 'liveblog_fetch_avatar_data', '__return_false' );`