### PR TITLE
Pass post object, not just the ID.

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -1869,7 +1869,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 				return;
 			}
 
-			$metadata = self::get_liveblog_metadata( array(), get_the_ID() );
+			$metadata = self::get_liveblog_metadata( array(), get_post( get_the_ID() ) );
 			if ( empty( $metadata ) ) {
 				return;
 			}


### PR DESCRIPTION
Fixes a PHP Notice caused by `get_liveblog_metadat()` expecting a full post object but only receiving a post ID.

> Notice: Trying to get property 'ID' of non-object in /wp-content/plugins/liveblog/liveblog.php on line 1809