### PR TITLE
Fix PHP 7.3 Warning of continue statements targeting switch control flow structures

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -910,8 +910,6 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 					case 'delete':
 						unset( $flatten[ $id ] );
 						break;
-					default:
-						continue;
 				}
 			}
 


### PR DESCRIPTION
Fixes #616.