### PR TITLE
Clean comment cache after direct SQL queries.

### DIFF
--- a/classes/class-wpcom-liveblog-wp-cli.php
+++ b/classes/class-wpcom-liveblog-wp-cli.php
@@ -110,6 +110,7 @@ class WPCOM_Liveblog_WP_CLI extends WP_CLI_Command {
 										),
 										array( 'comment_id' => $entry_id )
 									);
+									update_meta_cache( 'comment', array( $entry_id ) );
 								}
 							}
 						}
@@ -162,6 +163,7 @@ class WPCOM_Liveblog_WP_CLI extends WP_CLI_Command {
 							array( 'comment_content' => $content ),
 							array( 'comment_id' => $entry_replace->meta_value )
 						);
+						clean_comment_cache( $entry_replace->meta_value );
 					}
 
 					//Lets update the user with what we are doing.


### PR DESCRIPTION
As of WordPress 4.6, the `comment` cache group is persistent. Thus, after any direct SQL query which `INSERT`s, `UPDATE`s, or `DELETE`s data in comments table, the `clean_comment_cache` function should be called, in order to make the changes immediatelly visible in case a persistent object cache backend (memcache, redis...) is used.

This commit also calls the `update_meta_cache` function after direct SQL edits to `commentmeta` table.

see https://make.wordpress.org/core/2016/07/18/comments-in-4-6-can-now-be-cached-by-a-persistent-object-cache/

Fixes #657