### PR TITLE
Avoid namespace collision with multi-webpack runtimes

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,6 +21,7 @@ const webpackConfig = {
     path: path.join(__dirname, paths.out),
     filename: '[name].js',
     chunkFilename: '[name].bundle.js',
+    jsonpFunction: 'wpJsonpLiveBlog',
   },
 
   module: {


### PR DESCRIPTION
> If multiple webpack runtimes (from different compilations) are used on the same webpage, there is a risk of conflicts of on-demand chunks in the global namespace.

See: https://webpack.js.org/configuration/output/#outputjsonpfunction

When a conflict occurs, it causes a fatal JS error. I have experienced this behavior when a site bundle and Liveblog bundle are loaded on the same page.

According to Webpack documentation, changing `output.jsonpFunction` to a custom name will avoid the collision. 