### PR TITLE
Add jsonpFunction to prevent a conflict

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,6 +18,7 @@ const webpackConfig = {
   },
 
   output: {
+    jsonpFunction: 'liveblogJsonp',
     path: path.join(__dirname, paths.out),
     filename: '[name].js',
     chunkFilename: '[name].bundle.js',


### PR DESCRIPTION
**Problem:**
When loading the plugin with other webpack installations active, a Javascript conflict arises and throws a fatal console error. The live blog fails to load on the page.

**Solution:**
Adds a `jsonpFunction` option to the webpack output to prevent a conflict with other webpack installations (brings liveblog into its own little webpack bubble).