### PR TITLE
REST API routes require a permission_callback

### DIFF
--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -79,6 +79,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => true,
 					),
 				),
+				'permission_callback'  => '__return_true',
 			)
 		);
 
@@ -139,6 +140,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => true,
 					),
 				),
+				'permission_callback'  => '__return_true',
 			)
 		);
 
@@ -162,6 +164,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => true,
 					),
 				),
+				'permission_callback'  => '__return_true',
 			)
 		);
 
@@ -182,6 +185,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => true,
 					),
 				),
+				'permission_callback'  => '__return_true',
 			)
 		);
 
@@ -206,6 +210,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => false,
 					),
 				),
+				'permission_callback'  => '__return_true',
 			)
 		);
 
@@ -230,6 +235,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => false,
 					),
 				),
+				'permission_callback'  => '__return_true',
 			)
 		);
 
@@ -289,6 +295,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => true,
 					),
 				),
+				'permission_callback'  => '__return_true',
 			)
 		);
 
@@ -309,6 +316,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => true,
 					),
 				),
+				'permission_callback'  => '__return_true',
 			)
 		);
 
@@ -335,6 +343,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => true,
 					),
 				),
+				'permission_callback'  => '__return_true',
 			)
 		);
 


### PR DESCRIPTION
WordPress 5.5+ throws a doing_it_wrong notice when a route is registered without a permission_callback.

https://make.wordpress.org/core/2020/07/22/rest-api-changes-in-wordpress-5-5/

Since these endpoints are intended to be public, the `__return_true` callback can be used.