### PR TITLE
Load CPT support later to avoid fatals with early use of WP_Query

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -174,7 +174,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue_scripts' ) );
 			add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_enqueue_scripts' ) );
 			add_action( 'wp_ajax_set_liveblog_state_for_post', array( __CLASS__, 'admin_ajax_set_liveblog_state_for_post' ) );
-			add_action( 'pre_get_posts', array( __CLASS__, 'add_custom_post_type_support' ) );
+			add_action( 'after_setup_theme', array( __CLASS__, 'add_custom_post_type_support' ) );
 			add_action( 'wp_head', array( __CLASS__, 'print_liveblog_metadata' ) );
 		}
 


### PR DESCRIPTION
In essence, and as discussed way back in 2014 but [thought to be a core bug](https://github.com/Automattic/liveblog/pull/123#issuecomment-32673846), the error in #219 happens whenever another plugin uses `WP_Query` before the main query is created. As @kevinlisota quite [correctly pointed out](https://github.com/Automattic/liveblog/issues/219#issuecomment-198998787) this causes Liveblog's `add_custom_post_type_support()` to be invoked, leading to the `get_query_var()` call that ultimately results in a Fatal Error.

It seemed a little strange to me that `pre_get_posts` was the hook used for adding CPT support so I chose to move it to `after_setup_theme` and in my testing, Liveblog behaved exactly as expected.

Fixes #219 