### PR TITLE
FIX: Liveblog scheduled cron event auto_archive_check_hook does not get run

### DIFF
--- a/classes/class-wpcom-liveblog-cron.php
+++ b/classes/class-wpcom-liveblog-cron.php
@@ -24,7 +24,7 @@ class WPCOM_Liveblog_Cron {
 	private static function configure_autoarchive_cron() {
 
 		if ( ! wp_next_scheduled( 'auto_archive_check_hook' ) ) {
-			wp_schedule_event( strtotime( 'today midnight' ), 'daily', 'auto_archive_check_hook' );
+			wp_schedule_event( strtotime( 'tomorrow midnight' ), 'daily', 'auto_archive_check_hook' );
 		}
 
 		add_action( 'auto_archive_check_hook', array( __CLASS__, 'execute_auto_archive_housekeeping' ) );


### PR DESCRIPTION
There will not have any impact on the application, but It schedules the event for the previous midnight. 

This fix will change the schedule to one of the future dates from today midnight to tomorrow.