### PR TITLE
Fix the unathenticated vulnerability for ajax/rest endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 ## 1.9.7
-* Add a capability check to the preview endpoint, to prevent unauthenticated users from accessing it
+* Adds a capability check to the preview, authors and hashtag endpoint to prevent unauthenticated calls (#685)
 
 ## 1.9.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.9.7
+* Add a capability check to the preview endpoint, to prevent unauthenticated users from accessing it
+
 ## 1.9.6
 
 * Revert #597, restoring `get_fields_for_render()` that is being used in some implementations (#639)

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 * Requires at least: 4.4
 * Requires PHP: 5.6
 * Tested up to: 4.9.8
-* Stable tag: 1.9.6
+* Stable tag: 1.9.7
 * License: GPLv2 or later
 * License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -211,7 +211,6 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => false,
 					),
 				),
-				'permission_callback'  => '__return_true',
 			)
 		);
 
@@ -237,7 +236,6 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => false,
 					),
 				),
-				'permission_callback'  => '__return_true',
 			)
 		);
 

--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -180,12 +180,12 @@ class WPCOM_Liveblog_Rest_Api {
 			array(
 				'methods'  => WP_REST_Server::CREATABLE,
 				'callback' => array( __CLASS__, 'format_preview_entry' ),
+				'permission_callback' => array( 'WPCOM_Liveblog', 'current_user_can_edit_liveblog' ),
 				'args'     => array(
 					'entry_content' => array(
 						'required' => true,
 					),
 				),
-				'permission_callback'  => '__return_true',
 			)
 		);
 

--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -205,6 +205,7 @@ class WPCOM_Liveblog_Rest_Api {
 			array(
 				'methods'  => WP_REST_Server::READABLE,
 				'callback' => array( __CLASS__, 'get_authors' ),
+				'permission_callback' => array( 'WPCOM_Liveblog', 'current_user_can_edit_liveblog' ),
 				'args'     => array(
 					'term' => array(
 						'required' => false,
@@ -230,6 +231,7 @@ class WPCOM_Liveblog_Rest_Api {
 			array(
 				'methods'  => WP_REST_Server::READABLE,
 				'callback' => array( __CLASS__, 'get_hashtag_terms' ),
+				'permission_callback' => array( 'WPCOM_Liveblog', 'current_user_can_edit_liveblog' ),
 				'args'     => array(
 					'term' => array(
 						'required' => false,

--- a/liveblog.php
+++ b/liveblog.php
@@ -4,7 +4,7 @@
  * Plugin Name: Liveblog
  * Plugin URI: http://wordpress.org/extend/plugins/liveblog/
  * Description: Empowers website owners to provide rich and engaging live event coverage to a large, distributed audience.
- * Version:     1.9.6
+ * Version:     1.9.7
  * Author:      WordPress.com VIP, Big Bite Creative and contributors
  * Author URI: https://github.com/Automattic/liveblog/graphs/contributors
  * Text Domain: liveblog
@@ -26,7 +26,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 	final class WPCOM_Liveblog {
 
 		/** Constants *************************************************************/
-		const VERSION                 = '1.9.6';
+		const VERSION                 = '1.9.7';
 		const REWRITES_VERSION        = 1;
 		const MIN_WP_VERSION          = '4.4';
 		const MIN_WP_REST_API_VERSION = '4.4';

--- a/liveblog.php
+++ b/liveblog.php
@@ -917,6 +917,8 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		}
 
 		public static function ajax_preview_entry() {
+			self::ajax_current_user_can_edit_liveblog();
+
 			$entry_content = isset( $_REQUEST['entry_content'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['entry_content'] ) ) : ''; // input var ok
 			$entry_content = self::format_preview_entry( $entry_content );
 

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: liveblog
 Requires at least: 4.4
 Requires PHP: 5.6
 Tested up to: 5.8
-Stable tag: 1.9.6
+Stable tag: 1.9.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
**Description**

This PR has been made to a capability check to the preview ajax/rest endpoints, and the get author/hashtag rest endpoints so as to prevent unauthenticated calls from being made. This leverages the existing method already being used for various other endpoints.