### PR TITLE
Fix: string interpolation issue on the `WPCOM_Liveblog_Entry_Extend_Feature_Commands` class

### DIFF
--- a/classes/class-wpcom-liveblog-entry-extend-feature-commands.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-commands.php
@@ -240,7 +240,7 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Commands extends WPCOM_Liveblog_Entry_
 
 			// Run the command_after action on the
 			// content for the current type.
-			do_action( "liveblog_command_${type}_after", $content, $id, $post_id );
+			do_action( "liveblog_command_{$type}_after", $content, $id, $post_id );
 		}
 	}
 


### PR DESCRIPTION
I noticed this while testing a client site with PHP 8.2

```
PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /var/www/site/wp-content/plugins/liveblog/classes/class-wpcom-liveblog-entry-extend-feature-commands.php on line 243
```

This is usually harmless, but we use `convertDeprecationsToExceptions=true` in our unit tests, which essentially fails because of this PHP deprecation.

The fix works for any PHP version, so it should be safe for a minor version bump. :)
