### PR TITLE
Standardize .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@ insert_final_newline = true
 trim_trailing_whitespace = true
 indent_style = tab
 
-[{*.yml,*.feature}]
+[*.yml]
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
## Summary

Standardizes the `.editorconfig` file to align with the configuration used across other plugins.

## Why

This ensures consistent editor configuration across all plugins, matching WordPress core standards and simplifying maintenance.

## Testing

No functional changes - this only updates editor configuration.