### PR TITLE
Raise minimum PHP requirement to 7.4

### DIFF
--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -13,10 +13,7 @@ on:
 jobs:
   test:
     name: WP ${{ matrix.wordpress }} on PHP ${{ matrix.php }}
-    # Ubuntu-20.x includes MySQL 8.0, which causes `caching_sha2_password` issues with PHP < 7.4
-    # https://www.php.net/manual/en/mysqli.requirements.php
-    # TODO: change to ubuntu-latest when we no longer support PHP < 7.4
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     env:
       WP_VERSION: ${{ matrix.wordpress }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,10 +13,7 @@ on:
 jobs:
   lint:
     name: Run JS linting
-    # Ubuntu-20.x includes MySQL 8.0, which causes `caching_sha2_password` issues with PHP < 7.4
-    # https://www.php.net/manual/en/mysqli.requirements.php
-    # TODO: change to ubuntu-latest when we no longer support PHP < 7.4
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -32,7 +32,7 @@
 	<rule ref="PHPCompatibilityWP"/>
 	<!-- For help in understanding this testVersion:
 		https://github.com/PHPCompatibility/PHPCompatibility#sniffing-your-code-for-compatibility-with-specific-php-versions -->
-	<config name="testVersion" value="5.6-"/>
+	<config name="testVersion" value="7.4-"/>
 
 	<!-- Rules: WordPress Coding Standards - see
 		https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards -->

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
 		"source": "https://github.com/Automattic/liveblog"
 	},
 	"require": {
-		"php": ">=5.6",
+		"php": ">=7.4",
 		"composer/installers": "^1.0 || ^2.0"
 	},
 	"require-dev": {

--- a/liveblog.php
+++ b/liveblog.php
@@ -6,7 +6,7 @@
  * Description: Empowers website owners to provide rich and engaging live event coverage to a large, distributed audience.
  * Version:     1.9.7
  * Requires at least: 6.4
- * Requires PHP: 5.6
+ * Requires PHP: 7.4
  * Author:      WordPress.com VIP, Big Bite Creative and contributors
  * Author URI: https://github.com/Automattic/liveblog/graphs/contributors
  * Text Domain: liveblog


### PR DESCRIPTION
## Why This Change

The liveblog plugin has declared support for PHP 5.6 since 2018, despite that version reaching end-of-life and ceasing security updates the same year. This creates a false promise to users: we suggest they can safely run liveblog on PHP 5.6, but doing so exposes them to unpatched security vulnerabilities in their PHP runtime.

More practically, we already require WordPress 6.4, which itself demands PHP 7.4. The current configuration cannot actually be installed on PHP 5.6, making our declared minimum version misleading. This change corrects that mismatch and acknowledges the constraint we already impose.

Beyond compliance, raising the minimum PHP version provides tangible benefits for liveblog users. PHP 7.4 delivers 2-3x performance improvements over 5.6 and uses memory more efficiently. For a plugin focused on real-time content delivery—where server response time directly affects how quickly readers see live updates—these performance gains translate into measurably better user experiences during high-traffic live events.

## What Changed

This updates the required PHP version to 7.4 across all relevant declarations: the plugin header in liveblog.php, the composer.json constraints, and the PHPCS test version configuration. It also removes the Ubuntu 18.04 pinning from CI workflows, which was explicitly maintained only to support MySQL compatibility with older PHP versions—a constraint that no longer applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)