### PR TITLE
fix: add type check before is_dir() to prevent PHP 8.1+ deprecation warning

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -338,7 +338,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			self::$post_id = get_the_ID();
 
 			self::$custom_template_path = apply_filters( 'liveblog_template_path', self::$custom_template_path, self::$post_id );
-			if ( ! is_dir( self::$custom_template_path ) ) {
+			if ( ! is_string( self::$custom_template_path ) || ! is_dir( self::$custom_template_path ) ) {
 				self::$custom_template_path = null;
 			} else {
 				// realpath is used here to ensure we have an absolute path which is necessary to avoid APC related bugs


### PR DESCRIPTION
## Problem

PHP 8.1 introduced stricter type requirements for filesystem functions, causing deprecation warnings when null or non-string values are passed to `is_dir()`. The Liveblog plugin was triggering this warning because `$custom_template_path` is initialised as null and can potentially receive non-string values through the `liveblog_template_path` filter hook. This resulted in deprecation notices polluting logs and error output:

```
Deprecated: is_dir(): Passing null to parameter #1 ($filename) of type string is deprecated in /var/www/html/wp-content/plugins/liveblog/liveblog.php on line 341
```

Whilst the existing logic correctly reset invalid paths to null, it attempted to validate the path before performing this type check, causing the deprecation warning to fire on every request where the custom template path remained unset or was filtered to a non-string value.

## Solution

This change adds a type guard before the `is_dir()` call, checking that `$custom_template_path` is a string before attempting to validate it as a directory path. The logic now short-circuits when the value is null or any non-string type, immediately setting the property to null without triggering the deprecation warning. This maintains backward compatibility whilst ensuring the code adheres to PHP 8.1+ type expectations.

The fix is minimal and surgical, affecting only the specific line that caused the warning without altering the overall behaviour or logic flow of the template path resolution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)