### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+# Configuration for Dependabot version updates
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    groups:
+      actions:
+        patterns: ["*"]
+    labels:
+      - "dependencies"
+      - "github-actions"
+    assignees:
+      - "Automattic/vip-plugins"
+    commit-message:
+      prefix: "Actions"
+      include: "scope"
+    open-pull-requests-limit: 5
+
+  # Maintain dependencies for Composer
+  - package-ecosystem: "composer"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "automattic/*"
+          - "dealerdirect/*"
+          - "php-parallel-lint/*"
+          - "phpcompatibility/*"
+          - "phpunit/*"
+          - "squizlabs/*"
+          - "yoast/*"
+    labels:
+      - "dependencies"
+    assignees:
+      - "Automattic/vip-plugins"
+    commit-message:
+      prefix: "Composer"
+      include: "scope"
+    open-pull-requests-limit: 5
+    versioning-strategy: increase-if-necessary
+
+  # Maintain dependencies for npm
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "wednesday"
+    groups:
+      dev-dependencies:
+        patterns:
+          - "@wordpress/*"
+          - "eslint*"
+          - "prettier*"
+          - "@types/*"
+    labels:
+      - "dependencies"
+      - "npm"
+    assignees:
+      - "Automattic/vip-plugins"
+    commit-message:
+      prefix: "npm"
+      include: "scope"
+    open-pull-requests-limit: 5


### PR DESCRIPTION
## Summary
This PR adds Dependabot configuration to automate dependency updates for the liveblog repository.

## Configuration Details

The Dependabot configuration (`/.github/dependabot.yml`) sets up automated dependency updates for three package ecosystems:

### GitHub Actions
- **Schedule**: Weekly on Mondays
- **Grouping**: All actions grouped together
- **Labels**: `dependencies`, `github-actions`
- **Commit prefix**: `Actions`

### Composer Packages
- **Schedule**: Weekly on Tuesdays
- **Grouping**: Dev dependencies from common vendors (Automattic, PHPUnit, Squizlabs, Yoast, etc.)
- **Labels**: `dependencies`
- **Commit prefix**: `Composer`
- **Versioning strategy**: `increase-if-necessary` (only updates when required)

### npm Packages
- **Schedule**: Weekly on Wednesdays
- **Grouping**: Dev dependencies including WordPress packages, ESLint, Prettier, and TypeScript types
- **Labels**: `dependencies`, `npm`
- **Commit prefix**: `npm`

## Common Settings
- All updates are assigned to `@Automattic/vip-plugins` team
- Maximum of 5 open PRs per ecosystem to avoid overwhelming the team
- Updates run on different days to spread the review workload

## Benefits
- Automated security updates for dependencies
- Consistent update schedule across all ecosystems
- Grouped updates reduce PR noise
- Team assignment ensures proper review workflow
- Commit message prefixes make it easy to identify update types

🤖 Generated with [Claude Code](https://claude.com/claude-code)