### PR TITLE
Remove editor-specific entries from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,10 +7,3 @@ composer.lock
 vendor/
 .phpunit.cache/
 
-# Editor directories and files
-.idea
-*.suo
-*.ntvs*
-*.njsproj
-*.sln
-


### PR DESCRIPTION
## Summary

Removes editor and IDE-specific entries from `.gitignore`.

## Why

Editor-specific files (.idea, *.suo, Visual Studio files) should be handled by developers' global gitignore configuration rather than being specified in each project.

## Testing

No functional changes - this only updates the gitignore file.