### PR TITLE
Fix Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,7 @@ updates:
         patterns: ["*"]
     labels:
       - "dependencies"
-      - "github-actions"
-    assignees:
+    reviewers:
       - "Automattic/vip-plugins"
     commit-message:
       prefix: "Actions"
@@ -40,7 +39,7 @@ updates:
           - "yoast/*"
     labels:
       - "dependencies"
-    assignees:
+    reviewers:
       - "Automattic/vip-plugins"
     commit-message:
       prefix: "Composer"
@@ -63,8 +62,7 @@ updates:
           - "@types/*"
     labels:
       - "dependencies"
-      - "npm"
-    assignees:
+    reviewers:
       - "Automattic/vip-plugins"
     commit-message:
       prefix: "npm"


### PR DESCRIPTION
## Summary

Fixes two issues with the Dependabot configuration:

1. **Change `assignees` to `reviewers`** - Dependabot only accepts individual usernames for `assignees`, but supports team names for `reviewers`. This allows the `@Automattic/vip-plugins` team to be properly notified.

2. **Simplify labels** - Removes ecosystem-specific labels (`github-actions`, `npm`) and uses only `dependencies` for all update types.

## Changes

- ✅ Replace `assignees` with `reviewers` for all ecosystems
- ✅ Remove `github-actions` label from GitHub Actions updates  
- ✅ Remove `npm` label from npm updates
- ✅ Keep consistent `dependencies` label across all ecosystems

## Why

The original configuration in PR #720 had these issues which prevented proper team notifications and created unnecessary label complexity.

## Testing

Dependabot will validate the configuration automatically when merged.