### PR TITLE
ci: pin GitHub Actions to SHAs and ignore React 19 updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,12 @@ updates:
           - "eslint*"
           - "prettier*"
           - "@types/*"
+    ignore:
+      # React 19 not yet supported by @wordpress/scripts
+      - dependency-name: "react"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-dom"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
     reviewers:

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: "7.4"
           coverage: none
@@ -29,15 +29,15 @@ jobs:
       # Show PHP lint violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
       - name: Register PHP lint violations to appear as file diff comments
-        uses: korelstar/phplint-problem-matcher@v1
+        uses: korelstar/phplint-problem-matcher@cb2b753750ec7bf13a7cde0a476df8c5605bdfb1 # v1.2.0
 
       # Show XML violations inline in the file diff.
       # @link https://github.com/marketplace/actions/xmllint-problem-matcher
       - name: Register XML violations to appear as file diff comments
-        uses: korelstar/xmllint-problem-matcher@v1
+        uses: korelstar/xmllint-problem-matcher@1bd292d642ddf3d369d02aaa8b262834d61198c0 # v1.2.0
 
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       # Validate the composer.json file.
       # @link https://getcomposer.org/doc/03-cli.md#validate
@@ -47,7 +47,7 @@ jobs:
       # Install dependencies and handle caching in one go.
       # @link https://github.com/marketplace/actions/install-composer-dependencies
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
 
       # Lint PHP.
       - name: Lint PHP against parse errors
@@ -56,7 +56,7 @@ jobs:
       # Needed as runs-on: system doesn't have xml-lint by default.
       # @link https://github.com/marketplace/actions/xml-lint
       - name: Lint phpunit.xml.dist
-        uses: ChristophWurst/xmllint-action@v1
+        uses: ChristophWurst/xmllint-action@7c54ff113fc0f6d4588a15cb4dfe31b6ecca5212 # v1.2.1
         with:
           xml-file: ./phpunit.xml.dist
           xml-schema-file: ./vendor/phpunit/phpunit/phpunit.xsd

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install SVN (Subversion)
         run: |
@@ -22,7 +22,7 @@ jobs:
           npm install
           npm run build
       - name: Push to WordPress.org
-        uses: 10up/action-wordpress-plugin-deploy@stable
+        uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # 2.3.0
         env:
           SLUG: liveblog
           SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}

--- a/.github/workflows/integrations.yml
+++ b/.github/workflows/integrations.yml
@@ -31,13 +31,13 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install wordpress environment
         run: npm install -g @wordpress/env
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1 # 2.36.0
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ matrix.extensions }}
@@ -52,7 +52,7 @@ jobs:
         run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
 
       - name: Install Composer dependencies
-        uses: ramsey/composer-install@v3
+        uses: ramsey/composer-install@3cf229dc2919194e9e36783941438d17239e8520 # 3.1.1
         with:
           composer-options: "${{ matrix.composer-options }}"
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@1af3b93b6815bc44a9784bd300feb67ff0d1eeb3 # v6.0.0
 
       - name: Install node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: "20"
 


### PR DESCRIPTION
## Problem

GitHub Actions referenced by branch names or tags can be modified after workflows are created, presenting a potential security risk. Additionally, Dependabot has been attempting to update React and React-DOM to version 19, which is not yet supported by @wordpress/scripts, causing compatibility issues.

## Solution

This change addresses both concerns by pinning all GitHub Actions to specific commit SHAs and configuring Dependabot to ignore major version updates for React packages.

The workflow files now reference exact commits for all actions:
- actions/checkout@v6.0.0
- actions/setup-node@v6.0.0  
- shivammathur/setup-php@2.36.0
- ramsey/composer-install@3.1.1
- korelstar/phplint-problem-matcher@v1.2.0
- korelstar/xmllint-problem-matcher@v1.2.0
- ChristophWurst/xmllint-action@v1.2.1
- 10up/action-wordpress-plugin-deploy@2.3.0 (changed from @stable tag)

The Dependabot configuration now explicitly ignores semver-major updates for react and react-dom, preventing automatic PRs for React 19 until @wordpress/scripts adds support.