### PR TITLE
refactor: migrate sass-mq to @use syntax for v7 compatibility

### DIFF
--- a/src/styles/amp.scss
+++ b/src/styles/amp.scss
@@ -1,9 +1,9 @@
 @use "sass:color";
+@use "core/utils/mq";
 
 // Utils
 @import "core/utils/defaults";
 @import "core/utils/colors";
-@import "~sass-mq/mq";
 // Core Styles
 @import "core/utils/animations";
 @import "core/app/all";
@@ -20,7 +20,7 @@
 	padding: 1em;
 	font-family: "Libre Franklin", "Helvetica Neue", helvetica, arial, sans-serif;
 
-	@include mq($until: medium) {
+	@include mq.mq($until: medium) {
 		font-size: 14px;
 	}
 }
@@ -45,7 +45,7 @@
 .liveblog-entry-edit {
 	margin-left: 60px;
 
-	@include mq($until: medium) {
+	@include mq.mq($until: medium) {
 		margin-left: 0;
 	}
 }
@@ -102,7 +102,7 @@
 .liveblog-entry-tools {
 	margin-left: 60px;
 
-	@include mq($until: medium) {
+	@include mq.mq($until: medium) {
 		margin-left: 0;
 	}
 }

--- a/src/styles/core.scss
+++ b/src/styles/core.scss
@@ -1,7 +1,7 @@
 // Utils
+@use "core/utils/mq";
 @import "core/utils/defaults";
 @import "core/utils/colors";
-@import "~sass-mq/mq";
 // Core Styles
 @import "core/utils/animations";
 @import "core/app/all";

--- a/src/styles/core/app/_events.scss
+++ b/src/styles/core/app/_events.scss
@@ -1,3 +1,5 @@
+@use "../utils/mq";
+
 .liveblog-key-events {
 	position: relative;
 	overflow-y: visible;
@@ -19,7 +21,7 @@
 		margin-bottom: 10px;
 	}
 
-	@include mq($until: medium) {
+	@include mq.mq($until: medium) {
 		min-height: 130px;
 		max-width: 300px;
 	}

--- a/src/styles/core/editor/_block.scss
+++ b/src/styles/core/editor/_block.scss
@@ -1,4 +1,5 @@
 @use "sass:color";
+@use "../utils/mq";
 
 .liveblog-block {
 	position: relative;
@@ -45,7 +46,7 @@
 	padding: 0.4rem;
 	border-bottom: $base-border-size solid color.adjust($color-grey-x-light, $lightness: -5%);
 
-	@include mq($until: large) {
+	@include mq.mq($until: large) {
 		text-align: center;
 		flex-wrap: wrap;
 	}
@@ -53,7 +54,7 @@
 
 .liveblog-block-header > * {
 
-	@include mq($until: large) {
+	@include mq.mq($until: large) {
 		flex-basis: 100;
 	}
 }
@@ -68,7 +69,7 @@
 	flex-grow: 1;
 	font-size: 14px;
 
-	@include mq($until: x-small) {
+	@include mq.mq($until: x-small) {
 		flex-wrap: wrap;
 		justify-content: center;
 	}

--- a/src/styles/core/editor/_buttons.scss
+++ b/src/styles/core/editor/_buttons.scss
@@ -1,4 +1,5 @@
 @use "sass:color";
+@use "../utils/mq";
 
 .liveblog-editor-btn {
 	-webkit-appearance: none;
@@ -41,7 +42,7 @@
 	align-items: center;
 	flex-grow: 1;
 
-	@include mq($until: x-small) {
+	@include mq.mq($until: x-small) {
 		justify-content: center;
 		margin-top: 0.25rem;
 	}
@@ -117,7 +118,7 @@
 	margin-right: 0.35rem;
 }
 
-@include mq($until: small) {
+@include mq.mq($until: small) {
 
 	.liveblog-image-upload-btn-text {
 		display: none;

--- a/src/styles/core/editor/_container.scss
+++ b/src/styles/core/editor/_container.scss
@@ -1,10 +1,12 @@
+@use "../utils/mq";
+
 .liveblog-editor-container {
 	padding: 0.8rem;
 	margin-bottom: 0.8rem;
 	background: $color-grey-mid-light;
 	border-top: 2px solid $color-grey-x-dark;
 
-	@include mq($until: x-small) {
+	@include mq.mq($until: x-small) {
 		padding: 0.8rem 0 0 0;
 		background: transparent;
 	}
@@ -66,7 +68,7 @@
 	margin-bottom: 0.6rem;
 }
 
-@include mq($until: small) {
+@include mq.mq($until: small) {
 
 	.liveblog-editor-container .public-DraftEditor-content {
 		margin-bottom: 0;

--- a/src/styles/core/editor/_input.scss
+++ b/src/styles/core/editor/_input.scss
@@ -1,4 +1,5 @@
 @use "sass:color";
+@use "../utils/mq";
 
 .liveblog-editor-input-container {
 	position: absolute;
@@ -14,7 +15,7 @@
 	border-radius: $base-border-radius;
 	box-shadow: $base-drop-shadow;
 
-	@include mq($until: small) {
+	@include mq.mq($until: small) {
 		left: -160px;
 	}
 }
@@ -31,7 +32,7 @@
 	border-left: 10px solid transparent;
 	transform: rotate(-45deg);
 
-	@include mq($until: small) {
+	@include mq.mq($until: small) {
 		left: 67%;
 	}
 }

--- a/src/styles/core/editor/_media.scss
+++ b/src/styles/core/editor/_media.scss
@@ -1,4 +1,5 @@
 @use "sass:color";
+@use "../utils/mq";
 
 .liveblog-media-search-container {
 	display: flex;
@@ -40,11 +41,11 @@
 	cursor: pointer;
 	box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.1);
 
-	@include mq($until: medium) {
+	@include mq.mq($until: medium) {
 		flex-basis: 31%;
 	}
 
-	@include mq($until: small) {
+	@include mq.mq($until: small) {
 		flex-basis: 48%;
 	}
 }

--- a/src/styles/core/editor/_tabs.scss
+++ b/src/styles/core/editor/_tabs.scss
@@ -1,3 +1,5 @@
+@use "../utils/mq";
+
 .liveblog-editor-tabs {
 	display: flex;
 	justify-content: flex-end;
@@ -44,7 +46,7 @@
 	margin-right: 0.25rem;
 }
 
-@include mq($until: small) {
+@include mq.mq($until: small) {
 
 	.liveblog-editor-tab:first-child.is-active {
 		background: #fff;

--- a/src/styles/core/editor/_toolbar.scss
+++ b/src/styles/core/editor/_toolbar.scss
@@ -1,3 +1,5 @@
+@use "../utils/mq";
+
 .liveblog-toolbar {
 	background: $color-grey-x-light;
 	border: $base-border-size solid $color-grey-light;
@@ -5,7 +7,7 @@
 	line-height: 0;
 }
 
-@include mq($until: small) {
+@include mq.mq($until: small) {
 
 	.liveblog-editor-toolbar-container {
 		order: 2;

--- a/src/styles/core/utils/_defaults.scss
+++ b/src/styles/core/utils/_defaults.scss
@@ -1,14 +1,3 @@
 $base-border-size: 1px;
 $base-border-radius: 3px;
 $base-drop-shadow: 0 2px 6px 0 rgba(0, 0, 0, 0.25);
-
-$mq-breakpoints: (
-	xx-small: 320px,
-	x-small:  540px,
-	small:    760px,
-	medium:   940px,
-	large:    1024px,
-	x-large:  1280px,
-	xx-large: 1400px
-);
-

--- a/src/styles/core/utils/_mq.scss
+++ b/src/styles/core/utils/_mq.scss
@@ -1,0 +1,11 @@
+@forward "sass-mq" with (
+	$breakpoints: (
+		xx-small: 320px,
+		x-small:  540px,
+		small:    760px,
+		medium:   940px,
+		large:    1024px,
+		x-large:  1280px,
+		xx-large: 1400px
+	)
+);

--- a/src/styles/theme.scss
+++ b/src/styles/theme.scss
@@ -1,7 +1,7 @@
 // Utils
+@use "core/utils/mq";
 @import "core/utils/defaults";
 @import "core/utils/colors";
-@import "~sass-mq/mq";
 
 /**
 * Entries
@@ -19,7 +19,7 @@
 .liveblog-entry-edit {
 	margin-left: 60px;
 
-	@include mq($until: medium) {
+	@include mq.mq($until: medium) {
 		margin-left: 0;
 	}
 }
@@ -63,7 +63,7 @@
 .liveblog-entry-tools {
 	margin-left: 60px;
 
-	@include mq($until: medium) {
+	@include mq.mq($until: medium) {
 		margin-left: 0;
 	}
 }


### PR DESCRIPTION
## Summary

Migrate sass-mq from `@import` to `@use` syntax to prepare for sass-mq v7.0.0.

sass-mq v7 drops support for `@import` in favor of `@use`, as `@import` is deprecated in Dart Sass 1.80.0+.

## Changes

- Create `src/styles/core/utils/_mq.scss` that `@forward`s sass-mq with breakpoint configuration
- Update entry files (core.scss, theme.scss, amp.scss) to `@use` the new mq module
- Update all partials using the mq mixin to `@use "../utils/mq"` and change `@include mq()` to `@include mq.mq()`
- Move breakpoint configuration from `_defaults.scss` to `_mq.scss`

## Test plan

- [x] Build completes successfully (`npm run build`)
- [x] CSS linting passes (`npm run lint:css`)
- [ ] Visual inspection of styles in browser

## Related

This PR prepares the codebase for merging Dependabot PR #726 (sass-mq 6.0.0 → 7.0.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)