### PR TITLE
chore: add dependabot ignore rules for blocked major upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -62,6 +62,16 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "react-dom"
         update-types: ["version-update:semver-major"]
+      # Redux ecosystem must be upgraded together, blocked by redux-observable stable release (see #753)
+      - dependency-name: "redux"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "react-redux"
+        update-types: ["version-update:semver-major"]
+      - dependency-name: "redux-observable"
+        update-types: ["version-update:semver-major"]
+      # Draft.js ecosystem locked to immutable v3 (see #751)
+      - dependency-name: "immutable"
+        update-types: ["version-update:semver-major"]
     labels:
       - "dependencies"
     commit-message:


### PR DESCRIPTION
## Summary

Add Dependabot ignore rules for packages that require coordinated upgrades or have blocking dependencies. This prevents Dependabot from creating PRs that will fail CI.

## Ignored Packages

### Redux Ecosystem (see #753)
- `redux` — major versions
- `react-redux` — major versions  
- `redux-observable` — major versions

**Reason:** These must be upgraded together. Currently blocked because `redux-observable` has no stable v3 release compatible with Redux 5 (only RC available).

### Draft.js Ecosystem (see #751)
- `immutable` — major versions

**Reason:** Draft.js requires `immutable@3.x.x`. Cannot upgrade without replacing Draft.js entirely.

## Test plan

- [x] Dependabot config is valid YAML
- [x] Comments reference tracking issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)