### PR TITLE
fix: add Facebook App ID filter for AMP sharing

### DIFF
--- a/classes/class-wpcom-liveblog-amp.php
+++ b/classes/class-wpcom-liveblog-amp.php
@@ -87,17 +87,29 @@ class WPCOM_Liveblog_AMP {
 	}
 
 	/**
-	 * Add default social share options
+	 * Add default social share options.
+	 *
+	 * @return array Array of social platform identifiers for AMP sharing.
 	 */
 	public static function add_social_share_options() {
-		$social_array = array( 'twitter', 'pinterest', 'email', 'gplus' );
+		$social_array = array( 'twitter', 'pinterest', 'email' );
 
 		/**
-		 * Filter Liveblog AMP Facebook share app id
+		 * Filters the Facebook App ID for AMP social sharing.
 		 *
-		 * @param mixed $app_id Facebook app id to enable Facebook sharing, default false.
+		 * Facebook sharing requires an App ID. Return your Facebook App ID
+		 * from this filter to enable Facebook sharing on AMP liveblog entries.
+		 *
+		 * Example usage:
+		 *     add_filter( 'liveblog_amp_facebook_share_app_id', function() {
+		 *         return '123456789012345';
+		 *     } );
+		 *
+		 * @since 1.9.7
+		 *
+		 * @param string $app_id Facebook App ID. Default empty string (disabled).
 		 */
-		$facebook_app_id = apply_filters( 'liveblog_amp_facebook_share_app_id', false );
+		$facebook_app_id = apply_filters( 'liveblog_amp_facebook_share_app_id', '' );
 
 		if ( ! empty( $facebook_app_id ) ) {
 			$social_array[] = 'facebook';

--- a/templates/amp/entry.php
+++ b/templates/amp/entry.php
@@ -9,7 +9,7 @@
 	$share_link_amp = $this->get( 'share_link_amp' );
 
 	/* This filter is defined in class-wpcom-liveblog-amp.php */
-	$facebook_app_id = apply_filters( 'liveblog_amp_facebook_share_app_id', false );
+	$facebook_app_id = apply_filters( 'liveblog_amp_facebook_share_app_id', '' );
 ?>
 
 <div class="liveblog-entry" id="post<?php echo esc_attr( $update_time ); ?>"


### PR DESCRIPTION
## Summary

Add a `liveblog_amp_facebook_share_app_id` filter to enable Facebook sharing on AMP liveblog entries. Facebook sharing requires an App ID, which was previously attempted via an undocumented `LIVEBLOG_AMP_FACEBOOK_SHARE` constant that didn't work.

Also removes deprecated Google+ sharing (shut down April 2019).

## Changes

- Add `liveblog_amp_facebook_share_app_id` filter with documentation and usage example
- Add `data-param-app_id` attribute to Facebook amp-social-share element
- Remove `gplus` from default social platforms
- Add proper docblock to `add_social_share_options()` method

## Usage

```php
add_filter( 'liveblog_amp_facebook_share_app_id', function() {
    return '123456789012345'; // Your Facebook App ID
} );
```

## Credits

This PR is based on the original work by @christianc1 in #585, which couldn't be updated directly due to fork permission issues. The original commits have been preserved in the git history.

Supersedes #585
Fixes #584

## Test plan

- [ ] Verify AMP liveblog entries show Facebook share button when filter returns an App ID
- [ ] Verify Facebook sharing works with valid App ID
- [ ] Verify no Facebook button appears when filter is not used

🤖 Generated with [Claude Code](https://claude.com/claude-code)