### PR TITLE
Fix Facebook embed parsing for legacy XFBML format

### DIFF
--- a/src/react/utils/__tests__/utils.test.js
+++ b/src/react/utils/__tests__/utils.test.js
@@ -3,6 +3,7 @@ import {
   getFirstOfObject,
   getPollingPages,
   getNewestEntry,
+  triggerOembedLoad,
 } from '../utils';
 
 describe('utils', () => {
@@ -42,5 +43,128 @@ describe('utils', () => {
     expect(getNewestEntry(false, newerEntry)).toEqual(newerEntry);
     expect(getNewestEntry(olderEntry, false)).toEqual(olderEntry);
     expect(getNewestEntry(newerEntry, olderEntry)).toEqual(newerEntry);
+  });
+
+  describe('triggerOembedLoad', () => {
+    let mockElement;
+    let originalWindow;
+
+    beforeEach(() => {
+      // Store original window properties
+      originalWindow = {
+        FB: window.FB,
+        twttr: window.twttr,
+        instgrm: window.instgrm,
+        dispatchEvent: window.dispatchEvent,
+      };
+
+      // Create a mock DOM element
+      mockElement = document.createElement('div');
+
+      // Mock dispatchEvent
+      window.dispatchEvent = jest.fn();
+    });
+
+    afterEach(() => {
+      // Restore original window properties
+      window.FB = originalWindow.FB;
+      window.twttr = originalWindow.twttr;
+      window.instgrm = originalWindow.instgrm;
+      window.dispatchEvent = originalWindow.dispatchEvent;
+    });
+
+    it('should call FB.XFBML.parse with element when Facebook SDK is available', () => {
+      const mockParse = jest.fn();
+      window.FB = {
+        XFBML: {
+          parse: mockParse,
+        },
+      };
+
+      triggerOembedLoad(mockElement);
+
+      expect(mockParse).toHaveBeenCalledTimes(1);
+      expect(mockParse).toHaveBeenCalledWith(mockElement);
+    });
+
+    it('should not throw when Facebook SDK is not available', () => {
+      window.FB = undefined;
+
+      expect(() => triggerOembedLoad(mockElement)).not.toThrow();
+    });
+
+    it('should handle elements with fb-post class (modern HTML5 format)', () => {
+      const mockParse = jest.fn();
+      window.FB = {
+        XFBML: {
+          parse: mockParse,
+        },
+      };
+
+      // Add a modern HTML5 Facebook embed
+      mockElement.innerHTML = '<div class="fb-post" data-href="https://facebook.com/test"></div>';
+
+      triggerOembedLoad(mockElement);
+
+      expect(mockParse).toHaveBeenCalledWith(mockElement);
+    });
+
+    it('should handle elements with fb:post (legacy XFBML format)', () => {
+      const mockParse = jest.fn();
+      window.FB = {
+        XFBML: {
+          parse: mockParse,
+        },
+      };
+
+      // Add a legacy XFBML Facebook embed
+      mockElement.innerHTML = '<fb:post href="https://facebook.com/test" data-width="552"></fb:post>';
+
+      triggerOembedLoad(mockElement);
+
+      // Should still call parse - the SDK handles both formats
+      expect(mockParse).toHaveBeenCalledWith(mockElement);
+    });
+
+    it('should dispatch omembedTrigger custom event', () => {
+      triggerOembedLoad(mockElement);
+
+      expect(window.dispatchEvent).toHaveBeenCalledTimes(1);
+      expect(window.dispatchEvent).toHaveBeenCalledWith(
+        expect.any(CustomEvent)
+      );
+    });
+
+    it('should call Twitter widgets.load when Twitter SDK is available', () => {
+      const mockLoad = jest.fn();
+      window.twttr = {
+        widgets: {
+          load: mockLoad,
+        },
+      };
+
+      // Add a Twitter embed
+      mockElement.innerHTML = '<blockquote class="twitter-tweet"></blockquote>';
+
+      triggerOembedLoad(mockElement);
+
+      expect(mockLoad).toHaveBeenCalled();
+    });
+
+    it('should call Instagram Embeds.process when Instagram SDK is available', () => {
+      const mockProcess = jest.fn();
+      window.instgrm = {
+        Embeds: {
+          process: mockProcess,
+        },
+      };
+
+      // Add an Instagram embed
+      mockElement.innerHTML = '<blockquote class="instagram-media"></blockquote>';
+
+      triggerOembedLoad(mockElement);
+
+      expect(mockProcess).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/react/utils/utils.js
+++ b/src/react/utils/utils.js
@@ -179,8 +179,11 @@ export const triggerOembedLoad = (element) => {
     });
   }
 
-  if (window.FB && element.querySelector('.fb-post')) {
-    window.FB.XFBML.parse();
+  // Parse Facebook embeds when SDK is available.
+  // Uses element parameter to scope parsing and handles both modern HTML5 format
+  // (<div class="fb-post">) and legacy XFBML format (<fb:post>) from older cached embeds.
+  if (window.FB) {
+    window.FB.XFBML.parse(element);
   }
 
   window.dispatchEvent(new CustomEvent('omembedTrigger'));


### PR DESCRIPTION
## Summary

- Fix Facebook embeds not rendering when cached content uses legacy XFBML format (`<fb:post>`)
- The previous check for `.fb-post` class didn't match XFBML namespace elements
- Now always calls `FB.XFBML.parse(element)` when SDK is available, which handles both formats
- Passes element parameter to scope parsing to current container

## Background

Issue #306 reported Facebook embeds not rendering consistently. Investigation revealed that when oEmbed cached content in the legacy XFBML format (`<fb:post href="..." data-width="552">`), the JavaScript check `element.querySelector('.fb-post')` would fail because:
- `.fb-post` is a CSS class selector
- `<fb:post>` is an XML namespace element, not a class

The Facebook SDK's `XFBML.parse()` function handles both formats, so removing the element check and always calling parse when the SDK is loaded makes the code more robust.

## Test plan

- [x] Added Jest tests for `triggerOembedLoad` function
- [x] Tests cover Facebook SDK with both HTML5 and XFBML formats
- [x] Tests cover Twitter and Instagram SDKs
- [x] All existing tests pass

Fixes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)