### PR TITLE
Add VIP edge cache purging when liveblog entries change

### DIFF
--- a/tests/Integration/VipEdgeCachePurgeTest.php
+++ b/tests/Integration/VipEdgeCachePurgeTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare( strict_types=1 );
+
+/**
+ * Integration tests for VIP edge cache purging.
+ *
+ * @package Automattic\Liveblog\Tests\Integration
+ */
+
+namespace Automattic\Liveblog\Tests\Integration;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * Tests for the VIP edge cache purge functionality.
+ *
+ * @covers ::liveblog_purge_edge_cache
+ */
+final class VipEdgeCachePurgeTest extends TestCase {
+
+	/**
+	 * Test post ID.
+	 *
+	 * @var int
+	 */
+	private int $post_id;
+
+	/**
+	 * Tracks URLs that were purged.
+	 *
+	 * @var array
+	 */
+	private array $purged_urls = array();
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		// Create a test post.
+		$this->post_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Test Liveblog',
+				'post_status' => 'publish',
+			)
+		);
+
+		// Reset purged URLs tracker.
+		$this->purged_urls = array();
+	}
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down(): void {
+		// Remove the mock VIP function if we created it.
+		$this->purged_urls = array();
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Test that the purge function is hooked to liveblog_insert_entry.
+	 */
+	public function test_purge_function_hooked_to_insert_entry(): void {
+		$this->assertIsInt(
+			has_action( 'liveblog_insert_entry', 'liveblog_purge_edge_cache' )
+		);
+	}
+
+	/**
+	 * Test that the purge function is hooked to liveblog_update_entry.
+	 */
+	public function test_purge_function_hooked_to_update_entry(): void {
+		$this->assertIsInt(
+			has_action( 'liveblog_update_entry', 'liveblog_purge_edge_cache' )
+		);
+	}
+
+	/**
+	 * Test that the purge function is hooked to liveblog_delete_entry.
+	 */
+	public function test_purge_function_hooked_to_delete_entry(): void {
+		$this->assertIsInt(
+			has_action( 'liveblog_delete_entry', 'liveblog_purge_edge_cache' )
+		);
+	}
+
+	/**
+	 * Test that the function returns early when VIP function doesn't exist.
+	 */
+	public function test_returns_early_when_vip_function_not_available(): void {
+		// The VIP function shouldn't exist in test environment.
+		$this->assertFalse( function_exists( 'wpcom_vip_purge_edge_cache_for_url' ) );
+
+		// This should not throw an error.
+		liveblog_purge_edge_cache( 1, $this->post_id );
+
+		// If we got here without error, the early return worked.
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test that the function calls the VIP purge function with correct URL.
+	 */
+	public function test_calls_vip_purge_with_correct_url(): void {
+		// Create a mock for the VIP function.
+		$this->mock_vip_purge_function();
+
+		$expected_url = get_permalink( $this->post_id );
+
+		liveblog_purge_edge_cache( 1, $this->post_id );
+
+		$this->assertContains( $expected_url, $this->purged_urls );
+	}
+
+	/**
+	 * Test that the function handles invalid post ID gracefully.
+	 */
+	public function test_handles_invalid_post_id(): void {
+		// Create a mock for the VIP function.
+		$this->mock_vip_purge_function();
+
+		// Use a non-existent post ID.
+		liveblog_purge_edge_cache( 1, 999999 );
+
+		// Should not have purged anything.
+		$this->assertEmpty( $this->purged_urls );
+	}
+
+	/**
+	 * Test that the function sanitizes the post ID.
+	 */
+	public function test_sanitizes_post_id(): void {
+		// Create a mock for the VIP function.
+		$this->mock_vip_purge_function();
+
+		$expected_url = get_permalink( $this->post_id );
+
+		// Pass post ID as string (simulating untrusted input).
+		liveblog_purge_edge_cache( 1, (string) $this->post_id );
+
+		$this->assertContains( $expected_url, $this->purged_urls );
+	}
+
+	/**
+	 * Create a mock for the VIP purge function.
+	 *
+	 * This creates the function in the global namespace if it doesn't exist.
+	 */
+	private function mock_vip_purge_function(): void {
+		if ( ! function_exists( 'wpcom_vip_purge_edge_cache_for_url' ) ) {
+			$purged_urls = &$this->purged_urls;
+
+			// Define the function in global namespace.
+			eval( 'function wpcom_vip_purge_edge_cache_for_url( $url ) {
+				global $wpcom_vip_liveblog_test_purged_urls;
+				$wpcom_vip_liveblog_test_purged_urls[] = $url;
+			}' );
+		}
+
+		// Use a global to track purged URLs since we can't use $this in eval.
+		$GLOBALS['wpcom_vip_liveblog_test_purged_urls'] = &$this->purged_urls;
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -54,6 +54,7 @@ if ( $is_integration ) {
 		'muplugins_loaded',
 		function (): void {
 			require dirname( __DIR__ ) . '/liveblog.php';
+			require dirname( __DIR__ ) . '/vipgo-helper.php';
 		}
 	);
 

--- a/vipgo-helper.php
+++ b/vipgo-helper.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * VIP Go Helper file.
+ *
+ * This file is automatically loaded by the VIP Go platform and contains
+ * VIP-specific enhancements.
+ *
+ * @see https://docs.wpvip.com/plugins/helper-file/
+ * @package Automattic\Liveblog
+ */
+
+/**
+ * Purge the VIP edge cache for a liveblog when entries change.
+ *
+ * Ensures that a Liveblog page isn't cached with stale metadata during an
+ * active liveblog. This is particularly important for SEO and social sharing
+ * where the page's cached version may contain outdated entry counts or timestamps.
+ *
+ * @param int $comment_id ID of the comment for this entry.
+ * @param int $post_id    ID for this liveblog post.
+ */
+function liveblog_purge_edge_cache( $comment_id, $post_id ) {
+	if ( ! function_exists( 'wpcom_vip_purge_edge_cache_for_url' ) ) {
+		return;
+	}
+
+	$permalink = get_permalink( absint( $post_id ) );
+	if ( ! $permalink ) {
+		return;
+	}
+
+	wpcom_vip_purge_edge_cache_for_url( $permalink );
+}
+add_action( 'liveblog_insert_entry', 'liveblog_purge_edge_cache', 10, 2 );
+add_action( 'liveblog_update_entry', 'liveblog_purge_edge_cache', 10, 2 );
+add_action( 'liveblog_delete_entry', 'liveblog_purge_edge_cache', 10, 2 );


### PR DESCRIPTION
## Summary

Purge the VIP edge cache for a liveblog post whenever entries are inserted, updated, or deleted. This ensures visitors don't see cached pages with stale metadata during an active liveblog.

## Problem

On WordPress VIP, pages are cached at the edge (Varnish). During an active liveblog, the page's cached version may contain outdated:
- Entry counts
- Timestamps
- Social sharing metadata
- SEO-relevant content

This can cause issues where social shares or search engine crawls pick up stale information.

## Solution

Add a `vipgo-helper.php` file (following [VIP's documented convention](https://docs.wpvip.com/plugins/helper-file/) for platform-specific enhancements) with a function that hooks into liveblog entry actions and purges the edge cache:

```php
function liveblog_purge_edge_cache( $comment_id, $post_id ) {
    if ( ! function_exists( 'wpcom_vip_purge_edge_cache_for_url' ) ) {
        return;
    }
    // ... purge the cache
}
add_action( 'liveblog_insert_entry', 'liveblog_purge_edge_cache', 10, 2 );
add_action( 'liveblog_update_entry', 'liveblog_purge_edge_cache', 10, 2 );
add_action( 'liveblog_delete_entry', 'liveblog_purge_edge_cache', 10, 2 );
```

The function:
- Uses the `liveblog_` prefix per PHPCS requirements
- Lives in `vipgo-helper.php` which is automatically loaded on VIP Go
- Safely checks for the VIP-specific purge function before calling it

## Changes from original proposal

- Extended @WPprodigy's original code to also handle entry updates and deletions
- Placed in `vipgo-helper.php` rather than `wpcom-helper.php` per VIP documentation
- Renamed function to use `liveblog_` prefix for PHPCS compliance
- Added integration tests

## Test plan

- [x] PHP syntax validated
- [x] PHPCS passes
- [x] Integration tests pass (7 tests)
- [ ] Manual testing on VIP environment (cache purge is VIP-specific)
- Non-VIP installations are unaffected (function existence check)

Fixes #677

🤖 Generated with [Claude Code](https://claude.com/claude-code)