### PR TITLE
chore: add .wp-env.override.json to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@ composer.lock
 vendor/
 .phpunit.cache/
 
+# Local wp-env overrides
+.wp-env.override.json
+


### PR DESCRIPTION
## Summary

Add `.wp-env.override.json` to gitignore. This file contains local wp-env configuration overrides and should not be committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)