### PR TITLE
fix: use add_action for template_redirect hook in AMP class

### DIFF
--- a/classes/class-wpcom-liveblog-amp.php
+++ b/classes/class-wpcom-liveblog-amp.php
@@ -23,7 +23,7 @@ class WPCOM_Liveblog_AMP {
 		}
 
 		// Hook at template_redirect level as some Liveblog hooks require it.
-		add_filter( 'template_redirect', array( __CLASS__, 'setup' ), 10 );
+		add_action( 'template_redirect', array( __CLASS__, 'setup' ), 10 );
 
 		// Add query vars to support pagination and single entries.
 		add_filter( 'query_vars', array( __CLASS__, 'add_custom_query_vars' ), 10 );


### PR DESCRIPTION
## Problem

The AMP class was incorrectly using `add_filter()` to hook into `template_redirect`, which is an action hook rather than a filter. Whilst this works functionally (WordPress allows filters to be used on actions), it's semantically incorrect and could cause confusion for developers reading the code.

The `setup()` method being hooked performs side effects—adding and removing hooks—and doesn't return any value, making `add_action()` the appropriate function for this context.

## Solution

Changed the hook registration from `add_filter()` to `add_action()` on line 26 of `/classes/class-wpcom-liveblog-amp.php`. This aligns the code with WordPress best practices and makes the intent clearer.

Fixes #619