### PR TITLE
Enable PHPCS code style checks in CI

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -67,9 +67,8 @@ jobs:
           xml-schema-file: ./vendor/phpunit/phpunit/phpunit.xsd
 
       # Check the code-style consistency of the PHP files.
-#      - name: Check PHP code style
-#        continue-on-error: true
-#        run: vendor/bin/phpcs --report-full --report-checkstyle=./phpcs-report.xml
+      - name: Check PHP code style
+        run: composer cs -- --report-full --report-checkstyle=./phpcs-report.xml
 
-#      - name: Show PHPCS results in PR
-#        run: cs2pr ./phpcs-report.xml
+      - name: Show PHPCS results in PR
+        run: cs2pr ./phpcs-report.xml


### PR DESCRIPTION
## Problem

The PHPCS code style check steps in our GitHub Actions workflow were commented out because the codebase had numerous coding standards violations. This meant that whilst we had the infrastructure to check code quality, it wasn't being enforced, allowing new violations to be introduced.

## Solution

Now that all existing PHPCS violations have been resolved in PR #778, we can safely enable automated code style checking in continuous integration. This change uncomments the previously disabled workflow steps and removes the `continue-on-error` flag, ensuring that:

- All pull requests are checked for PHP coding standards compliance
- Violations are displayed inline in pull request diffs via cs2pr
- Builds fail when coding standards violations are present, preventing regressions

This maintains code quality standards across the project and provides immediate feedback to contributors about any style issues.