### PR TITLE
feat: add image cropping and resizing to Lexical editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^18.3.1",
         "react-ace": "^14.0.1",
         "react-dom": "^18.3.1",
+        "react-image-crop": "^11.0.10",
         "react-redux": "^8.1.0",
         "react-select": "^5.8.0",
         "react-select-async-paginate": "^0.7.11",
@@ -2013,16 +2014,16 @@
       "license": "MIT"
     },
     "node_modules/@cacheable/memory": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.6.tgz",
-      "integrity": "sha512-7e8SScMocHxcAb8YhtkbMhGG+EKLRIficb1F5sjvhSYsWTZGxvg4KIDp8kgxnV2PUJ3ddPe6J9QESjKvBWRDkg==",
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@cacheable/memory/-/memory-2.0.7.tgz",
+      "integrity": "sha512-RbxnxAMf89Tp1dLhXMS7ceft/PGsDl1Ip7T20z5nZ+pwIAsQ1p2izPjVG69oCLv/jfQ7HDPHTWK0c9rcAWXN3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@cacheable/utils": "^2.3.2",
+        "@cacheable/utils": "^2.3.3",
         "@keyv/bigmap": "^1.3.0",
-        "hookified": "^1.13.0",
-        "keyv": "^5.5.4"
+        "hookified": "^1.14.0",
+        "keyv": "^5.5.5"
       }
     },
     "node_modules/@cacheable/memory/node_modules/@keyv/bigmap": {
@@ -2053,14 +2054,14 @@
       }
     },
     "node_modules/@cacheable/utils": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.2.tgz",
-      "integrity": "sha512-8kGE2P+HjfY8FglaOiW+y8qxcaQAfAhVML+i66XJR3YX5FtyDqn6Txctr3K2FrbxLKixRRYYBWMbuGciOhYNDg==",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@cacheable/utils/-/utils-2.3.3.tgz",
+      "integrity": "sha512-JsXDL70gQ+1Vc2W/KUFfkAJzgb4puKwwKehNLuB+HrNKWf91O736kGfxn4KujXCCSuh6mRRL4XEB0PkAFjWS0A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "hashery": "^1.2.0",
-        "keyv": "^5.5.4"
+        "hashery": "^1.3.0",
+        "keyv": "^5.5.5"
       }
     },
     "node_modules/@cacheable/utils/node_modules/keyv": {
@@ -3080,9 +3081,9 @@
       }
     },
     "node_modules/@jest/environment-jsdom-abstract/node_modules/@sinclair/typebox": {
-      "version": "0.34.41",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
-      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "version": "0.34.45",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.45.tgz",
+      "integrity": "sha512-qJcFVfCa5jxBFSuv7S5WYbA8XdeCPmhnaVVfX/2Y6L8WYg8sk3XY2+6W0zH+3mq1Cz+YC7Ki66HfqX6IHAwnkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -8341,9 +8342,9 @@
       }
     },
     "node_modules/basic-ftp": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.0.5.tgz",
-      "integrity": "sha512-4Bcg1P8xhUuqcii/S0Z9wiHIrQVPMermM1any+MX5GeGD7faD3/msQUDGLol9wOcz4/jbg/WJnGqoJF6LiBdtg==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.1.0.tgz",
+      "integrity": "sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14840,9 +14841,9 @@
       }
     },
     "node_modules/jest-environment-jsdom/node_modules/@sinclair/typebox": {
-      "version": "0.34.41",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.41.tgz",
-      "integrity": "sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==",
+      "version": "0.34.45",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.34.45.tgz",
+      "integrity": "sha512-qJcFVfCa5jxBFSuv7S5WYbA8XdeCPmhnaVVfX/2Y6L8WYg8sk3XY2+6W0zH+3mq1Cz+YC7Ki66HfqX6IHAwnkg==",
       "dev": true,
       "license": "MIT"
     },
@@ -18690,9 +18691,9 @@
       }
     },
     "node_modules/prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.1.tgz",
+      "integrity": "sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -19076,6 +19077,15 @@
       "dependencies": {
         "@babel/runtime": "^7.12.5"
       },
+      "peerDependencies": {
+        "react": ">=16.13.1"
+      }
+    },
+    "node_modules/react-image-crop": {
+      "version": "11.0.10",
+      "resolved": "https://registry.npmjs.org/react-image-crop/-/react-image-crop-11.0.10.tgz",
+      "integrity": "sha512-+5FfDXUgYLLqBh1Y/uQhIycpHCbXkI50a+nbfkB1C0xXXUTwkisHDo2QCB1SQJyHCqIuia4FeyReqXuMDKWQTQ==",
+      "license": "ISC",
       "peerDependencies": {
         "react": ">=16.13.1"
       }
@@ -21275,9 +21285,9 @@
       }
     },
     "node_modules/stylelint-scss": {
-      "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.13.0.tgz",
-      "integrity": "sha512-kZPwFUJkfup2gP1enlrS2h9U5+T5wFoqzJ1n/56AlpwSj28kmFe7ww/QFydvPsg5gLjWchAwWWBLtterynZrOw==",
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/stylelint-scss/-/stylelint-scss-6.14.0.tgz",
+      "integrity": "sha512-ZKmHMZolxeuYsnB+PCYrTpFce0/QWX9i9gh0hPXzp73WjuIMqUpzdQaBCrKoLWh6XtCFSaNDErkMPqdjy1/8aA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -23400,6 +23410,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
       "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "^18.3.1",
     "react-ace": "^14.0.1",
     "react-dom": "^18.3.1",
+    "react-image-crop": "^11.0.10",
     "react-redux": "^8.1.0",
     "react-select": "^5.8.0",
     "react-select-async-paginate": "^0.7.11",

--- a/src/react/Editor/ImageCropModal.js
+++ b/src/react/Editor/ImageCropModal.js
@@ -1,0 +1,197 @@
+/**
+ * Image crop modal component.
+ *
+ * @package Liveblog
+ */
+
+import React, { useState, useRef, useCallback, useEffect } from 'react';
+import PropTypes from 'prop-types';
+import ReactCrop from 'react-image-crop';
+import 'react-image-crop/dist/ReactCrop.css';
+import { getCroppedImage, scaleToNaturalDimensions } from './cropUtils';
+
+/**
+ * Modal component for cropping images before upload.
+ *
+ * @param {Object}   props               Component props.
+ * @param {File}     props.imageFile     The image file to crop.
+ * @param {Function} props.onCropComplete Called with the cropped File when user confirms.
+ * @param {Function} props.onCancel      Called when user cancels the crop.
+ * @param {number}   props.aspectRatio   Optional fixed aspect ratio for the crop.
+ * @return {JSX.Element|null} The modal component or null if no image.
+ */
+function ImageCropModal( { imageFile, onCropComplete, onCancel, aspectRatio } ) {
+	const [ crop, setCrop ] = useState();
+	const [ imageSrc, setImageSrc ] = useState( '' );
+	const [ isProcessing, setIsProcessing ] = useState( false );
+	const imageRef = useRef( null );
+	const modalRef = useRef( null );
+
+	// Load image preview when file changes.
+	useEffect( () => {
+		if ( ! imageFile ) {
+			return;
+		}
+
+		const reader = new FileReader();
+		reader.onload = () => setImageSrc( reader.result );
+		reader.readAsDataURL( imageFile );
+	}, [ imageFile ] );
+
+	// Focus the modal when it opens.
+	useEffect( () => {
+		if ( modalRef.current ) {
+			modalRef.current.focus();
+		}
+	}, [ imageSrc ] );
+
+	// Handle crop confirmation.
+	const handleApplyCrop = useCallback( async () => {
+		if ( ! imageRef.current ) {
+			onCropComplete( imageFile );
+			return;
+		}
+
+		// If no crop selected or crop is too small, use original image.
+		if ( ! crop?.width || ! crop?.height || crop.width < 10 || crop.height < 10 ) {
+			onCropComplete( imageFile );
+			return;
+		}
+
+		setIsProcessing( true );
+		try {
+			// Scale crop from displayed size to natural image dimensions.
+			const pixelCrop = scaleToNaturalDimensions( crop, imageRef.current );
+
+			const croppedFile = await getCroppedImage(
+				imageRef.current,
+				pixelCrop,
+				imageFile.name
+			);
+			onCropComplete( croppedFile );
+		} catch ( error ) {
+			// eslint-disable-next-line no-console
+			console.error( 'Crop failed:', error );
+			// Fall back to original on error.
+			onCropComplete( imageFile );
+		} finally {
+			setIsProcessing( false );
+		}
+	}, [ crop, imageFile, onCropComplete ] );
+
+	// Handle keyboard events.
+	const handleKeyDown = useCallback(
+		( event ) => {
+			if ( event.key === 'Escape' ) {
+				event.preventDefault();
+				onCancel();
+			} else if ( event.key === 'Enter' && ! isProcessing ) {
+				event.preventDefault();
+				handleApplyCrop();
+			}
+		},
+		[ onCancel, handleApplyCrop, isProcessing ]
+	);
+
+	// Handle overlay click (close on backdrop click).
+	const handleOverlayClick = useCallback(
+		( event ) => {
+			if ( event.target === event.currentTarget ) {
+				onCancel();
+			}
+		},
+		[ onCancel ]
+	);
+
+	if ( ! imageSrc ) {
+		return null;
+	}
+
+	return (
+		<div
+			className="liveblog-crop-modal-overlay"
+			onClick={ handleOverlayClick }
+			onKeyDown={ handleKeyDown }
+			role="presentation"
+		>
+			<div
+				ref={ modalRef }
+				className="liveblog-crop-modal"
+				role="dialog"
+				aria-modal="true"
+				aria-labelledby="liveblog-crop-modal-title"
+				tabIndex={ -1 }
+			>
+				<div className="liveblog-crop-modal-header">
+					<h2
+						id="liveblog-crop-modal-title"
+						className="liveblog-crop-modal-title"
+					>
+						Crop Image
+					</h2>
+					<button
+						type="button"
+						className="liveblog-crop-modal-close"
+						onClick={ onCancel }
+						aria-label="Close"
+						disabled={ isProcessing }
+					>
+						<span className="dashicons dashicons-no-alt" />
+					</button>
+				</div>
+
+				<div className="liveblog-crop-modal-content">
+					<ReactCrop
+						crop={ crop }
+						onChange={ ( c ) => setCrop( c ) }
+						aspect={ aspectRatio }
+						className="liveblog-crop-react-crop"
+					>
+						<img
+							ref={ imageRef }
+							src={ imageSrc }
+							alt="Crop preview"
+							className="liveblog-crop-modal-image"
+						/>
+					</ReactCrop>
+					<p className="liveblog-crop-modal-hint">
+						Drag to select the area you want to keep. Click Apply to
+						use the full image without cropping.
+					</p>
+				</div>
+
+				<div className="liveblog-crop-modal-footer">
+					<button
+						type="button"
+						className="liveblog-btn liveblog-btn-cancel"
+						onClick={ onCancel }
+						disabled={ isProcessing }
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						className="liveblog-btn liveblog-btn-primary"
+						onClick={ handleApplyCrop }
+						disabled={ isProcessing }
+					>
+						{ isProcessing ? 'Processing...' : 'Apply' }
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+ImageCropModal.propTypes = {
+	imageFile: PropTypes.instanceOf( File ).isRequired,
+	onCropComplete: PropTypes.func.isRequired,
+	onCancel: PropTypes.func.isRequired,
+	aspectRatio: PropTypes.number,
+};
+
+ImageCropModal.defaultProps = {
+	aspectRatio: undefined,
+};
+
+export default ImageCropModal;

--- a/src/react/Editor/cropUtils.js
+++ b/src/react/Editor/cropUtils.js
@@ -1,0 +1,126 @@
+/**
+ * Canvas-based image cropping utilities.
+ *
+ * @package Liveblog
+ */
+
+/**
+ * Create a cropped image from the source image and crop area.
+ *
+ * @param {HTMLImageElement} image    The source image element.
+ * @param {Object}           crop     The crop area with x, y, width, height in pixels.
+ * @param {string}           fileName Original file name for the output.
+ * @return {Promise<File>} The cropped image as a File object.
+ */
+export async function getCroppedImage( image, crop, fileName ) {
+	const canvas = document.createElement( 'canvas' );
+	const ctx = canvas.getContext( '2d' );
+
+	if ( ! ctx ) {
+		throw new Error( 'Could not get canvas context' );
+	}
+
+	// Set canvas size to the crop dimensions.
+	canvas.width = crop.width;
+	canvas.height = crop.height;
+
+	// Draw the cropped portion of the image onto the canvas.
+	ctx.drawImage(
+		image,
+		crop.x,
+		crop.y,
+		crop.width,
+		crop.height,
+		0,
+		0,
+		crop.width,
+		crop.height
+	);
+
+	// Determine output type from filename.
+	const extension = fileName.split( '.' ).pop()?.toLowerCase();
+	let mimeType = 'image/jpeg';
+	let quality = 0.92;
+
+	if ( extension === 'png' ) {
+		mimeType = 'image/png';
+		quality = undefined; // PNG doesn't use quality parameter.
+	} else if ( extension === 'webp' ) {
+		mimeType = 'image/webp';
+		quality = 0.92;
+	}
+
+	// Convert canvas to Blob, then to File.
+	return new Promise( ( resolve, reject ) => {
+		canvas.toBlob(
+			( blob ) => {
+				if ( ! blob ) {
+					reject( new Error( 'Canvas is empty' ) );
+					return;
+				}
+				// Create File from Blob to preserve filename.
+				const file = new File( [ blob ], fileName, {
+					type: mimeType,
+					lastModified: Date.now(),
+				} );
+				resolve( file );
+			},
+			mimeType,
+			quality
+		);
+	} );
+}
+
+/**
+ * Convert pixel crop to percentage-based crop.
+ *
+ * @param {Object}           pixelCrop The crop in pixels { x, y, width, height }.
+ * @param {HTMLImageElement} image     The image element.
+ * @return {Object} The crop as percentages.
+ */
+export function pixelCropToPercent( pixelCrop, image ) {
+	return {
+		x: ( pixelCrop.x / image.naturalWidth ) * 100,
+		y: ( pixelCrop.y / image.naturalHeight ) * 100,
+		width: ( pixelCrop.width / image.naturalWidth ) * 100,
+		height: ( pixelCrop.height / image.naturalHeight ) * 100,
+	};
+}
+
+/**
+ * Convert percentage crop to pixel-based crop.
+ *
+ * @param {Object}           percentCrop The crop as percentages { x, y, width, height }.
+ * @param {HTMLImageElement} image       The image element.
+ * @return {Object} The crop in pixels.
+ */
+export function percentCropToPixel( percentCrop, image ) {
+	return {
+		x: ( percentCrop.x / 100 ) * image.naturalWidth,
+		y: ( percentCrop.y / 100 ) * image.naturalHeight,
+		width: ( percentCrop.width / 100 ) * image.naturalWidth,
+		height: ( percentCrop.height / 100 ) * image.naturalHeight,
+	};
+}
+
+/**
+ * Scale displayed pixel crop to natural image dimensions.
+ *
+ * ReactCrop returns pixel values relative to the displayed image size.
+ * We need to scale these to the natural image dimensions for canvas drawing.
+ *
+ * @param {Object}           displayedCrop The crop in displayed pixels { x, y, width, height }.
+ * @param {HTMLImageElement} image         The image element.
+ * @return {Object} The crop in natural image pixels.
+ */
+export function scaleToNaturalDimensions( displayedCrop, image ) {
+	const scaleX = image.naturalWidth / image.width;
+	const scaleY = image.naturalHeight / image.height;
+
+	return {
+		x: displayedCrop.x * scaleX,
+		y: displayedCrop.y * scaleY,
+		width: displayedCrop.width * scaleX,
+		height: displayedCrop.height * scaleY,
+	};
+}

--- a/src/styles/core/editor/_all.scss
+++ b/src/styles/core/editor/_all.scss
@@ -14,3 +14,4 @@
 @forward "./media";
 @forward "./html-editor";
 @forward "./lexical";
+@forward "./crop-modal";

--- a/src/styles/core/editor/_crop-modal.scss
+++ b/src/styles/core/editor/_crop-modal.scss
@@ -1,0 +1,193 @@
+/**
+ * Image crop modal styles.
+ *
+ * @package Liveblog
+ */
+
+@use "../utils" as *;
+
+// Fade in animation for overlay.
+@keyframes fadeIn {
+
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+// Scale up animation for modal.
+@keyframes modalScaleUp {
+
+	from {
+		opacity: 0;
+		transform: scale(0.95);
+	}
+
+	to {
+		opacity: 1;
+		transform: scale(1);
+	}
+}
+
+// Overlay - full screen backdrop.
+.liveblog-crop-modal-overlay {
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	z-index: 100000;
+	background: rgba(0, 0, 0, 0.7);
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	animation: fadeIn 0.2s ease-out;
+}
+
+// Modal container.
+.liveblog-crop-modal {
+	background: #fff;
+	border-radius: $base-border-radius;
+	box-shadow: $base-drop-shadow;
+	max-width: 90vw;
+	max-height: 90vh;
+	width: 600px;
+	display: flex;
+	flex-direction: column;
+	animation: modalScaleUp 0.2s cubic-bezier(0.3, 1.2, 0.2, 1);
+	outline: none;
+
+	&:focus {
+		outline: none;
+	}
+}
+
+// Header.
+.liveblog-crop-modal-header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 1rem;
+	border-bottom: $base-border-size solid $color-grey-mid-light;
+	flex-shrink: 0;
+}
+
+.liveblog-crop-modal-title {
+	margin: 0;
+	font-size: 1.1rem;
+	font-weight: 600;
+	color: $color-grey-dark;
+}
+
+.liveblog-crop-modal-close {
+
+	@include button-reset;
+
+	padding: 0.25rem;
+	color: $color-grey-base;
+	cursor: pointer;
+	background: transparent;
+	border-radius: $base-border-radius;
+	transition: color 0.15s ease, background-color 0.15s ease;
+
+	&:hover {
+		color: $color-grey-dark;
+		background-color: $color-grey-x-light;
+	}
+
+	&:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+
+	.dashicons {
+		font-size: 20px;
+		width: 20px;
+		height: 20px;
+	}
+}
+
+// Content area.
+.liveblog-crop-modal-content {
+	padding: 1rem;
+	overflow: auto;
+	flex: 1;
+	display: flex;
+	flex-direction: column;
+	align-items: center;
+	min-height: 0; // Allow flex shrinking.
+}
+
+.liveblog-crop-modal-image {
+	max-width: 100%;
+	max-height: 50vh;
+	display: block;
+}
+
+.liveblog-crop-modal-hint {
+	margin: 0.75rem 0 0;
+	font-size: 0.85rem;
+	color: $color-grey-base;
+	text-align: center;
+}
+
+// Footer with action buttons.
+.liveblog-crop-modal-footer {
+	display: flex;
+	justify-content: flex-end;
+	gap: 0.5rem;
+	padding: 1rem;
+	border-top: $base-border-size solid $color-grey-mid-light;
+	flex-shrink: 0;
+}
+
+// Button styles for modal.
+.liveblog-crop-modal-footer .liveblog-btn {
+
+	@include button-reset;
+
+	padding: 0.5rem 1rem;
+	font-size: 0.9rem;
+	border-radius: $base-border-radius;
+	transition: background-color 0.15s ease, opacity 0.15s ease;
+
+	&:disabled {
+		opacity: 0.5;
+		cursor: not-allowed;
+	}
+}
+
+.liveblog-crop-modal-footer .liveblog-btn-cancel {
+	background: $color-grey-x-light;
+	color: $color-grey-dark;
+
+	&:hover:not(:disabled) {
+		background: $color-grey-mid-light;
+	}
+}
+
+.liveblog-crop-modal-footer .liveblog-btn-primary {
+	background: $color-primary;
+	color: #fff;
+
+	&:hover:not(:disabled) {
+		background: $raw-color-primary;
+		filter: brightness(1.1);
+	}
+}
+
+// ReactCrop overrides to match liveblog theme.
+.liveblog-crop-react-crop {
+	max-width: 100%;
+
+	.ReactCrop__crop-selection {
+		border: 2px solid $raw-color-primary;
+	}
+
+	.ReactCrop__drag-handle {
+		background-color: $raw-color-primary;
+	}
+}

--- a/src/styles/core/editor/_lexical.scss
+++ b/src/styles/core/editor/_lexical.scss
@@ -148,12 +148,49 @@
 	max-width: 100%;
 }
 
+.liveblog-resizable-image-container {
+	display: inline-block;
+	position: relative;
+	max-width: 100%;
+
+	&.selected {
+		outline: 2px solid #007cba;
+		outline-offset: 2px;
+	}
+
+	&.resizing {
+		user-select: none;
+	}
+}
+
 .liveblog-lexical-image {
 	max-width: 100%;
 	height: auto;
 	display: block;
 	margin: 8px 0;
 	border-radius: 4px;
+	cursor: pointer;
+}
+
+// Resize handles
+.liveblog-resize-handle {
+	position: absolute;
+	width: 12px;
+	height: 12px;
+	background: #007cba;
+	border: 2px solid #fff;
+	border-radius: 2px;
+	cursor: nwse-resize;
+	z-index: 10;
+
+	&:hover {
+		background: #005a8c;
+	}
+}
+
+.liveblog-resize-handle-se {
+	bottom: 4px;
+	right: 4px;
 }
 
 // Drag-over state for image dropping


### PR DESCRIPTION
## Why This Change Was Needed

The Lexical editor lacked essential image manipulation capabilities that authors need when preparing visual content for liveblog entries. Without the ability to crop and resize images within the editor, users had to pre-process images externally or accept suboptimal framing and sizing, which slowed down the content creation workflow and created friction in the authoring experience.

This gap represented a significant feature disparity between the Lexical editor and the legacy Draft.js editor, where these capabilities already exist. For the Lexical editor to become a viable replacement, it needs to match or exceed the functionality authors have come to rely upon.

## How This Addresses the Problem

This change introduces two core image manipulation features that integrate seamlessly into the existing Lexical editor workflow:

**Image Cropping with Modal Interface**

When authors select images for upload, a modal now appears powered by the `react-image-crop` library. Authors can drag to select the portion of the image they want to keep, with the crop processed client-side using the Canvas API before upload. The modal includes keyboard shortcuts (ESC to cancel, Enter to apply) and falls back to the original image if no crop is selected. This client-side processing reduces server load whilst giving authors immediate visual feedback.

**Image Resizing with Drag Handles**

Once images are inserted into the editor, authors can click to select them (indicated by a blue outline) and drag a corner handle to resize whilst maintaining the original aspect ratio. The resize dimensions persist in the node state and export to HTML `width` and `height` attributes, ensuring the sizing is preserved when entries are published. This works with both newly uploaded images and previously uploaded images in existing entries.

The implementation maintains clean separation of concerns:
- `ImageCropModal.js` handles the cropping UI and user interactions
- `cropUtils.js` provides reusable Canvas-based image processing utilities
- `ResizableImage` component manages the resize functionality within the Lexical editor
- Enhanced `ImageNode` class stores dimension state and exports it correctly to HTML

These features bring the Lexical editor closer to feature parity with the Draft.js editor whilst providing a more streamlined authoring experience for visual content. Authors can now prepare images within the editor itself, reducing the need for external tools and accelerating the content creation process.