### PR TITLE
fix: use add_action for template_redirect hook

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -383,7 +383,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		 * @uses add_filter()
 		 */
 		private static function add_filters() {
-			add_filter( 'template_redirect', array( __CLASS__, 'handle_request' ), 9 );
+			add_action( 'template_redirect', array( __CLASS__, 'handle_request' ), 9 );
 			add_filter( 'comment_class', array( __CLASS__, 'add_comment_class' ), 10, 3 );
 			add_filter( 'is_protected_meta', array( __CLASS__, 'protect_liveblog_meta_key' ), 10, 2 );
 
@@ -552,7 +552,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		 *
 		 * @return void
 		 */
-		public static function handle_request() { // phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter -- This is hooked to an action, not a filter.
+		public static function handle_request() {
 
 			if ( ! self::is_viewing_liveblog_post() ) {
 				return;


### PR DESCRIPTION
## Summary

- Change `add_filter()` to `add_action()` for the `template_redirect` hook
- Remove now-unnecessary phpcs:ignore comment from `handle_request()`

## Problem

`template_redirect` is an **action** hook, not a filter, but the code was using `add_filter()` to register the callback. This caused VIP coding standards warnings:

```
WARNING | Please, make sure that a callback to 'template_redirect' filter is returning void intentionally.
WARNING | Please, make sure that a callback to 'template_redirect' filter is always returning some value.
```

## Solution

Use `add_action()` instead of `add_filter()` since `template_redirect` is an action hook that doesn't expect a return value.

## Test plan

- [ ] Verify liveblog still loads correctly on the frontend
- [ ] Verify AJAX requests for new entries still work

Fixes #620

🤖 Generated with [Claude Code](https://claude.com/claude-code)