### PR TITLE
ci: add concurrency controls to GitHub Actions workflows

### DIFF
--- a/.github/workflows/behat.yml
+++ b/.github/workflows/behat.yml
@@ -25,6 +25,11 @@ on:
 permissions:
   contents: read
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   behat:
     uses: automattic/wpvip-plugins-.github/.github/workflows/reusable-behat-test.yml@trunk

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,6 +12,11 @@ on:
 permissions:
   contents: read
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: Build JS assets

--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -13,6 +13,11 @@ on:
 permissions:
   contents: read
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   checkcs:
     name: "Basic CS and QA checks"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,11 @@ on:
 # Workflow-level permissions set to none; jobs declare their own minimal permissions
 permissions: {}
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   release:
     name: Deploy to WordPress.org

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -7,6 +7,11 @@ on:
 permissions:
   contents: read
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: WP ${{ matrix.wordpress }} on PHP ${{ matrix.php }}

--- a/.github/workflows/js-unit.yml
+++ b/.github/workflows/js-unit.yml
@@ -7,6 +7,11 @@ on:
 permissions:
   contents: read
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: JS Unit Tests

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,11 @@ on:
 permissions:
   contents: read
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: Run JS linting

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -7,6 +7,11 @@ on:
 permissions:
   contents: read
 
+# Cancels all previous workflow runs for the same branch that have not yet completed.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: PHP ${{ matrix.php }}


### PR DESCRIPTION
## Summary

- Adds concurrency settings to all GitHub Actions workflows to automatically cancel previous runs when new commits are pushed to the same branch

## Why

Prevents resource waste and potential conflicts by ensuring only the most recent workflow run proceeds. This optimisation was identified through zizmor security auditing.

## Test plan

- [ ] Verify workflows still trigger correctly on push/PR
- [ ] Push multiple commits in quick succession and confirm older runs are cancelled

🤖 Generated with [Claude Code](https://claude.com/claude-code)