### PR TITLE
feat: add keyboard shortcuts and auto-focus for entry publishing

### DIFF
--- a/src/react/Editor/LexicalEditor.js
+++ b/src/react/Editor/LexicalEditor.js
@@ -19,6 +19,7 @@ import { useLexicalComposerContext } from '@lexical/react/LexicalComposerContext
 import { LexicalErrorBoundary } from '@lexical/react/LexicalErrorBoundary';
 import { LinkPlugin } from '@lexical/react/LexicalLinkPlugin';
 import { ListPlugin } from '@lexical/react/LexicalListPlugin';
+import { AutoFocusPlugin } from '@lexical/react/LexicalAutoFocusPlugin';
 
 import { HeadingNode, QuoteNode, $isQuoteNode, $createQuoteNode } from '@lexical/rich-text';
 import { ListNode, ListItemNode } from '@lexical/list';
@@ -1359,6 +1360,7 @@ const LexicalEditor = ( {
 					/>
 				</div>
 				<HistoryPlugin />
+				<AutoFocusPlugin />
 				<LinkPlugin />
 				<ListPlugin />
 				<ImagePlugin handleImageUpload={ handleImageUpload } />

--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -77,6 +77,19 @@ class EditorContainer extends Component {
     }));
   }
 
+  /**
+   * Handle keyboard shortcuts.
+   *
+   * @param {KeyboardEvent} event - The keyboard event.
+   */
+  handleKeyDown(event) {
+    // Ctrl+Enter (Windows/Linux) or Cmd+Enter (Mac) to publish
+    if ((event.ctrlKey || event.metaKey) && event.key === 'Enter') {
+      event.preventDefault();
+      this.publish();
+    }
+  }
+
   publish() {
     const { updateEntry, entry, entryEditClose, createEntry, isEditing } = this.props;
     const { authors, editorContent } = this.state;
@@ -251,7 +264,7 @@ class EditorContainer extends Component {
     const { isEditing, config } = this.props;
 
     return (
-      <div className="liveblog-editor-container">
+      <div className="liveblog-editor-container" onKeyDown={this.handleKeyDown.bind(this)}>
         {!isEditing && <h1 className="liveblog-editor-title">{ __( 'Add New Entry', 'liveblog' ) }</h1>}
         <div className="liveblog-editor-tabs">
           <button

--- a/src/react/index.js
+++ b/src/react/index.js
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase, no-undef */
 // Set webpack public path BEFORE any imports that might trigger dynamic chunk loading
-__webpack_public_path__ = `${window.liveblog_settings.plugin_dir}assets/`;
+__webpack_public_path__ = `${window.liveblog_settings.plugin_dir}build/`;
 
 import React from 'react';
 import { createRoot } from 'react-dom/client';


### PR DESCRIPTION
## Problem

Issue #181 identified the need for keyboard shortcuts to improve the efficiency of the liveblog entry creation workflow. Users had to rely solely on mouse clicks to publish entries, which slowed down the process during live events when speed is crucial. Additionally, after publishing an entry, the editor did not automatically refocus, requiring manual interaction to begin the next entry.

Furthermore, there was a webpack configuration issue where the public path was incorrectly set to `assets/` instead of `build/`, causing dynamic chunk loading failures in production environments.

## Solution

This PR introduces three key improvements to address these issues:

**Keyboard Shortcut for Publishing**
Added a keyboard event handler in `EditorContainer.js` that listens for Ctrl+Enter (Windows/Linux) or Cmd+Enter (Mac) to publish entries. This follows common editor conventions and allows users to publish without leaving the keyboard, significantly speeding up the workflow during live events.

**Automatic Editor Focus**
Integrated Lexical's `AutoFocusPlugin` into the editor configuration. This ensures that after publishing an entry, the editor automatically receives focus, allowing users to immediately start typing the next entry without any manual interaction. This creates a seamless, uninterrupted workflow.

**Webpack Public Path Correction**
Corrected the webpack public path from `assets/` to `build/` in `src/react/index.js`. This fixes chunk loading failures that occurred when webpack attempted to dynamically load split bundles, ensuring proper asset resolution in production environments.

These changes work together to create a more efficient, keyboard-driven workflow that reduces friction during live blogging sessions.

Fixes #181