### PR TITLE
fix: improve accessibility and UX for editor and author selection

### DIFF
--- a/src/react/Editor/LexicalEditor.js
+++ b/src/react/Editor/LexicalEditor.js
@@ -1349,7 +1349,10 @@ const LexicalEditor = ( {
 				<div className="liveblog-lexical-editor-inner">
 					<RichTextPlugin
 						contentEditable={
-							<ContentEditable className="liveblog-lexical-content-editable" />
+							<ContentEditable
+								className="liveblog-lexical-content-editable"
+								aria-label={ __( 'Liveblog entry content', 'liveblog' ) }
+							/>
 						}
 						placeholder={
 							<div className="liveblog-lexical-placeholder">

--- a/src/react/components/AuthorSelectOption.js
+++ b/src/react/components/AuthorSelectOption.js
@@ -1,57 +1,42 @@
-import React, { Component } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 
-class AuthorSelectOption extends Component {
-  handleMouseDown(event) {
-    const { onSelect, option, data, selectOption } = this.props;
-    const item = data || option;
-    event.preventDefault();
-    event.stopPropagation();
-    // react-select v5 uses selectOption instead of onSelect
-    if (selectOption) {
-      selectOption(item);
-    } else if (onSelect) {
-      onSelect(item, event);
-    }
-  }
-
-  handleMouseEnter(event) {
-    const { onFocus, option, data } = this.props;
-    const item = data || option;
-    if (onFocus) onFocus(item, event);
-  }
-
-  handleMouseMove(event) {
-    const { isFocused, onFocus, option, data } = this.props;
-    if (isFocused) return;
-    const item = data || option;
-    if (onFocus) onFocus(item, event);
-  }
-
-  render() {
-    const { className, option, data } = this.props;
-    // react-select v5 uses 'data' prop instead of 'option'
-    const item = data || option || {};
+/**
+ * Custom Option component for react-select author picker.
+ * Must spread innerProps and use innerRef for keyboard navigation to work.
+ */
+const AuthorSelectOption = ({ innerRef, innerProps, data, isFocused, isSelected, isDisabled }) => {
+  // Render hint option differently
+  if (data.isHint) {
     return (
       <div
-        className={`${className} liveblog-popover-item`}
-        onMouseDown={this.handleMouseDown.bind(this)}
-        onMouseEnter={this.handleMouseEnter.bind(this)}
-        onMouseMove={this.handleMouseMove.bind(this)}
+        ref={innerRef}
+        className="liveblog-popover-item liveblog-popover-hint"
       >
-        { item.avatar && <div dangerouslySetInnerHTML={{ __html: item.avatar }} /> }
-        {item.name}
+        {data.name}
       </div>
     );
   }
-}
+
+  return (
+    <div
+      ref={innerRef}
+      {...innerProps}
+      className={`liveblog-popover-item ${isFocused ? 'is-focused' : ''} ${isSelected ? 'is-selected' : ''} ${isDisabled ? 'is-disabled' : ''}`}
+    >
+      {data.avatar && <div dangerouslySetInnerHTML={{ __html: data.avatar }} />}
+      {data.name}
+    </div>
+  );
+};
 
 AuthorSelectOption.propTypes = {
-  onSelect: PropTypes.func,
-  option: PropTypes.object,
-  onFocus: PropTypes.func,
+  innerRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+  innerProps: PropTypes.object,
+  data: PropTypes.object,
   isFocused: PropTypes.bool,
-  className: PropTypes.string,
+  isSelected: PropTypes.bool,
+  isDisabled: PropTypes.bool,
 };
 
 export default AuthorSelectOption;

--- a/src/styles/core/editor/_lexical.scss
+++ b/src/styles/core/editor/_lexical.scss
@@ -38,7 +38,7 @@
 	padding: 12px;
 	min-height: 150px;
 	outline: none;
-	font-size: 14px;
+	font-size: 16px; // 16px minimum prevents iOS zoom on focus
 	line-height: 1.6;
 
 	&:focus {
@@ -50,9 +50,9 @@
 	position: absolute;
 	top: 12px;
 	left: 12px;
-	color: #999;
+	color: #767676; // WCAG AA compliant on white (4.54:1)
 	pointer-events: none;
-	font-size: 14px;
+	font-size: 16px; // Match editable area
 }
 
 // Text formatting classes (applied within editor)

--- a/src/styles/core/editor/_popover.scss
+++ b/src/styles/core/editor/_popover.scss
@@ -38,9 +38,20 @@
 }
 
 .liveblog-popover-item.is-focused {
-	background: $color-grey-x-light;
+	background: #e3f2fd; // Light blue for better focus visibility
 }
 
 .liveblog-popover-item-figure {
 	margin-right: 0.4rem;
+}
+
+// Hint option (e.g., "Type to search for more...")
+.liveblog-popover-hint {
+	color: #767676; // WCAG AA compliant
+	font-style: italic;
+	font-size: 0.75rem;
+	cursor: default;
+	border-top: 1px solid #eee;
+	margin-top: 0.2rem;
+	padding-top: 0.5rem;
 }

--- a/src/styles/core/editor/_select.scss
+++ b/src/styles/core/editor/_select.scss
@@ -1,57 +1,124 @@
-@use "../utils" as *;
+// React-select v5 styles for Liveblog
+// Uses classNamePrefix="liveblog-select"
 
-.Select:not(:last-child) {
-	margin-bottom: 1rem;
+.liveblog-select__control {
+	border-radius: 4px;
+	border-color: #bbb;
+	min-height: 38px;
+
+	&:hover {
+		border-color: #999;
+	}
+
+	&--is-focused {
+		border-color: #007cba;
+		box-shadow: 0 0 0 1px #007cba;
+
+		&:hover {
+			border-color: #007cba;
+		}
+	}
 }
 
-.Select.is-focused:not(.is-open) > .Select-control {
-	border-color: $color-grey-light;
-	box-shadow: none;
+// Placeholder text - WCAG AA compliant (4.54:1 on white)
+.liveblog-select__placeholder {
+	color: #767676;
+	font-size: 16px; // 16px minimum prevents iOS zoom on focus
 }
 
-.Select-control {
-	border-radius: $base-border-radius;
-	border-color: $color-grey-light;
+// Selected author tags
+.liveblog-select__multi-value {
+	background: #e0e0e0;
+	border-radius: 3px;
 }
 
-.Select-control:hover {
-	box-shadow: none;
-	border-radius: $base-border-radius;
-	border-color: $color-grey-light;
+.liveblog-select__multi-value__label {
+	color: #333;
+	padding: 3px 6px;
+	font-size: 0.9em;
 }
 
-.Select--multi .Select-value {
-	border-color: $color-grey-mid;
-	background: $color-grey-mid-light;
-	color: $color-grey-dark;
+.liveblog-select__multi-value__remove {
+	cursor: pointer;
+	padding: 0 4px;
+	display: flex;
+	align-items: center;
+
+	// SVG icon inherits color
+	svg {
+		fill: #666;
+		width: 14px;
+		height: 14px;
+	}
+
+	&:hover {
+		background: #c00;
+
+		svg {
+			fill: #fff;
+		}
+	}
 }
 
-.Select-value-label {
-	color: $color-grey-dark;
-	line-height: 1;
+// Input field - 16px minimum prevents iOS zoom on focus
+.liveblog-select__input-container {
+	color: #333;
+	font-size: 16px;
 }
 
-.Select--multi .Select-value-icon {
-	padding: 0;
-	padding-left: 5px;
-	padding-right: 5px;
-	vertical-align: middle;
-	color: $color-grey-dark;
-	border-color: $color-grey-mid;
-	background: transparent;
-	transition: color 0.2s ease-in-out;
+.liveblog-select__single-value {
+	font-size: 16px;
 }
 
-.Select--multi .Select-value-icon:hover {
-	background: transparent;
-	color: $color-warning;
-	transition: color 0.2s ease-in-out;
+// Dropdown menu
+.liveblog-select__menu {
+	border-radius: 4px;
+	box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+	z-index: 100;
 }
 
-.Select-menu-outer {
-	width: calc(100% - 1px);
+// "No options" / "Type to search" message - WCAG AA compliant
+.liveblog-select__menu-notice {
+	color: #767676;
+	padding: 8px 12px;
+	text-align: center;
 }
 
-.Select-option .is-selected .is-focused {
-	background-color: $color-grey-x-light;
+// Individual option styling (fallback, custom component used)
+.liveblog-select__option {
+	cursor: pointer;
+	padding: 8px 12px;
+
+	&--is-focused {
+		background: #e3f2fd;
+	}
+
+	&--is-selected {
+		background: #007cba;
+		color: #fff;
+	}
+}
+
+// Clear indicator (if enabled in future)
+.liveblog-select__clear-indicator {
+	color: #999;
+	cursor: pointer;
+
+	&:hover {
+		color: #c00;
+	}
+}
+
+// Dropdown indicator
+.liveblog-select__dropdown-indicator {
+	color: #767676;
+
+	&:hover {
+		color: #333;
+	}
+}
+
+// Loading indicator
+.liveblog-select__loading-indicator {
+	color: #007cba;
 }


### PR DESCRIPTION
## Summary

- Fix WCAG AA contrast issues for placeholder text (`#767676`, 4.54:1 ratio)
- Increase input font size to 16px to prevent iOS zoom on focus
- Add `aria-label` attributes to Lexical editor and Authors select
- Improve author selection keyboard navigation (react-select v5 compatibility)
- Pre-load first 10 authors when dropdown opens for better discoverability

## Changes

### Accessibility
- Placeholder contrast: `#999` → `#767676` (passes WCAG AA)
- Font size: 14px → 16px (prevents iOS Safari zoom)
- Added `aria-label="Liveblog entry content"` to editor
- Added `aria-label="Entry authors"` to author select
- Focus highlight: `#f7f7f7` → `#e3f2fd` (visible light blue)

### Author Selection UX
- Pre-loads first 10 authors on dropdown open (`defaultOptions={true}`)
- Shows "Type to search for more authors…" hint when more available
- Contextual messages: "Loading authors…" / "No authors matched"
- Fixed keyboard navigation by using `innerRef` and `innerProps` in custom Option component

### Technical
- Added `classNamePrefix="liveblog-select"` for CSS targeting
- Rewrote `_select.scss` for react-select v5 class names
- Fixed SVG icon styling for remove button (uses `fill` not `color`)

## Test plan

- [ ] Verify placeholder text is readable (not too light)
- [ ] Test on iOS Safari - inputs should not zoom when focused
- [ ] Test keyboard navigation in author dropdown (arrow keys, enter)
- [ ] Verify author dropdown shows initial list when opened
- [ ] Screen reader test: editor and author select should announce labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)