### PR TITLE
chore: remove redundant SVN installation step from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,11 +40,6 @@ jobs:
       - name: Build assets
         run: npm run build
 
-      - name: Install SVN
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y subversion
-
       - name: Deploy to WordPress.org
         uses: 10up/action-wordpress-plugin-deploy@54bd289b8525fd23a5c365ec369185f2966529c2 # v2.3.0
         with:


### PR DESCRIPTION
## Summary

The 10up/action-wordpress-plugin-deploy action (v2.3.0) automatically checks for SVN availability and installs it if needed, making the explicit installation step in our workflow unnecessary.

This removes the redundancy and slightly improves workflow execution time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)