### PR TITLE
feat: add key event checkbox UI with backward compatible /key handling

### DIFF
--- a/src/react/containers/EditorContainer.js
+++ b/src/react/containers/EditorContainer.js
@@ -35,16 +35,79 @@ class EditorContainer extends Component {
       ? props.entry.authors
       : [];
 
+    // Get entry content for editing, stripping /key command since checkbox handles it
+    const rawEntryContent = props.entry ? props.entry.content : '';
+    const entryContent = this.stripKeyCommand(rawEntryContent);
+
+    // Check if entry is a key event:
+    // 1. First check the key_event property from PHP (based on meta)
+    // 2. Fall back to checking if /key exists in content (for old entries without meta)
+    const hasKeyEventMeta = props.entry ? props.entry.key_event : false;
+    const hasKeyInContent = this.hasKeyCommand(rawEntryContent);
+    const isKeyEvent = hasKeyEventMeta || hasKeyInContent;
+
     this.state = {
       suggestions: [],
       authors: initialAuthors,
       mode: 'editor',
       readOnly: false,
-      rawText: props.entry ? props.entry.content : '',
+      rawText: entryContent,
       previewKey: 0,
-      // Store the HTML content for the editor
-      editorContent: props.entry ? props.entry.content : '',
+      // Store the HTML content for the editor (with /key stripped)
+      editorContent: entryContent,
+      // Key event checkbox state - synced with key_event meta or /key in content
+      isKeyEvent: isKeyEvent,
+      // Track if entry was originally a key event (for save logic)
+      wasOriginallyKeyEvent: isKeyEvent,
     };
+  }
+
+  /**
+   * Check if content contains the /key command in any form.
+   *
+   * @param {string} content - The content to check.
+   * @returns {boolean} True if /key command is present.
+   */
+  hasKeyCommand(content) {
+    if (!content) return false;
+    // Check for /key at start of content or after non-word character
+    const hasPlainKey = /(^|[^\w])\/key([^\w]|$)/i.test(content);
+    // Check for transformed span version
+    const hasSpanKey = /<span[^>]*class="liveblog-command[^"]*type-key"[^>]*>/i.test(content);
+    return hasPlainKey || hasSpanKey;
+  }
+
+  /**
+   * Strip /key command from content for display in editor.
+   * The checkbox handles key event status, so we hide the command.
+   *
+   * @param {string} content - The content to process.
+   * @returns {string} Content with /key command removed.
+   */
+  stripKeyCommand(content) {
+    if (!content) return '';
+
+    let processed = content;
+
+    // Remove /key when it's inside a paragraph (with optional br): <p>/key</p> or <p>/key<br></p>
+    processed = processed.replace(/<p[^>]*>\s*\/key\s*(<br\s*\/?>)?\s*<\/p>\s*/gi, '');
+
+    // Remove transformed span version (entire span element with optional trailing whitespace/br)
+    processed = processed.replace(/<span[^>]*class="liveblog-command[^"]*type-key"[^>]*>[^<]*<\/span>[\s\n]*/gi, '');
+
+    // Remove /key at the start of content (with optional trailing whitespace/br)
+    processed = processed.replace(/^\/key[\s\n]*(<br\s*\/?>[\s\n]*)*/i, '');
+
+    // Remove /key after HTML tags (e.g., after <p> or >)
+    processed = processed.replace(/(>)\s*\/key[\s\n]*(<br\s*\/?>[\s\n]*)*/gi, '$1');
+
+    // Clean up empty paragraphs (including those with just <br>)
+    processed = processed.replace(/<p[^>]*>\s*(<br\s*\/?>)?\s*<\/p>\s*/gi, '');
+
+    // Clean up leading <br> tags
+    processed = processed.replace(/^[\s\n]*(<br\s*\/?>[\s\n]*)+/gi, '');
+
+    return processed.trim();
   }
 
   setReadOnly(state) {
@@ -93,10 +156,49 @@ class EditorContainer extends Component {
     }
   }
 
+  /**
+   * Process content to add or remove /key command based on checkbox state.
+   *
+   * Logic:
+   * - If checkbox is checked: ensure /key is in content (add if missing)
+   * - If checkbox is unchecked AND entry was originally a key event: strip /key
+   * - If checkbox is unchecked AND entry was NOT originally a key event: preserve /key
+   *   (user manually typed it for backward compatibility)
+   *
+   * @param {string} content - The entry content.
+   * @param {boolean} isKeyEvent - Whether the key event checkbox is checked.
+   * @returns {string} The processed content.
+   */
+  processKeyEventContent(content, isKeyEvent) {
+    const hasKey = this.hasKeyCommand(content);
+    const { wasOriginallyKeyEvent } = this.state;
+
+    if (isKeyEvent) {
+      // Checkbox is checked - ensure /key is in content
+      if (hasKey) {
+        // Already has /key (manually typed), keep as-is
+        return content;
+      }
+      // Add /key at the beginning
+      return '/key ' + content;
+    }
+
+    // Checkbox is unchecked
+    // Only strip /key if the entry WAS originally a key event
+    // (meaning we stripped /key on load and user explicitly unchecked)
+    // If entry was NOT originally a key event, preserve any /key user typed
+    if (hasKey && wasOriginallyKeyEvent) {
+      return this.stripKeyCommand(content);
+    }
+
+    // Return content as-is (preserves manually typed /key)
+    return content;
+  }
+
   publish() {
     const { updateEntry, entry, entryEditClose, createEntry, isEditing } = this.props;
-    const { authors, editorContent } = this.state;
-    const content = this.getContent();
+    const { authors, editorContent, isKeyEvent } = this.state;
+    let content = this.getContent();
     const authorIds = authors.map(author => author.id);
     const author = authorIds.length > 0 ? authorIds[0] : false;
     const contributors = authorIds.length > 1 ? authorIds.slice(1, authorIds.length) : false;
@@ -110,6 +212,9 @@ class EditorContainer extends Component {
     if (!textContent && htmlregex.exec(editorContent) === null) {
       return;
     }
+
+    // Process /key command based on checkbox state
+    content = this.processKeyEventContent(content, isKeyEvent);
 
     if (isEditing) {
       updateEntry({
@@ -134,6 +239,7 @@ class EditorContainer extends Component {
       rawText: '',
       readOnly: false,
       previewKey: prevState.previewKey + 1,
+      isKeyEvent: false,
     }));
   }
 
@@ -275,6 +381,7 @@ class EditorContainer extends Component {
       authors,
       readOnly,
       previewKey,
+      isKeyEvent,
     } = this.state;
 
     const { isEditing, config } = this.props;
@@ -302,6 +409,16 @@ class EditorContainer extends Component {
               inputValue ? __( 'No authors matched', 'liveblog' ) : __( 'Loading authors…', 'liveblog' )
             }
           />
+        </div>
+        <div className="liveblog-editor-key-event">
+          <label>
+            <input
+              type="checkbox"
+              checked={isKeyEvent}
+              onChange={(e) => this.setState({ isKeyEvent: e.target.checked })}
+            />
+            { __( 'Key Event', 'liveblog' ) }
+          </label>
         </div>
         <div className="liveblog-editor-tabs">
           <button

--- a/src/react/containers/__tests__/EditorContainer.keyEvents.test.js
+++ b/src/react/containers/__tests__/EditorContainer.keyEvents.test.js
@@ -1,0 +1,264 @@
+/**
+ * Tests for key event detection and processing in EditorContainer.
+ *
+ * These tests cover the /key command handling logic:
+ * - hasKeyCommand: Detects /key in content
+ * - stripKeyCommand: Removes /key from content
+ * - processKeyEventContent: Adds/removes /key based on checkbox state
+ */
+
+// Extract the regex patterns and logic for testing
+// These match the patterns in EditorContainer.js
+
+/**
+ * Check if content contains the /key command in any form.
+ */
+const hasKeyCommand = (content) => {
+  if (!content) return false;
+  // Check for /key at start of content or after non-word character
+  const hasPlainKey = /(^|[^\w])\/key([^\w]|$)/i.test(content);
+  // Check for transformed span version
+  const hasSpanKey = /<span[^>]*class="liveblog-command[^"]*type-key"[^>]*>/i.test(content);
+  return hasPlainKey || hasSpanKey;
+};
+
+/**
+ * Strip /key command from content for display in editor.
+ */
+const stripKeyCommand = (content) => {
+  if (!content) return '';
+
+  let processed = content;
+
+  // Remove /key when it's inside a paragraph (with optional br): <p>/key</p> or <p>/key<br></p>
+  processed = processed.replace(/<p[^>]*>\s*\/key\s*(<br\s*\/?>)?\s*<\/p>\s*/gi, '');
+
+  // Remove transformed span version (entire span element with optional trailing whitespace/br)
+  processed = processed.replace(/<span[^>]*class="liveblog-command[^"]*type-key"[^>]*>[^<]*<\/span>[\s\n]*/gi, '');
+
+  // Remove /key at the start of content (with optional trailing whitespace/br)
+  processed = processed.replace(/^\/key[\s\n]*(<br\s*\/?>[\s\n]*)*/i, '');
+
+  // Remove /key after HTML tags (e.g., after <p> or >)
+  processed = processed.replace(/(>)\s*\/key[\s\n]*(<br\s*\/?>[\s\n]*)*/gi, '$1');
+
+  // Clean up empty paragraphs (including those with just <br>)
+  processed = processed.replace(/<p[^>]*>\s*(<br\s*\/?>)?\s*<\/p>\s*/gi, '');
+
+  // Clean up leading <br> tags
+  processed = processed.replace(/^[\s\n]*(<br\s*\/?>[\s\n]*)+/gi, '');
+
+  return processed.trim();
+};
+
+/**
+ * Process content to add or remove /key command based on checkbox state.
+ */
+const processKeyEventContent = (content, isKeyEvent, wasOriginallyKeyEvent) => {
+  const hasKey = hasKeyCommand(content);
+
+  if (isKeyEvent) {
+    // Checkbox is checked - ensure /key is in content
+    if (hasKey) {
+      // Already has /key (manually typed), keep as-is
+      return content;
+    }
+    // Add /key at the beginning
+    return '/key ' + content;
+  }
+
+  // Checkbox is unchecked
+  // Only strip /key if the entry WAS originally a key event
+  if (hasKey && wasOriginallyKeyEvent) {
+    return stripKeyCommand(content);
+  }
+
+  // Return content as-is (preserves manually typed /key)
+  return content;
+};
+
+describe('hasKeyCommand', () => {
+  describe('plain /key detection', () => {
+    it('should detect /key at the start of content', () => {
+      expect(hasKeyCommand('/key some text')).toBe(true);
+    });
+
+    it('should detect /key after HTML tag', () => {
+      expect(hasKeyCommand('<p>/key some text</p>')).toBe(true);
+    });
+
+    it('should detect /key with newline after', () => {
+      expect(hasKeyCommand('/key\nsome text')).toBe(true);
+    });
+
+    it('should detect /key followed by space', () => {
+      expect(hasKeyCommand('/key breaking news')).toBe(true);
+    });
+
+    it('should not detect /key as part of another word', () => {
+      expect(hasKeyCommand('/keyboard')).toBe(false);
+    });
+
+    it('should not detect /key preceded by word character', () => {
+      expect(hasKeyCommand('my/key')).toBe(false);
+    });
+
+    it('should detect /key at end of content', () => {
+      expect(hasKeyCommand('some text /key')).toBe(true);
+    });
+  });
+
+  describe('span version detection', () => {
+    it('should detect transformed span with type-key class', () => {
+      expect(hasKeyCommand('<span class="liveblog-command type-key">key</span> text')).toBe(true);
+    });
+
+    it('should detect span with type-key at end of class', () => {
+      // The regex expects class="liveblog-command...type-key" pattern (type-key before closing quote)
+      expect(hasKeyCommand('<span class="liveblog-command foo type-key">key</span>')).toBe(true);
+    });
+
+    it('should not detect span without type-key class', () => {
+      expect(hasKeyCommand('<span class="liveblog-command type-other">other</span>')).toBe(false);
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return false for empty content', () => {
+      expect(hasKeyCommand('')).toBe(false);
+    });
+
+    it('should return false for null content', () => {
+      expect(hasKeyCommand(null)).toBe(false);
+    });
+
+    it('should return false for undefined content', () => {
+      expect(hasKeyCommand(undefined)).toBe(false);
+    });
+
+    it('should return false for content without /key', () => {
+      expect(hasKeyCommand('<p>Regular content here</p>')).toBe(false);
+    });
+  });
+});
+
+describe('stripKeyCommand', () => {
+  describe('plain /key removal', () => {
+    it('should remove /key at the start of content', () => {
+      expect(stripKeyCommand('/key some text')).toBe('some text');
+    });
+
+    it('should remove /key from inside paragraph', () => {
+      expect(stripKeyCommand('<p>/key</p><p>content</p>')).toBe('<p>content</p>');
+    });
+
+    it('should remove /key after HTML tag', () => {
+      expect(stripKeyCommand('<p>/key some text</p>')).toBe('<p>some text</p>');
+    });
+
+    it('should remove /key with trailing whitespace', () => {
+      expect(stripKeyCommand('/key   text')).toBe('text');
+    });
+  });
+
+  describe('span version removal', () => {
+    it('should remove transformed span', () => {
+      const input = '<span class="liveblog-command type-key">key</span> some text';
+      expect(stripKeyCommand(input)).toBe('some text');
+    });
+
+    it('should remove span with trailing whitespace', () => {
+      const input = '<span class="liveblog-command type-key">key</span>   text';
+      expect(stripKeyCommand(input)).toBe('text');
+    });
+  });
+
+  describe('cleanup', () => {
+    it('should remove empty paragraphs', () => {
+      expect(stripKeyCommand('<p></p><p>content</p>')).toBe('<p>content</p>');
+    });
+
+    it('should remove paragraphs with only br', () => {
+      expect(stripKeyCommand('<p><br></p><p>content</p>')).toBe('<p>content</p>');
+    });
+
+    it('should trim result', () => {
+      // Note: /key preceded by spaces is not stripped (not at start or after >)
+      // Only the final result is trimmed
+      expect(stripKeyCommand('/key text  ')).toBe('text');
+    });
+  });
+
+  describe('edge cases', () => {
+    it('should return empty string for empty content', () => {
+      expect(stripKeyCommand('')).toBe('');
+    });
+
+    it('should return empty string for null content', () => {
+      expect(stripKeyCommand(null)).toBe('');
+    });
+
+    it('should preserve content without /key', () => {
+      expect(stripKeyCommand('<p>Regular content</p>')).toBe('<p>Regular content</p>');
+    });
+  });
+});
+
+describe('processKeyEventContent', () => {
+  describe('checkbox checked (isKeyEvent = true)', () => {
+    it('should add /key when content does not have it', () => {
+      const result = processKeyEventContent('<p>some text</p>', true, false);
+      expect(result).toBe('/key <p>some text</p>');
+    });
+
+    it('should preserve existing /key when content already has it', () => {
+      const result = processKeyEventContent('/key some text', true, false);
+      expect(result).toBe('/key some text');
+    });
+
+    it('should preserve existing span when content has transformed version', () => {
+      const input = '<span class="liveblog-command type-key">key</span> text';
+      const result = processKeyEventContent(input, true, false);
+      expect(result).toBe(input);
+    });
+  });
+
+  describe('checkbox unchecked (isKeyEvent = false)', () => {
+    describe('entry was originally a key event', () => {
+      it('should strip /key when unchecking existing key event', () => {
+        const result = processKeyEventContent('/key some text', false, true);
+        expect(result).toBe('some text');
+      });
+
+      it('should strip span when unchecking existing key event', () => {
+        const input = '<span class="liveblog-command type-key">key</span> text';
+        const result = processKeyEventContent(input, false, true);
+        expect(result).toBe('text');
+      });
+    });
+
+    describe('entry was NOT originally a key event', () => {
+      it('should preserve manually typed /key in new entry', () => {
+        const result = processKeyEventContent('/key some text', false, false);
+        expect(result).toBe('/key some text');
+      });
+
+      it('should preserve manually typed /key when editing non-key entry', () => {
+        const result = processKeyEventContent('<p>/key some text</p>', false, false);
+        expect(result).toBe('<p>/key some text</p>');
+      });
+    });
+
+    describe('no /key in content', () => {
+      it('should return content as-is when no /key present', () => {
+        const result = processKeyEventContent('<p>regular text</p>', false, false);
+        expect(result).toBe('<p>regular text</p>');
+      });
+
+      it('should return content as-is when was key event but no /key now', () => {
+        const result = processKeyEventContent('<p>regular text</p>', false, true);
+        expect(result).toBe('<p>regular text</p>');
+      });
+    });
+  });
+});

--- a/src/styles/core/app/_theme.scss
+++ b/src/styles/core/app/_theme.scss
@@ -19,6 +19,7 @@
 }
 
 @keyframes liveblog-highlight {
+
 	0% {
 		background-color: rgba(33, 150, 243, 0.15);
 		border-color: $color-accent;

--- a/src/styles/core/editor/_container.scss
+++ b/src/styles/core/editor/_container.scss
@@ -74,6 +74,27 @@
 	margin-bottom: 1rem;
 }
 
+.liveblog-editor-key-event {
+	margin-bottom: 1rem;
+
+	label {
+		display: flex;
+		align-items: center;
+		gap: 0.5rem;
+		font-size: 0.9rem;
+		font-weight: 500;
+		color: $color-grey-dark;
+		cursor: pointer;
+	}
+
+	input[type="checkbox"] {
+		width: 1rem;
+		height: 1rem;
+		margin: 0;
+		cursor: pointer;
+	}
+}
+
 @include mq($until: small) {
 
 	.liveblog-editor-container .public-DraftEditor-content {

--- a/tests/Integration/EntryKeyEventsTest.php
+++ b/tests/Integration/EntryKeyEventsTest.php
@@ -49,8 +49,8 @@ final class EntryKeyEventsTest extends TestCase {
 	public function test_render_key_template_sets_key_event_true_for_plain_key_command(): void {
 		$entry = $this->insert_entry( array( 'content' => 'Breaking news! /key' ) );
 
-		$entry_data   = array( 'id' => $entry->get_id() );
-		$result       = WPCOM_Liveblog_Entry_Key_Events::render_key_template( $entry_data, $entry );
+		$entry_data = array( 'id' => $entry->get_id() );
+		$result     = WPCOM_Liveblog_Entry_Key_Events::render_key_template( $entry_data, $entry );
 
 		$this->assertTrue( $result['key_event'] );
 	}

--- a/tests/Integration/EntryKeyEventsTest.php
+++ b/tests/Integration/EntryKeyEventsTest.php
@@ -1,0 +1,311 @@
+<?php
+/**
+ * Tests for the WPCOM_Liveblog_Entry_Key_Events class.
+ *
+ * @package Automattic\Liveblog\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Tests\Integration;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+use WPCOM_Liveblog_Entry;
+use WPCOM_Liveblog_Entry_Key_Events;
+
+/**
+ * Entry Key Events test case.
+ *
+ * Tests the key event detection and meta sync functionality.
+ */
+final class EntryKeyEventsTest extends TestCase {
+
+	/**
+	 * Test post ID.
+	 *
+	 * @var int
+	 */
+	private int $post_id;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function setUp(): void {
+		parent::setUp();
+		$this->post_id = self::factory()->post->create();
+	}
+
+	/**
+	 * Tear down test fixtures.
+	 */
+	protected function tearDown(): void {
+		wp_delete_post( $this->post_id, true );
+		parent::tearDown();
+	}
+
+	/**
+	 * Test render_key_template sets key_event true when content contains plain /key command.
+	 */
+	public function test_render_key_template_sets_key_event_true_for_plain_key_command(): void {
+		$entry = $this->insert_entry( array( 'content' => 'Breaking news! /key' ) );
+
+		$entry_data   = array( 'id' => $entry->get_id() );
+		$result       = WPCOM_Liveblog_Entry_Key_Events::render_key_template( $entry_data, $entry );
+
+		$this->assertTrue( $result['key_event'] );
+	}
+
+	/**
+	 * Test render_key_template sets key_event true when /key is at start of content.
+	 */
+	public function test_render_key_template_sets_key_event_true_for_key_at_start(): void {
+		$entry = $this->insert_entry( array( 'content' => '/key This is important' ) );
+
+		$entry_data = array( 'id' => $entry->get_id() );
+		$result     = WPCOM_Liveblog_Entry_Key_Events::render_key_template( $entry_data, $entry );
+
+		$this->assertTrue( $result['key_event'] );
+	}
+
+	/**
+	 * Test render_key_template sets key_event true when content contains transformed span.
+	 */
+	public function test_render_key_template_sets_key_event_true_for_transformed_span(): void {
+		$content = 'Important update <span class="liveblog-command type-key">key</span>';
+		$entry   = $this->insert_entry( array( 'content' => $content ) );
+
+		$entry_data = array( 'id' => $entry->get_id() );
+		$result     = WPCOM_Liveblog_Entry_Key_Events::render_key_template( $entry_data, $entry );
+
+		$this->assertTrue( $result['key_event'] );
+	}
+
+	/**
+	 * Test render_key_template sets key_event true for span with multiple classes.
+	 */
+	public function test_render_key_template_sets_key_event_true_for_span_with_multiple_classes(): void {
+		$content = '<span class="liveblog-command special type-key active">key</span> News';
+		$entry   = $this->insert_entry( array( 'content' => $content ) );
+
+		$entry_data = array( 'id' => $entry->get_id() );
+		$result     = WPCOM_Liveblog_Entry_Key_Events::render_key_template( $entry_data, $entry );
+
+		$this->assertTrue( $result['key_event'] );
+	}
+
+	/**
+	 * Test render_key_template sets key_event false when content has neither /key nor span.
+	 */
+	public function test_render_key_template_sets_key_event_false_when_no_key_command(): void {
+		$entry = $this->insert_entry( array( 'content' => 'Regular entry content without key command' ) );
+
+		$entry_data = array( 'id' => $entry->get_id() );
+		$result     = WPCOM_Liveblog_Entry_Key_Events::render_key_template( $entry_data, $entry );
+
+		$this->assertFalse( $result['key_event'] );
+	}
+
+	/**
+	 * Test render_key_template sets key_event false when /key is part of a word.
+	 */
+	public function test_render_key_template_sets_key_event_false_when_key_is_part_of_word(): void {
+		$entry = $this->insert_entry( array( 'content' => 'This is a keyboard test' ) );
+
+		$entry_data = array( 'id' => $entry->get_id() );
+		$result     = WPCOM_Liveblog_Entry_Key_Events::render_key_template( $entry_data, $entry );
+
+		$this->assertFalse( $result['key_event'] );
+	}
+
+	/**
+	 * Test render_key_template sets key_event false for /keyboard (key followed by word chars).
+	 */
+	public function test_render_key_template_sets_key_event_false_for_key_followed_by_word_chars(): void {
+		$entry = $this->insert_entry( array( 'content' => 'Check out /keyboard layout' ) );
+
+		$entry_data = array( 'id' => $entry->get_id() );
+		$result     = WPCOM_Liveblog_Entry_Key_Events::render_key_template( $entry_data, $entry );
+
+		$this->assertFalse( $result['key_event'] );
+	}
+
+	/**
+	 * Test sync_key_event_meta adds meta when content has /key and comment does not have meta.
+	 */
+	public function test_sync_key_event_meta_adds_meta_when_content_has_key_without_meta(): void {
+		$comment = self::factory()->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $this->post_id,
+				'comment_content'  => 'Important /key event',
+				'comment_approved' => 'liveblog',
+				'comment_type'     => 'liveblog',
+			)
+		);
+
+		// Verify no meta exists initially.
+		$this->assertFalse( WPCOM_Liveblog_Entry_Key_Events::is_key_event( $comment->comment_ID ) );
+
+		// Trigger the sync.
+		WPCOM_Liveblog_Entry_Key_Events::sync_key_event_meta( $comment->comment_ID, $this->post_id );
+
+		// Verify meta was added.
+		$this->assertTrue( WPCOM_Liveblog_Entry_Key_Events::is_key_event( $comment->comment_ID ) );
+	}
+
+	/**
+	 * Test sync_key_event_meta removes meta when content has no /key and comment has meta.
+	 */
+	public function test_sync_key_event_meta_removes_meta_when_content_lacks_key_but_has_meta(): void {
+		$comment = self::factory()->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $this->post_id,
+				'comment_content'  => 'Regular content without key command',
+				'comment_approved' => 'liveblog',
+				'comment_type'     => 'liveblog',
+			)
+		);
+
+		// Add meta manually to simulate existing key event.
+		add_comment_meta(
+			$comment->comment_ID,
+			WPCOM_Liveblog_Entry_Key_Events::META_KEY,
+			WPCOM_Liveblog_Entry_Key_Events::META_VALUE
+		);
+
+		// Verify meta exists.
+		$this->assertTrue( WPCOM_Liveblog_Entry_Key_Events::is_key_event( $comment->comment_ID ) );
+
+		// Trigger the sync.
+		WPCOM_Liveblog_Entry_Key_Events::sync_key_event_meta( $comment->comment_ID, $this->post_id );
+
+		// Verify meta was removed.
+		$this->assertFalse( WPCOM_Liveblog_Entry_Key_Events::is_key_event( $comment->comment_ID ) );
+	}
+
+	/**
+	 * Test sync_key_event_meta does nothing when content has /key and meta already exists.
+	 */
+	public function test_sync_key_event_meta_does_nothing_when_key_and_meta_both_exist(): void {
+		$comment = self::factory()->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $this->post_id,
+				'comment_content'  => 'Important /key event',
+				'comment_approved' => 'liveblog',
+				'comment_type'     => 'liveblog',
+			)
+		);
+
+		// Add meta manually.
+		add_comment_meta(
+			$comment->comment_ID,
+			WPCOM_Liveblog_Entry_Key_Events::META_KEY,
+			WPCOM_Liveblog_Entry_Key_Events::META_VALUE
+		);
+
+		// Trigger the sync.
+		WPCOM_Liveblog_Entry_Key_Events::sync_key_event_meta( $comment->comment_ID, $this->post_id );
+
+		// Verify meta still exists (not duplicated).
+		$this->assertTrue( WPCOM_Liveblog_Entry_Key_Events::is_key_event( $comment->comment_ID ) );
+		$meta_values = get_comment_meta( $comment->comment_ID, WPCOM_Liveblog_Entry_Key_Events::META_KEY, false );
+		$this->assertCount( 1, $meta_values, 'Meta should not be duplicated' );
+	}
+
+	/**
+	 * Test sync_key_event_meta does nothing when content lacks /key and meta does not exist.
+	 */
+	public function test_sync_key_event_meta_does_nothing_when_no_key_and_no_meta(): void {
+		$comment = self::factory()->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $this->post_id,
+				'comment_content'  => 'Regular content without key',
+				'comment_approved' => 'liveblog',
+				'comment_type'     => 'liveblog',
+			)
+		);
+
+		// Verify no meta exists.
+		$this->assertFalse( WPCOM_Liveblog_Entry_Key_Events::is_key_event( $comment->comment_ID ) );
+
+		// Trigger the sync.
+		WPCOM_Liveblog_Entry_Key_Events::sync_key_event_meta( $comment->comment_ID, $this->post_id );
+
+		// Verify still no meta.
+		$this->assertFalse( WPCOM_Liveblog_Entry_Key_Events::is_key_event( $comment->comment_ID ) );
+	}
+
+	/**
+	 * Test sync_key_event_meta handles transformed span content.
+	 */
+	public function test_sync_key_event_meta_adds_meta_for_transformed_span(): void {
+		$content = '<span class="liveblog-command type-key">key</span> Important update';
+		$comment = self::factory()->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $this->post_id,
+				'comment_content'  => $content,
+				'comment_approved' => 'liveblog',
+				'comment_type'     => 'liveblog',
+			)
+		);
+
+		// Trigger the sync.
+		WPCOM_Liveblog_Entry_Key_Events::sync_key_event_meta( $comment->comment_ID, $this->post_id );
+
+		// Verify meta was added.
+		$this->assertTrue( WPCOM_Liveblog_Entry_Key_Events::is_key_event( $comment->comment_ID ) );
+	}
+
+	/**
+	 * Test is_key_event returns true when meta exists with correct value.
+	 */
+	public function test_is_key_event_returns_true_when_meta_exists(): void {
+		$comment = self::factory()->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $this->post_id,
+				'comment_approved' => 'liveblog',
+				'comment_type'     => 'liveblog',
+			)
+		);
+
+		add_comment_meta(
+			$comment->comment_ID,
+			WPCOM_Liveblog_Entry_Key_Events::META_KEY,
+			WPCOM_Liveblog_Entry_Key_Events::META_VALUE
+		);
+
+		$this->assertTrue( WPCOM_Liveblog_Entry_Key_Events::is_key_event( $comment->comment_ID ) );
+	}
+
+	/**
+	 * Test is_key_event returns false when meta does not exist.
+	 */
+	public function test_is_key_event_returns_false_when_meta_absent(): void {
+		$comment = self::factory()->comment->create_and_get(
+			array(
+				'comment_post_ID'  => $this->post_id,
+				'comment_approved' => 'liveblog',
+				'comment_type'     => 'liveblog',
+			)
+		);
+
+		$this->assertFalse( WPCOM_Liveblog_Entry_Key_Events::is_key_event( $comment->comment_ID ) );
+	}
+
+	/**
+	 * Insert a liveblog entry.
+	 *
+	 * @param array $args Arguments for entry.
+	 * @return WPCOM_Liveblog_Entry
+	 */
+	private function insert_entry( array $args = array() ): WPCOM_Liveblog_Entry {
+		$user     = self::factory()->user->create_and_get();
+		$defaults = array(
+			'post_id' => $this->post_id,
+			'content' => 'Test content',
+			'user'    => $user,
+		);
+		$args     = array_merge( $defaults, $args );
+
+		return WPCOM_Liveblog_Entry::insert( $args );
+	}
+}


### PR DESCRIPTION
## Summary
Introduces a "Key Event" checkbox in the liveblog editor, providing a more intuitive way to mark entries as key events whilst maintaining full backward compatibility with the existing `/key` command workflow.

## How it works

### Checkbox behaviour
- **Checked** → `/key` is prepended to entry content on save
- **Unchecked** (on existing key event) → `/key` is stripped from content
- **Display** → `/key` is hidden in the editor; checkbox state shows key event status

### Backward compatibility
- **Manual `/key` typing preserved** → Users who prefer typing `/key` can continue doing so
- **Both formats detected** → Works with plain `/key` text and the transformed `<span class="liveblog-command type-key">` format from older plugin versions
- **Reliable on updates** → Content-based detection ensures accuracy even when WordPress creates new comment records for entry updates

https://github.com/user-attachments/assets/96cf033e-f9df-480c-8cdb-5adfef83a593

## Test plan
- [x] Create new entry with checkbox checked → should save with `/key` and show red border
- [x] Create new entry by typing `/key` manually → should work as before
- [x] Edit key event, uncheck checkbox → should remove `/key` and show blue border
- [x] Edit regular entry, check checkbox → should add `/key` and show red border
- [x] Edit regular entry, type `/key` manually → should preserve and become key event

## Test coverage
- **35 JavaScript unit tests** covering `hasKeyCommand`, `stripKeyCommand`, and `processKeyEventContent`
- **14 PHP integration tests** covering `render_key_template`, `sync_key_event_meta`, and `is_key_event`

🤖 Generated with [Claude Code](https://claude.ai/code)