### PR TITLE
feat: introduce repository pattern and application service layer

### DIFF
--- a/src/php/Application/Service/EntryService.php
+++ b/src/php/Application/Service/EntryService.php
@@ -1,0 +1,286 @@
+<?php
+/**
+ * Entry service for orchestrating entry operations.
+ *
+ * @package Automattic\Liveblog\Application\Service
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Application\Service;
+
+use Automattic\Liveblog\Domain\Repository\EntryRepositoryInterface;
+use Automattic\Liveblog\Domain\ValueObject\EntryId;
+use InvalidArgumentException;
+use RuntimeException;
+use WP_User;
+
+/**
+ * Application service for liveblog entry operations.
+ *
+ * This service orchestrates entry creation, updates, and deletion,
+ * using the repository for persistence. It encapsulates the business
+ * logic for entry operations while remaining agnostic to the storage
+ * mechanism.
+ */
+final class EntryService {
+
+	/**
+	 * Entry repository.
+	 *
+	 * @var EntryRepositoryInterface
+	 */
+	private EntryRepositoryInterface $repository;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param EntryRepositoryInterface $repository Entry repository.
+	 */
+	public function __construct( EntryRepositoryInterface $repository ) {
+		$this->repository = $repository;
+	}
+
+	/**
+	 * Create a new liveblog entry.
+	 *
+	 * @param int        $post_id   Post ID for the liveblog.
+	 * @param string     $content   Entry content.
+	 * @param WP_User    $author    Author user object.
+	 * @param bool       $hide_author Whether to hide the author.
+	 * @param array|null $contributor_ids Optional contributor user IDs.
+	 * @return EntryId The new entry's ID.
+	 * @throws InvalidArgumentException If required parameters are invalid.
+	 * @throws RuntimeException If entry creation fails.
+	 */
+	public function create(
+		int $post_id,
+		string $content,
+		WP_User $author,
+		bool $hide_author = false,
+		?array $contributor_ids = null
+	): EntryId {
+		$this->validate_post_id( $post_id );
+
+		$entry_id = $this->repository->insert(
+			array(
+				'post_id'      => $post_id,
+				'content'      => $content,
+				'user_id'      => $author->ID,
+				'author_name'  => $author->display_name,
+				'author_email' => $author->user_email,
+				'author_url'   => $author->user_url,
+			)
+		);
+
+		if ( $hide_author ) {
+			$this->repository->set_authors_hidden( $entry_id, true );
+		}
+
+		if ( ! empty( $contributor_ids ) ) {
+			$this->repository->set_contributors( $entry_id, $contributor_ids );
+		}
+
+		return $entry_id;
+	}
+
+	/**
+	 * Update an existing liveblog entry.
+	 *
+	 * Creates a new entry that replaces the original. The original entry
+	 * is also updated to store the new content (for audit purposes).
+	 *
+	 * @param int     $post_id     Post ID for the liveblog.
+	 * @param EntryId $entry_id    ID of the entry to update.
+	 * @param string  $content     New content.
+	 * @param WP_User $author      Author of the update (typically original author).
+	 * @return EntryId The new replacement entry's ID.
+	 * @throws InvalidArgumentException If entry not found or post ID is invalid.
+	 */
+	public function update(
+		int $post_id,
+		EntryId $entry_id,
+		string $content,
+		WP_User $author
+	): EntryId {
+		$this->validate_post_id( $post_id );
+
+		// Verify the original entry exists.
+		$original = $this->repository->find_by_id( $entry_id );
+		if ( ! $original ) {
+			throw new InvalidArgumentException( 'Entry not found' );
+		}
+
+		// Create the replacement entry.
+		$new_entry_id = $this->repository->insert(
+			array(
+				'post_id'      => $post_id,
+				'content'      => $content,
+				'user_id'      => $author->ID,
+				'author_name'  => $author->display_name,
+				'author_email' => $author->user_email,
+				'author_url'   => $author->user_url,
+			)
+		);
+
+		// Link the new entry to the original.
+		$this->repository->set_replaces_id( $new_entry_id, $entry_id );
+
+		// Update the original entry's content for audit trail.
+		$this->repository->update( $entry_id, array( 'content' => $content ) );
+
+		return $new_entry_id;
+	}
+
+	/**
+	 * Delete a liveblog entry.
+	 *
+	 * Creates a delete marker entry that replaces the original.
+	 * Also cleans up any orphaned update entries.
+	 *
+	 * @param int     $post_id  Post ID for the liveblog.
+	 * @param EntryId $entry_id ID of the entry to delete.
+	 * @param WP_User $author   Author performing the deletion.
+	 * @return EntryId The delete marker entry's ID.
+	 * @throws InvalidArgumentException If entry not found or post ID is invalid.
+	 */
+	public function delete(
+		int $post_id,
+		EntryId $entry_id,
+		WP_User $author
+	): EntryId {
+		$this->validate_post_id( $post_id );
+
+		// Verify the original entry exists.
+		$original = $this->repository->find_by_id( $entry_id );
+		if ( ! $original ) {
+			throw new InvalidArgumentException( 'Entry not found' );
+		}
+
+		// Create the delete marker (empty content).
+		$delete_marker_id = $this->repository->insert(
+			array(
+				'post_id'      => $post_id,
+				'content'      => '',
+				'user_id'      => $author->ID,
+				'author_name'  => $author->display_name,
+				'author_email' => $author->user_email,
+				'author_url'   => $author->user_url,
+			)
+		);
+
+		// Link the delete marker to the original.
+		$this->repository->set_replaces_id( $delete_marker_id, $entry_id );
+
+		// Clean up orphaned update entries.
+		$this->cleanup_orphaned_entries( $post_id, $entry_id, $delete_marker_id );
+
+		// Delete the original entry.
+		$this->repository->delete( $entry_id, false );
+
+		return $delete_marker_id;
+	}
+
+	/**
+	 * Update the author of an entry.
+	 *
+	 * @param EntryId      $entry_id  Entry ID.
+	 * @param WP_User|null $author    New author, or null to hide authors.
+	 * @return bool True on success.
+	 * @throws InvalidArgumentException If entry not found.
+	 */
+	public function update_author( EntryId $entry_id, ?WP_User $author ): bool {
+		$entry = $this->repository->find_by_id( $entry_id );
+		if ( ! $entry ) {
+			throw new InvalidArgumentException( 'Entry not found' );
+		}
+
+		if ( null === $author ) {
+			// Hide authors.
+			return $this->repository->set_authors_hidden( $entry_id, true );
+		}
+
+		// Update author info.
+		$this->repository->update(
+			$entry_id,
+			array(
+				'user_id'      => $author->ID,
+				'author_name'  => $author->display_name,
+				'author_email' => $author->user_email,
+				'author_url'   => $author->user_url,
+			)
+		);
+
+		// Show authors.
+		return $this->repository->set_authors_hidden( $entry_id, false );
+	}
+
+	/**
+	 * Add contributors to an entry.
+	 *
+	 * @param EntryId $entry_id       Entry ID.
+	 * @param int[]   $contributor_ids User IDs of contributors.
+	 * @return bool True on success.
+	 * @throws InvalidArgumentException If entry not found.
+	 */
+	public function set_contributors( EntryId $entry_id, array $contributor_ids ): bool {
+		$entry = $this->repository->find_by_id( $entry_id );
+		if ( ! $entry ) {
+			throw new InvalidArgumentException( 'Entry not found' );
+		}
+
+		return $this->repository->set_contributors( $entry_id, $contributor_ids );
+	}
+
+	/**
+	 * Get contributors for an entry.
+	 *
+	 * @param EntryId $entry_id Entry ID.
+	 * @return int[] Array of contributor user IDs.
+	 */
+	public function get_contributors( EntryId $entry_id ): array {
+		return $this->repository->get_contributors( $entry_id );
+	}
+
+	/**
+	 * Check if authors are hidden for an entry.
+	 *
+	 * @param EntryId $entry_id Entry ID.
+	 * @return bool True if authors are hidden.
+	 */
+	public function is_authors_hidden( EntryId $entry_id ): bool {
+		return $this->repository->is_authors_hidden( $entry_id );
+	}
+
+	/**
+	 * Clean up orphaned update entries.
+	 *
+	 * When an entry is deleted, any previous update entries that reference
+	 * it should also be removed.
+	 *
+	 * @param int     $post_id          Post ID.
+	 * @param EntryId $entry_id         Original entry ID.
+	 * @param EntryId $exclude_entry_id Entry ID to exclude (the delete marker).
+	 * @return void
+	 */
+	private function cleanup_orphaned_entries( int $post_id, EntryId $entry_id, EntryId $exclude_entry_id ): void {
+		$orphans = $this->repository->find_referencing_entries( $post_id, $entry_id, $exclude_entry_id );
+
+		foreach ( $orphans as $orphan ) {
+			$this->repository->delete( EntryId::from_int( (int) $orphan->comment_ID ), true );
+		}
+	}
+
+	/**
+	 * Validate post ID.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return void
+	 * @throws InvalidArgumentException If post ID is invalid.
+	 */
+	private function validate_post_id( int $post_id ): void {
+		if ( $post_id <= 0 ) {
+			throw new InvalidArgumentException( 'Invalid post ID' );
+		}
+	}
+}

--- a/src/php/Domain/Repository/EntryRepositoryInterface.php
+++ b/src/php/Domain/Repository/EntryRepositoryInterface.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Entry repository interface.
+ *
+ * @package Automattic\Liveblog\Domain\Repository
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Domain\Repository;
+
+use Automattic\Liveblog\Domain\ValueObject\EntryId;
+use WP_Comment;
+
+/**
+ * Defines the contract for liveblog entry persistence.
+ *
+ * This interface abstracts the storage mechanism for liveblog entries,
+ * allowing different implementations (comments, custom post types, etc.)
+ * while maintaining a consistent API.
+ */
+interface EntryRepositoryInterface {
+
+	/**
+	 * Find an entry by its ID.
+	 *
+	 * @param EntryId $id Entry ID.
+	 * @return WP_Comment|null The entry data or null if not found.
+	 */
+	public function find_by_id( EntryId $id ): ?WP_Comment;
+
+	/**
+	 * Find entries by post ID.
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param array $args    Optional query arguments.
+	 * @return WP_Comment[] Array of entries.
+	 */
+	public function find_by_post_id( int $post_id, array $args = array() ): array;
+
+	/**
+	 * Insert a new entry.
+	 *
+	 * @param array $data Entry data including post_id, content, author info.
+	 * @return EntryId The new entry's ID.
+	 * @throws \RuntimeException If insertion fails.
+	 */
+	public function insert( array $data ): EntryId;
+
+	/**
+	 * Update an existing entry.
+	 *
+	 * @param EntryId $id   Entry ID.
+	 * @param array   $data Data to update.
+	 * @return bool True on success.
+	 * @throws \RuntimeException If update fails.
+	 */
+	public function update( EntryId $id, array $data ): bool;
+
+	/**
+	 * Delete an entry.
+	 *
+	 * @param EntryId $id    Entry ID.
+	 * @param bool    $force Whether to force permanent deletion.
+	 * @return bool True on success.
+	 */
+	public function delete( EntryId $id, bool $force = false ): bool;
+
+	/**
+	 * Get the ID of the entry that this entry replaces.
+	 *
+	 * @param EntryId $id Entry ID.
+	 * @return EntryId|null The replaced entry ID or null.
+	 */
+	public function get_replaces_id( EntryId $id ): ?EntryId;
+
+	/**
+	 * Set the entry that this entry replaces.
+	 *
+	 * @param EntryId $id       Entry ID.
+	 * @param EntryId $replaces ID of the entry being replaced.
+	 * @return bool True on success.
+	 */
+	public function set_replaces_id( EntryId $id, EntryId $replaces ): bool;
+
+	/**
+	 * Find entries that reference a given entry as their replacement target.
+	 *
+	 * Used to find orphaned update/delete entries when cleaning up.
+	 *
+	 * @param int     $post_id  Post ID.
+	 * @param EntryId $entry_id Entry ID being replaced.
+	 * @param EntryId $exclude  Entry ID to exclude from results.
+	 * @return WP_Comment[] Array of referencing entries.
+	 */
+	public function find_referencing_entries( int $post_id, EntryId $entry_id, EntryId $exclude ): array;
+
+	/**
+	 * Get contributor user IDs for an entry.
+	 *
+	 * @param EntryId $id Entry ID.
+	 * @return int[] Array of user IDs.
+	 */
+	public function get_contributors( EntryId $id ): array;
+
+	/**
+	 * Set contributors for an entry.
+	 *
+	 * @param EntryId $id       Entry ID.
+	 * @param int[]   $user_ids Array of contributor user IDs.
+	 * @return bool True on success.
+	 */
+	public function set_contributors( EntryId $id, array $user_ids ): bool;
+
+	/**
+	 * Check if authors are hidden for an entry.
+	 *
+	 * @param EntryId $id Entry ID.
+	 * @return bool True if authors are hidden.
+	 */
+	public function is_authors_hidden( EntryId $id ): bool;
+
+	/**
+	 * Set whether authors are hidden for an entry.
+	 *
+	 * @param EntryId $id     Entry ID.
+	 * @param bool    $hidden Whether to hide authors.
+	 * @return bool True on success.
+	 */
+	public function set_authors_hidden( EntryId $id, bool $hidden ): bool;
+
+	/**
+	 * Invalidate any caches for entries belonging to a post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return void
+	 */
+	public function invalidate_cache( int $post_id ): void;
+}

--- a/src/php/Infrastructure/Repository/CommentEntryRepository.php
+++ b/src/php/Infrastructure/Repository/CommentEntryRepository.php
@@ -1,0 +1,356 @@
+<?php
+/**
+ * Comment-based entry repository implementation.
+ *
+ * @package Automattic\Liveblog\Infrastructure\Repository
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Infrastructure\Repository;
+
+use Automattic\Liveblog\Domain\Repository\EntryRepositoryInterface;
+use Automattic\Liveblog\Domain\ValueObject\EntryId;
+use RuntimeException;
+use WP_Comment;
+
+/**
+ * Repository implementation using WordPress comments as storage.
+ *
+ * This is the default implementation for liveblog entries, storing them
+ * as comments with type 'liveblog' and approval status 'liveblog'.
+ */
+final class CommentEntryRepository implements EntryRepositoryInterface {
+
+	/**
+	 * Meta key for tracking which entry this entry replaces.
+	 *
+	 * @var string
+	 */
+	public const REPLACES_META_KEY = 'liveblog_replaces';
+
+	/**
+	 * Meta key for tracking contributors.
+	 *
+	 * @var string
+	 */
+	public const CONTRIBUTORS_META_KEY = 'liveblog_contributors';
+
+	/**
+	 * Meta key for hiding authors.
+	 *
+	 * @var string
+	 */
+	public const HIDE_AUTHORS_KEY = 'liveblog_hide_authors';
+
+	/**
+	 * Comment type for liveblog entries.
+	 *
+	 * @var string
+	 */
+	public const COMMENT_TYPE = 'liveblog';
+
+	/**
+	 * Cache group for liveblog entries.
+	 *
+	 * @var string
+	 */
+	private const CACHE_GROUP = 'liveblog';
+
+	/**
+	 * Find an entry by its ID.
+	 *
+	 * @param EntryId $id Entry ID.
+	 * @return WP_Comment|null The entry data or null if not found.
+	 */
+	public function find_by_id( EntryId $id ): ?WP_Comment {
+		$comment = get_comment( $id->to_int() );
+
+		if ( ! $comment instanceof WP_Comment ) {
+			return null;
+		}
+
+		return $comment;
+	}
+
+	/**
+	 * Find entries by post ID.
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param array $args    Optional query arguments.
+	 * @return WP_Comment[] Array of entries.
+	 */
+	public function find_by_post_id( int $post_id, array $args = array() ): array {
+		$defaults = array(
+			'post_id' => $post_id,
+			'type'    => self::COMMENT_TYPE,
+			'status'  => self::COMMENT_TYPE,
+		);
+
+		$query_args = array_merge( $defaults, $args );
+
+		return get_comments( $query_args );
+	}
+
+	/**
+	 * Insert a new entry.
+	 *
+	 * @param array $data Entry data including post_id, content, user_id, author info.
+	 * @return EntryId The new entry's ID.
+	 * @throws RuntimeException If insertion fails.
+	 */
+	public function insert( array $data ): EntryId {
+		$this->validate_insert_data( $data );
+
+		$comment_data = array(
+			'comment_post_ID'      => $data['post_id'],
+			'comment_content'      => $this->sanitize_content( $data['content'] ?? '' ),
+			'comment_approved'     => self::COMMENT_TYPE,
+			'comment_type'         => self::COMMENT_TYPE,
+			'user_id'              => $data['user_id'],
+			'comment_author'       => $data['author_name'] ?? '',
+			'comment_author_email' => $data['author_email'] ?? '',
+			'comment_author_url'   => $data['author_url'] ?? '',
+		);
+
+		$comment_id = wp_insert_comment( $comment_data );
+
+		if ( empty( $comment_id ) || is_wp_error( $comment_id ) ) {
+			throw new RuntimeException( 'Failed to insert liveblog entry' );
+		}
+
+		$this->invalidate_cache( $data['post_id'] );
+
+		return EntryId::from_int( $comment_id );
+	}
+
+	/**
+	 * Update an existing entry.
+	 *
+	 * @param EntryId $id   Entry ID.
+	 * @param array   $data Data to update.
+	 * @return bool True on success.
+	 * @throws RuntimeException If update fails.
+	 */
+	public function update( EntryId $id, array $data ): bool {
+		$comment = $this->find_by_id( $id );
+
+		if ( ! $comment ) {
+			throw new RuntimeException( 'Entry not found' );
+		}
+
+		$update_data = array( 'comment_ID' => $id->to_int() );
+
+		if ( isset( $data['content'] ) ) {
+			$update_data['comment_content'] = $this->sanitize_content( $data['content'] );
+		}
+
+		if ( isset( $data['user_id'] ) ) {
+			$update_data['user_id'] = $data['user_id'];
+		}
+
+		if ( isset( $data['author_name'] ) ) {
+			$update_data['comment_author'] = $data['author_name'];
+		}
+
+		if ( isset( $data['author_email'] ) ) {
+			$update_data['comment_author_email'] = $data['author_email'];
+		}
+
+		if ( isset( $data['author_url'] ) ) {
+			$update_data['comment_author_url'] = $data['author_url'];
+		}
+
+		$result = wp_update_comment( $update_data );
+
+		if ( is_wp_error( $result ) ) {
+			throw new RuntimeException( 'Failed to update liveblog entry' );
+		}
+
+		$this->invalidate_cache( (int) $comment->comment_post_ID );
+
+		return true;
+	}
+
+	/**
+	 * Delete an entry.
+	 *
+	 * @param EntryId $id    Entry ID.
+	 * @param bool    $force Whether to force permanent deletion.
+	 * @return bool True on success.
+	 */
+	public function delete( EntryId $id, bool $force = false ): bool {
+		$comment = $this->find_by_id( $id );
+
+		if ( ! $comment ) {
+			return false;
+		}
+
+		$post_id = (int) $comment->comment_post_ID;
+		$result  = wp_delete_comment( $id->to_int(), $force );
+
+		if ( $result ) {
+			$this->invalidate_cache( $post_id );
+		}
+
+		return (bool) $result;
+	}
+
+	/**
+	 * Get the ID of the entry that this entry replaces.
+	 *
+	 * @param EntryId $id Entry ID.
+	 * @return EntryId|null The replaced entry ID or null.
+	 */
+	public function get_replaces_id( EntryId $id ): ?EntryId {
+		$replaces = get_comment_meta( $id->to_int(), self::REPLACES_META_KEY, true );
+
+		if ( empty( $replaces ) ) {
+			return null;
+		}
+
+		return EntryId::from_int( (int) $replaces );
+	}
+
+	/**
+	 * Set the entry that this entry replaces.
+	 *
+	 * @param EntryId $id       Entry ID.
+	 * @param EntryId $replaces ID of the entry being replaced.
+	 * @return bool True on success.
+	 */
+	public function set_replaces_id( EntryId $id, EntryId $replaces ): bool {
+		$result = add_comment_meta( $id->to_int(), self::REPLACES_META_KEY, $replaces->to_int() );
+
+		return false !== $result;
+	}
+
+	/**
+	 * Find entries that reference a given entry as their replacement target.
+	 *
+	 * @param int     $post_id  Post ID.
+	 * @param EntryId $entry_id Entry ID being replaced.
+	 * @param EntryId $exclude  Entry ID to exclude from results.
+	 * @return WP_Comment[] Array of referencing entries.
+	 */
+	public function find_referencing_entries( int $post_id, EntryId $entry_id, EntryId $exclude ): array {
+		return get_comments(
+			array(
+				'post_id'         => $post_id,
+				'type'            => self::COMMENT_TYPE,
+				'status'          => self::COMMENT_TYPE,
+				'meta_key'        => self::REPLACES_META_KEY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value'      => $entry_id->to_int(), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				'comment__not_in' => array( $exclude->to_int() ),
+			)
+		);
+	}
+
+	/**
+	 * Get contributor user IDs for an entry.
+	 *
+	 * @param EntryId $id Entry ID.
+	 * @return int[] Array of user IDs.
+	 */
+	public function get_contributors( EntryId $id ): array {
+		$contributors = get_comment_meta( $id->to_int(), self::CONTRIBUTORS_META_KEY, true );
+
+		if ( ! is_array( $contributors ) ) {
+			return array();
+		}
+
+		return array_map( 'intval', $contributors );
+	}
+
+	/**
+	 * Set contributors for an entry.
+	 *
+	 * @param EntryId $id       Entry ID.
+	 * @param int[]   $user_ids Array of contributor user IDs.
+	 * @return bool True on success.
+	 */
+	public function set_contributors( EntryId $id, array $user_ids ): bool {
+		$comment_id = $id->to_int();
+
+		// Remove empty values.
+		$user_ids = array_filter( array_map( 'intval', $user_ids ) );
+
+		if ( empty( $user_ids ) ) {
+			return delete_comment_meta( $comment_id, self::CONTRIBUTORS_META_KEY );
+		}
+
+		if ( metadata_exists( 'comment', $comment_id, self::CONTRIBUTORS_META_KEY ) ) {
+			$result = update_comment_meta( $comment_id, self::CONTRIBUTORS_META_KEY, $user_ids );
+		} else {
+			$result = add_comment_meta( $comment_id, self::CONTRIBUTORS_META_KEY, $user_ids );
+		}
+
+		return false !== $result;
+	}
+
+	/**
+	 * Check if authors are hidden for an entry.
+	 *
+	 * @param EntryId $id Entry ID.
+	 * @return bool True if authors are hidden.
+	 */
+	public function is_authors_hidden( EntryId $id ): bool {
+		return (bool) get_comment_meta( $id->to_int(), self::HIDE_AUTHORS_KEY, true );
+	}
+
+	/**
+	 * Set whether authors are hidden for an entry.
+	 *
+	 * @param EntryId $id     Entry ID.
+	 * @param bool    $hidden Whether to hide authors.
+	 * @return bool True on success.
+	 */
+	public function set_authors_hidden( EntryId $id, bool $hidden ): bool {
+		$comment_id = $id->to_int();
+
+		if ( $hidden ) {
+			$result = update_comment_meta( $comment_id, self::HIDE_AUTHORS_KEY, true );
+		} else {
+			$result = delete_comment_meta( $comment_id, self::HIDE_AUTHORS_KEY );
+		}
+
+		return false !== $result;
+	}
+
+	/**
+	 * Invalidate any caches for entries belonging to a post.
+	 *
+	 * @param int $post_id Post ID.
+	 * @return void
+	 */
+	public function invalidate_cache( int $post_id ): void {
+		wp_cache_delete( 'liveblog_entries_asc_' . $post_id, self::CACHE_GROUP );
+	}
+
+	/**
+	 * Validate data for insert operation.
+	 *
+	 * @param array $data Data to validate.
+	 * @return void
+	 * @throws RuntimeException If validation fails.
+	 */
+	private function validate_insert_data( array $data ): void {
+		if ( empty( $data['post_id'] ) ) {
+			throw new RuntimeException( 'Missing required field: post_id' );
+		}
+
+		if ( empty( $data['user_id'] ) ) {
+			throw new RuntimeException( 'Missing required field: user_id' );
+		}
+	}
+
+	/**
+	 * Sanitize content for storage.
+	 *
+	 * @param string $content Raw content.
+	 * @return string Sanitized content.
+	 */
+	private function sanitize_content( string $content ): string {
+		return wp_filter_post_kses( $content );
+	}
+}

--- a/src/php/Infrastructure/ServiceContainer.php
+++ b/src/php/Infrastructure/ServiceContainer.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Service container for dependency injection.
+ *
+ * @package Automattic\Liveblog\Infrastructure
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Infrastructure;
+
+use Automattic\Liveblog\Application\Service\EntryService;
+use Automattic\Liveblog\Domain\Repository\EntryRepositoryInterface;
+use Automattic\Liveblog\Infrastructure\Repository\CommentEntryRepository;
+
+/**
+ * Simple service container for wiring up dependencies.
+ *
+ * This acts as the composition root for the application, creating and
+ * providing access to service instances. Services are lazily instantiated
+ * and cached for the lifetime of the request.
+ *
+ * Usage:
+ *   $container = ServiceContainer::instance();
+ *   $service   = $container->entry_service();
+ */
+final class ServiceContainer {
+
+	/**
+	 * Singleton instance.
+	 *
+	 * @var self|null
+	 */
+	private static ?self $instance = null;
+
+	/**
+	 * Cached entry repository instance.
+	 *
+	 * @var EntryRepositoryInterface|null
+	 */
+	private ?EntryRepositoryInterface $entry_repository = null;
+
+	/**
+	 * Cached entry service instance.
+	 *
+	 * @var EntryService|null
+	 */
+	private ?EntryService $entry_service = null;
+
+	/**
+	 * Private constructor to enforce singleton.
+	 */
+	private function __construct() {}
+
+	/**
+	 * Get the singleton instance.
+	 *
+	 * @return self
+	 */
+	public static function instance(): self {
+		if ( null === self::$instance ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Reset the container (primarily for testing).
+	 *
+	 * @return void
+	 */
+	public static function reset(): void {
+		self::$instance = null;
+	}
+
+	/**
+	 * Get the entry repository.
+	 *
+	 * @return EntryRepositoryInterface
+	 */
+	public function entry_repository(): EntryRepositoryInterface {
+		if ( null === $this->entry_repository ) {
+			$this->entry_repository = new CommentEntryRepository();
+		}
+
+		return $this->entry_repository;
+	}
+
+	/**
+	 * Get the entry service.
+	 *
+	 * @return EntryService
+	 */
+	public function entry_service(): EntryService {
+		if ( null === $this->entry_service ) {
+			$this->entry_service = new EntryService( $this->entry_repository() );
+		}
+
+		return $this->entry_service;
+	}
+
+	/**
+	 * Set a custom entry repository (for testing or alternative implementations).
+	 *
+	 * @param EntryRepositoryInterface $repository Repository instance.
+	 * @return self
+	 */
+	public function set_entry_repository( EntryRepositoryInterface $repository ): self {
+		$this->entry_repository = $repository;
+		// Clear the service so it gets recreated with the new repository.
+		$this->entry_service = null;
+
+		return $this;
+	}
+
+	/**
+	 * Set a custom entry service (for testing).
+	 *
+	 * @param EntryService $service Service instance.
+	 * @return self
+	 */
+	public function set_entry_service( EntryService $service ): self {
+		$this->entry_service = $service;
+
+		return $this;
+	}
+}

--- a/tests/Unit/Application/Service/EntryServiceTest.php
+++ b/tests/Unit/Application/Service/EntryServiceTest.php
@@ -1,0 +1,459 @@
+<?php
+/**
+ * Unit tests for EntryService.
+ *
+ * @package Automattic\Liveblog\Tests\Unit\Application\Service
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Tests\Unit\Application\Service;
+
+use Automattic\Liveblog\Application\Service\EntryService;
+use Automattic\Liveblog\Domain\Repository\EntryRepositoryInterface;
+use Automattic\Liveblog\Domain\ValueObject\EntryId;
+use InvalidArgumentException;
+use Mockery;
+use WP_Comment;
+use WP_User;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+/**
+ * EntryService unit test case.
+ *
+ * @covers \Automattic\Liveblog\Application\Service\EntryService
+ */
+final class EntryServiceTest extends TestCase {
+
+	/**
+	 * Mock repository.
+	 *
+	 * @var EntryRepositoryInterface&Mockery\MockInterface
+	 */
+	private $repository;
+
+	/**
+	 * Service under test.
+	 *
+	 * @var EntryService
+	 */
+	private EntryService $service;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function set_up(): void {
+		parent::set_up();
+
+		$this->repository = Mockery::mock( EntryRepositoryInterface::class );
+		$this->service    = new EntryService( $this->repository );
+	}
+
+	/**
+	 * Test create inserts entry and returns ID.
+	 */
+	public function test_create_inserts_entry(): void {
+		$author   = $this->create_mock_user( 1, 'John Doe' );
+		$entry_id = EntryId::from_int( 100 );
+
+		$this->repository
+			->shouldReceive( 'insert' )
+			->once()
+			->with(
+				Mockery::on(
+					function ( $data ) {
+						return 42 === $data['post_id']
+							&& 'Test content' === $data['content']
+							&& 1 === $data['user_id']
+							&& 'John Doe' === $data['author_name'];
+					}
+				)
+			)
+			->andReturn( $entry_id );
+
+		$result = $this->service->create( 42, 'Test content', $author );
+
+		$this->assertSame( $entry_id, $result );
+	}
+
+	/**
+	 * Test create with hidden author sets meta.
+	 */
+	public function test_create_with_hidden_author(): void {
+		$author   = $this->create_mock_user( 1, 'John Doe' );
+		$entry_id = EntryId::from_int( 100 );
+
+		$this->repository
+			->shouldReceive( 'insert' )
+			->once()
+			->andReturn( $entry_id );
+
+		$this->repository
+			->shouldReceive( 'set_authors_hidden' )
+			->once()
+			->with(
+				Mockery::on( fn( $id ) => $id->to_int() === 100 ),
+				true
+			)
+			->andReturn( true );
+
+		$result = $this->service->create( 42, 'Test content', $author, true );
+
+		$this->assertSame( $entry_id, $result );
+	}
+
+	/**
+	 * Test create with contributors sets meta.
+	 */
+	public function test_create_with_contributors(): void {
+		$author   = $this->create_mock_user( 1, 'John Doe' );
+		$entry_id = EntryId::from_int( 100 );
+
+		$this->repository
+			->shouldReceive( 'insert' )
+			->once()
+			->andReturn( $entry_id );
+
+		$this->repository
+			->shouldReceive( 'set_contributors' )
+			->once()
+			->with(
+				Mockery::on( fn( $id ) => $id->to_int() === 100 ),
+				array( 2, 3 )
+			)
+			->andReturn( true );
+
+		$result = $this->service->create( 42, 'Test content', $author, false, array( 2, 3 ) );
+
+		$this->assertSame( $entry_id, $result );
+	}
+
+	/**
+	 * Test create throws on invalid post ID.
+	 */
+	public function test_create_throws_on_invalid_post_id(): void {
+		$author = $this->create_mock_user( 1, 'John Doe' );
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Invalid post ID' );
+
+		$this->service->create( 0, 'Test content', $author );
+	}
+
+	/**
+	 * Test update creates replacement entry.
+	 */
+	public function test_update_creates_replacement(): void {
+		$author       = $this->create_mock_user( 1, 'John Doe' );
+		$entry_id     = EntryId::from_int( 100 );
+		$new_entry_id = EntryId::from_int( 101 );
+		$comment      = $this->create_mock_comment( 100 );
+
+		$this->repository
+			->shouldReceive( 'find_by_id' )
+			->once()
+			->with( Mockery::on( fn( $id ) => $id->to_int() === 100 ) )
+			->andReturn( $comment );
+
+		$this->repository
+			->shouldReceive( 'insert' )
+			->once()
+			->andReturn( $new_entry_id );
+
+		$this->repository
+			->shouldReceive( 'set_replaces_id' )
+			->once()
+			->with(
+				Mockery::on( fn( $id ) => $id->to_int() === 101 ),
+				Mockery::on( fn( $id ) => $id->to_int() === 100 )
+			)
+			->andReturn( true );
+
+		$this->repository
+			->shouldReceive( 'update' )
+			->once()
+			->with(
+				Mockery::on( fn( $id ) => $id->to_int() === 100 ),
+				array( 'content' => 'Updated content' )
+			)
+			->andReturn( true );
+
+		$result = $this->service->update( 42, $entry_id, 'Updated content', $author );
+
+		$this->assertSame( 101, $result->to_int() );
+	}
+
+	/**
+	 * Test update throws when entry not found.
+	 */
+	public function test_update_throws_when_entry_not_found(): void {
+		$author   = $this->create_mock_user( 1, 'John Doe' );
+		$entry_id = EntryId::from_int( 999 );
+
+		$this->repository
+			->shouldReceive( 'find_by_id' )
+			->once()
+			->andReturn( null );
+
+		$this->expectException( InvalidArgumentException::class );
+		$this->expectExceptionMessage( 'Entry not found' );
+
+		$this->service->update( 42, $entry_id, 'Updated content', $author );
+	}
+
+	/**
+	 * Test delete creates delete marker.
+	 */
+	public function test_delete_creates_marker(): void {
+		$author           = $this->create_mock_user( 1, 'John Doe' );
+		$entry_id         = EntryId::from_int( 100 );
+		$delete_marker_id = EntryId::from_int( 101 );
+		$comment          = $this->create_mock_comment( 100 );
+
+		$this->repository
+			->shouldReceive( 'find_by_id' )
+			->once()
+			->with( Mockery::on( fn( $id ) => $id->to_int() === 100 ) )
+			->andReturn( $comment );
+
+		$this->repository
+			->shouldReceive( 'insert' )
+			->once()
+			->with( Mockery::on( fn( $data ) => '' === $data['content'] ) )
+			->andReturn( $delete_marker_id );
+
+		$this->repository
+			->shouldReceive( 'set_replaces_id' )
+			->once()
+			->andReturn( true );
+
+		$this->repository
+			->shouldReceive( 'find_referencing_entries' )
+			->once()
+			->andReturn( array() );
+
+		$this->repository
+			->shouldReceive( 'delete' )
+			->once()
+			->with(
+				Mockery::on( fn( $id ) => $id->to_int() === 100 ),
+				false
+			)
+			->andReturn( true );
+
+		$result = $this->service->delete( 42, $entry_id, $author );
+
+		$this->assertSame( 101, $result->to_int() );
+	}
+
+	/**
+	 * Test delete cleans up orphaned entries.
+	 */
+	public function test_delete_cleans_up_orphans(): void {
+		$author           = $this->create_mock_user( 1, 'John Doe' );
+		$entry_id         = EntryId::from_int( 100 );
+		$delete_marker_id = EntryId::from_int( 103 );
+		$comment          = $this->create_mock_comment( 100 );
+		$orphan1          = $this->create_mock_comment( 101 );
+		$orphan2          = $this->create_mock_comment( 102 );
+
+		$this->repository
+			->shouldReceive( 'find_by_id' )
+			->once()
+			->andReturn( $comment );
+
+		$this->repository
+			->shouldReceive( 'insert' )
+			->once()
+			->andReturn( $delete_marker_id );
+
+		$this->repository
+			->shouldReceive( 'set_replaces_id' )
+			->once()
+			->andReturn( true );
+
+		$this->repository
+			->shouldReceive( 'find_referencing_entries' )
+			->once()
+			->andReturn( array( $orphan1, $orphan2 ) );
+
+		// Orphans should be force-deleted.
+		$this->repository
+			->shouldReceive( 'delete' )
+			->with( Mockery::on( fn( $id ) => $id->to_int() === 101 ), true )
+			->once()
+			->andReturn( true );
+
+		$this->repository
+			->shouldReceive( 'delete' )
+			->with( Mockery::on( fn( $id ) => $id->to_int() === 102 ), true )
+			->once()
+			->andReturn( true );
+
+		// Original entry soft-deleted.
+		$this->repository
+			->shouldReceive( 'delete' )
+			->with( Mockery::on( fn( $id ) => $id->to_int() === 100 ), false )
+			->once()
+			->andReturn( true );
+
+		$result = $this->service->delete( 42, $entry_id, $author );
+
+		$this->assertSame( 103, $result->to_int() );
+	}
+
+	/**
+	 * Test update_author with user updates entry.
+	 */
+	public function test_update_author_with_user(): void {
+		$author   = $this->create_mock_user( 2, 'Jane Doe' );
+		$entry_id = EntryId::from_int( 100 );
+		$comment  = $this->create_mock_comment( 100 );
+
+		$this->repository
+			->shouldReceive( 'find_by_id' )
+			->once()
+			->andReturn( $comment );
+
+		$this->repository
+			->shouldReceive( 'update' )
+			->once()
+			->with(
+				Mockery::on( fn( $id ) => $id->to_int() === 100 ),
+				Mockery::on(
+					function ( $data ) {
+						return 2 === $data['user_id']
+							&& 'Jane Doe' === $data['author_name'];
+					}
+				)
+			)
+			->andReturn( true );
+
+		$this->repository
+			->shouldReceive( 'set_authors_hidden' )
+			->once()
+			->with(
+				Mockery::on( fn( $id ) => $id->to_int() === 100 ),
+				false
+			)
+			->andReturn( true );
+
+		$result = $this->service->update_author( $entry_id, $author );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test update_author with null hides authors.
+	 */
+	public function test_update_author_with_null_hides(): void {
+		$entry_id = EntryId::from_int( 100 );
+		$comment  = $this->create_mock_comment( 100 );
+
+		$this->repository
+			->shouldReceive( 'find_by_id' )
+			->once()
+			->andReturn( $comment );
+
+		$this->repository
+			->shouldReceive( 'set_authors_hidden' )
+			->once()
+			->with(
+				Mockery::on( fn( $id ) => $id->to_int() === 100 ),
+				true
+			)
+			->andReturn( true );
+
+		$result = $this->service->update_author( $entry_id, null );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test set_contributors delegates to repository.
+	 */
+	public function test_set_contributors(): void {
+		$entry_id = EntryId::from_int( 100 );
+		$comment  = $this->create_mock_comment( 100 );
+
+		$this->repository
+			->shouldReceive( 'find_by_id' )
+			->once()
+			->andReturn( $comment );
+
+		$this->repository
+			->shouldReceive( 'set_contributors' )
+			->once()
+			->with(
+				Mockery::on( fn( $id ) => $id->to_int() === 100 ),
+				array( 2, 3, 4 )
+			)
+			->andReturn( true );
+
+		$result = $this->service->set_contributors( $entry_id, array( 2, 3, 4 ) );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test get_contributors delegates to repository.
+	 */
+	public function test_get_contributors(): void {
+		$entry_id = EntryId::from_int( 100 );
+
+		$this->repository
+			->shouldReceive( 'get_contributors' )
+			->once()
+			->with( Mockery::on( fn( $id ) => $id->to_int() === 100 ) )
+			->andReturn( array( 2, 3 ) );
+
+		$result = $this->service->get_contributors( $entry_id );
+
+		$this->assertSame( array( 2, 3 ), $result );
+	}
+
+	/**
+	 * Test is_authors_hidden delegates to repository.
+	 */
+	public function test_is_authors_hidden(): void {
+		$entry_id = EntryId::from_int( 100 );
+
+		$this->repository
+			->shouldReceive( 'is_authors_hidden' )
+			->once()
+			->with( Mockery::on( fn( $id ) => $id->to_int() === 100 ) )
+			->andReturn( true );
+
+		$this->assertTrue( $this->service->is_authors_hidden( $entry_id ) );
+	}
+
+	/**
+	 * Create a mock WP_User object.
+	 *
+	 * @param int    $id           User ID.
+	 * @param string $display_name Display name.
+	 * @return WP_User
+	 */
+	private function create_mock_user( int $id, string $display_name ): WP_User {
+		$user               = Mockery::mock( WP_User::class );
+		$user->ID           = $id;
+		$user->display_name = $display_name;
+		$user->user_email   = strtolower( str_replace( ' ', '.', $display_name ) ) . '@example.com';
+		$user->user_url     = '';
+
+		return $user;
+	}
+
+	/**
+	 * Create a mock WP_Comment object.
+	 *
+	 * @param int $id Comment ID.
+	 * @return WP_Comment
+	 */
+	private function create_mock_comment( int $id ): WP_Comment {
+		$comment             = Mockery::mock( WP_Comment::class );
+		$comment->comment_ID = $id;
+
+		return $comment;
+	}
+}

--- a/tests/Unit/Infrastructure/Repository/CommentEntryRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Repository/CommentEntryRepositoryTest.php
@@ -182,7 +182,7 @@ final class CommentEntryRepositoryTest extends TestCase {
 	 * Test update modifies comment.
 	 */
 	public function test_update_modifies_comment(): void {
-		$comment                   = $this->create_mock_comment( 123 );
+		$comment                  = $this->create_mock_comment( 123 );
 		$comment->comment_post_ID = 42;
 
 		Functions\expect( 'get_comment' )
@@ -236,7 +236,7 @@ final class CommentEntryRepositoryTest extends TestCase {
 	 * Test delete removes comment.
 	 */
 	public function test_delete_removes_comment(): void {
-		$comment                   = $this->create_mock_comment( 123 );
+		$comment                  = $this->create_mock_comment( 123 );
 		$comment->comment_post_ID = 42;
 
 		Functions\expect( 'get_comment' )

--- a/tests/Unit/Infrastructure/Repository/CommentEntryRepositoryTest.php
+++ b/tests/Unit/Infrastructure/Repository/CommentEntryRepositoryTest.php
@@ -1,0 +1,491 @@
+<?php
+/**
+ * Unit tests for CommentEntryRepository.
+ *
+ * @package Automattic\Liveblog\Tests\Unit\Infrastructure\Repository
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Tests\Unit\Infrastructure\Repository;
+
+use Automattic\Liveblog\Domain\ValueObject\EntryId;
+use Automattic\Liveblog\Infrastructure\Repository\CommentEntryRepository;
+use Brain\Monkey\Functions;
+use Mockery;
+use RuntimeException;
+use WP_Comment;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+/**
+ * CommentEntryRepository unit test case.
+ *
+ * @covers \Automattic\Liveblog\Infrastructure\Repository\CommentEntryRepository
+ */
+final class CommentEntryRepositoryTest extends TestCase {
+
+	/**
+	 * Repository instance under test.
+	 *
+	 * @var CommentEntryRepository
+	 */
+	private CommentEntryRepository $repository;
+
+	/**
+	 * Set up test fixtures.
+	 */
+	protected function set_up(): void {
+		parent::set_up();
+		$this->repository = new CommentEntryRepository();
+	}
+
+	/**
+	 * Test find_by_id returns comment when found.
+	 */
+	public function test_find_by_id_returns_comment(): void {
+		$comment = $this->create_mock_comment( 123 );
+
+		Functions\expect( 'get_comment' )
+			->once()
+			->with( 123 )
+			->andReturn( $comment );
+
+		$result = $this->repository->find_by_id( EntryId::from_int( 123 ) );
+
+		$this->assertSame( $comment, $result );
+	}
+
+	/**
+	 * Test find_by_id returns null when not found.
+	 */
+	public function test_find_by_id_returns_null_when_not_found(): void {
+		Functions\expect( 'get_comment' )
+			->once()
+			->with( 999 )
+			->andReturn( null );
+
+		$result = $this->repository->find_by_id( EntryId::from_int( 999 ) );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test find_by_post_id returns comments.
+	 */
+	public function test_find_by_post_id_returns_comments(): void {
+		$comments = array(
+			$this->create_mock_comment( 1 ),
+			$this->create_mock_comment( 2 ),
+		);
+
+		Functions\expect( 'get_comments' )
+			->once()
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return 42 === $args['post_id']
+							&& 'liveblog' === $args['type']
+							&& 'liveblog' === $args['status'];
+					}
+				)
+			)
+			->andReturn( $comments );
+
+		$result = $this->repository->find_by_post_id( 42 );
+
+		$this->assertCount( 2, $result );
+	}
+
+	/**
+	 * Test insert creates comment and returns ID.
+	 */
+	public function test_insert_creates_comment(): void {
+		Functions\expect( 'wp_filter_post_kses' )
+			->once()
+			->with( 'Test content' )
+			->andReturn( 'Test content' );
+
+		Functions\expect( 'wp_insert_comment' )
+			->once()
+			->with(
+				Mockery::on(
+					function ( $data ) {
+						return 42 === $data['comment_post_ID']
+							&& 'Test content' === $data['comment_content']
+							&& 'liveblog' === $data['comment_type']
+							&& 'liveblog' === $data['comment_approved']
+							&& 1 === $data['user_id'];
+					}
+				)
+			)
+			->andReturn( 100 );
+
+		Functions\expect( 'wp_cache_delete' )
+			->once()
+			->with( 'liveblog_entries_asc_42', 'liveblog' );
+
+		$entry_id = $this->repository->insert(
+			array(
+				'post_id'      => 42,
+				'user_id'      => 1,
+				'content'      => 'Test content',
+				'author_name'  => 'Test Author',
+				'author_email' => 'test@example.com',
+			)
+		);
+
+		$this->assertSame( 100, $entry_id->to_int() );
+	}
+
+	/**
+	 * Test insert throws exception on failure.
+	 */
+	public function test_insert_throws_on_failure(): void {
+		Functions\expect( 'wp_filter_post_kses' )
+			->andReturn( '' );
+
+		Functions\expect( 'wp_insert_comment' )
+			->andReturn( 0 );
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Failed to insert liveblog entry' );
+
+		$this->repository->insert(
+			array(
+				'post_id' => 42,
+				'user_id' => 1,
+			)
+		);
+	}
+
+	/**
+	 * Test insert throws exception when post_id missing.
+	 */
+	public function test_insert_throws_when_post_id_missing(): void {
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Missing required field: post_id' );
+
+		$this->repository->insert( array( 'user_id' => 1 ) );
+	}
+
+	/**
+	 * Test insert throws exception when user_id missing.
+	 */
+	public function test_insert_throws_when_user_id_missing(): void {
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Missing required field: user_id' );
+
+		$this->repository->insert( array( 'post_id' => 42 ) );
+	}
+
+	/**
+	 * Test update modifies comment.
+	 */
+	public function test_update_modifies_comment(): void {
+		$comment                   = $this->create_mock_comment( 123 );
+		$comment->comment_post_ID = 42;
+
+		Functions\expect( 'get_comment' )
+			->once()
+			->with( 123 )
+			->andReturn( $comment );
+
+		Functions\expect( 'wp_filter_post_kses' )
+			->once()
+			->with( 'Updated content' )
+			->andReturn( 'Updated content' );
+
+		Functions\expect( 'wp_update_comment' )
+			->once()
+			->with(
+				Mockery::on(
+					function ( $data ) {
+						return 123 === $data['comment_ID']
+							&& 'Updated content' === $data['comment_content'];
+					}
+				)
+			)
+			->andReturn( 1 );
+
+		Functions\expect( 'wp_cache_delete' )
+			->once();
+
+		$result = $this->repository->update(
+			EntryId::from_int( 123 ),
+			array( 'content' => 'Updated content' )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test update throws when entry not found.
+	 */
+	public function test_update_throws_when_not_found(): void {
+		Functions\expect( 'get_comment' )
+			->once()
+			->andReturn( null );
+
+		$this->expectException( RuntimeException::class );
+		$this->expectExceptionMessage( 'Entry not found' );
+
+		$this->repository->update( EntryId::from_int( 999 ), array() );
+	}
+
+	/**
+	 * Test delete removes comment.
+	 */
+	public function test_delete_removes_comment(): void {
+		$comment                   = $this->create_mock_comment( 123 );
+		$comment->comment_post_ID = 42;
+
+		Functions\expect( 'get_comment' )
+			->once()
+			->with( 123 )
+			->andReturn( $comment );
+
+		Functions\expect( 'wp_delete_comment' )
+			->once()
+			->with( 123, false )
+			->andReturn( true );
+
+		Functions\expect( 'wp_cache_delete' )
+			->once();
+
+		$result = $this->repository->delete( EntryId::from_int( 123 ) );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test delete returns false when not found.
+	 */
+	public function test_delete_returns_false_when_not_found(): void {
+		Functions\expect( 'get_comment' )
+			->once()
+			->andReturn( null );
+
+		$result = $this->repository->delete( EntryId::from_int( 999 ) );
+
+		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test get_replaces_id returns entry ID when set.
+	 */
+	public function test_get_replaces_id_returns_id(): void {
+		Functions\expect( 'get_comment_meta' )
+			->once()
+			->with( 123, CommentEntryRepository::REPLACES_META_KEY, true )
+			->andReturn( 456 );
+
+		$result = $this->repository->get_replaces_id( EntryId::from_int( 123 ) );
+
+		$this->assertInstanceOf( EntryId::class, $result );
+		$this->assertSame( 456, $result->to_int() );
+	}
+
+	/**
+	 * Test get_replaces_id returns null when not set.
+	 */
+	public function test_get_replaces_id_returns_null(): void {
+		Functions\expect( 'get_comment_meta' )
+			->once()
+			->andReturn( '' );
+
+		$result = $this->repository->get_replaces_id( EntryId::from_int( 123 ) );
+
+		$this->assertNull( $result );
+	}
+
+	/**
+	 * Test set_replaces_id adds meta.
+	 */
+	public function test_set_replaces_id(): void {
+		Functions\expect( 'add_comment_meta' )
+			->once()
+			->with( 123, CommentEntryRepository::REPLACES_META_KEY, 456 )
+			->andReturn( 1 );
+
+		$result = $this->repository->set_replaces_id(
+			EntryId::from_int( 123 ),
+			EntryId::from_int( 456 )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test get_contributors returns user IDs.
+	 */
+	public function test_get_contributors(): void {
+		Functions\expect( 'get_comment_meta' )
+			->once()
+			->with( 123, CommentEntryRepository::CONTRIBUTORS_META_KEY, true )
+			->andReturn( array( 1, 2, 3 ) );
+
+		$result = $this->repository->get_contributors( EntryId::from_int( 123 ) );
+
+		$this->assertSame( array( 1, 2, 3 ), $result );
+	}
+
+	/**
+	 * Test get_contributors returns empty array when not set.
+	 */
+	public function test_get_contributors_empty(): void {
+		Functions\expect( 'get_comment_meta' )
+			->once()
+			->andReturn( '' );
+
+		$result = $this->repository->get_contributors( EntryId::from_int( 123 ) );
+
+		$this->assertSame( array(), $result );
+	}
+
+	/**
+	 * Test set_contributors updates meta.
+	 */
+	public function test_set_contributors(): void {
+		Functions\expect( 'metadata_exists' )
+			->once()
+			->with( 'comment', 123, CommentEntryRepository::CONTRIBUTORS_META_KEY )
+			->andReturn( true );
+
+		Functions\expect( 'update_comment_meta' )
+			->once()
+			->with( 123, CommentEntryRepository::CONTRIBUTORS_META_KEY, array( 1, 2 ) )
+			->andReturn( true );
+
+		$result = $this->repository->set_contributors(
+			EntryId::from_int( 123 ),
+			array( 1, 2 )
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test set_contributors deletes meta when empty.
+	 */
+	public function test_set_contributors_deletes_when_empty(): void {
+		Functions\expect( 'delete_comment_meta' )
+			->once()
+			->with( 123, CommentEntryRepository::CONTRIBUTORS_META_KEY )
+			->andReturn( true );
+
+		$result = $this->repository->set_contributors(
+			EntryId::from_int( 123 ),
+			array()
+		);
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test is_authors_hidden returns true when hidden.
+	 */
+	public function test_is_authors_hidden_true(): void {
+		Functions\expect( 'get_comment_meta' )
+			->once()
+			->with( 123, CommentEntryRepository::HIDE_AUTHORS_KEY, true )
+			->andReturn( true );
+
+		$this->assertTrue( $this->repository->is_authors_hidden( EntryId::from_int( 123 ) ) );
+	}
+
+	/**
+	 * Test is_authors_hidden returns false when not hidden.
+	 */
+	public function test_is_authors_hidden_false(): void {
+		Functions\expect( 'get_comment_meta' )
+			->once()
+			->andReturn( '' );
+
+		$this->assertFalse( $this->repository->is_authors_hidden( EntryId::from_int( 123 ) ) );
+	}
+
+	/**
+	 * Test set_authors_hidden sets meta when hiding.
+	 */
+	public function test_set_authors_hidden_true(): void {
+		Functions\expect( 'update_comment_meta' )
+			->once()
+			->with( 123, CommentEntryRepository::HIDE_AUTHORS_KEY, true )
+			->andReturn( true );
+
+		$result = $this->repository->set_authors_hidden( EntryId::from_int( 123 ), true );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test set_authors_hidden deletes meta when showing.
+	 */
+	public function test_set_authors_hidden_false(): void {
+		Functions\expect( 'delete_comment_meta' )
+			->once()
+			->with( 123, CommentEntryRepository::HIDE_AUTHORS_KEY )
+			->andReturn( true );
+
+		$result = $this->repository->set_authors_hidden( EntryId::from_int( 123 ), false );
+
+		$this->assertTrue( $result );
+	}
+
+	/**
+	 * Test invalidate_cache clears cache.
+	 */
+	public function test_invalidate_cache(): void {
+		Functions\expect( 'wp_cache_delete' )
+			->once()
+			->with( 'liveblog_entries_asc_42', 'liveblog' );
+
+		$this->repository->invalidate_cache( 42 );
+
+		// No return value to assert, just verify function was called.
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Test find_referencing_entries queries correctly.
+	 */
+	public function test_find_referencing_entries(): void {
+		$comments = array( $this->create_mock_comment( 200 ) );
+
+		Functions\expect( 'get_comments' )
+			->once()
+			->with(
+				Mockery::on(
+					function ( $args ) {
+						return 42 === $args['post_id']
+							&& 'liveblog' === $args['type']
+							&& CommentEntryRepository::REPLACES_META_KEY === $args['meta_key']
+							&& 123 === $args['meta_value']
+							&& array( 456 ) === $args['comment__not_in'];
+					}
+				)
+			)
+			->andReturn( $comments );
+
+		$result = $this->repository->find_referencing_entries(
+			42,
+			EntryId::from_int( 123 ),
+			EntryId::from_int( 456 )
+		);
+
+		$this->assertCount( 1, $result );
+	}
+
+	/**
+	 * Create a mock WP_Comment object.
+	 *
+	 * @param int $id Comment ID.
+	 * @return WP_Comment
+	 */
+	private function create_mock_comment( int $id ): WP_Comment {
+		$comment             = Mockery::mock( WP_Comment::class );
+		$comment->comment_ID = $id;
+
+		return $comment;
+	}
+}

--- a/tests/Unit/wp-stubs.php
+++ b/tests/Unit/wp-stubs.php
@@ -41,19 +41,8 @@ if ( ! function_exists( 'wp_parse_args' ) ) {
 	}
 }
 
-if ( ! function_exists( 'get_comment_meta' ) ) {
-	/**
-	 * Stub for get_comment_meta.
-	 *
-	 * @param int    $comment_id Comment ID.
-	 * @param string $key        Meta key.
-	 * @param bool   $single     Return single value.
-	 * @return mixed Empty string for unit tests.
-	 */
-	function get_comment_meta( $comment_id, $key = '', $single = false ) {
-		return $single ? '' : array();
-	}
-}
+// NOTE: get_comment_meta is NOT stubbed here - use Brain\Monkey Functions\expect() in tests
+// that need to mock it. This allows Patchwork to intercept the function.
 
 // phpcs:enable
 


### PR DESCRIPTION
## Summary

- Introduces the Repository Pattern to abstract entry persistence from `WPCOM_Liveblog_Entry`
- Adds an Application Service Layer (`EntryService`) to orchestrate entry operations
- Creates a simple Service Container for dependency wiring

### Repository Layer (`src/php/Infrastructure/Repository/`)
- `EntryRepositoryInterface` defines the persistence contract (find, insert, update, delete, metadata operations)
- `CommentEntryRepository` implements the interface using WordPress comments as the storage backend

### Application Layer (`src/php/Application/Service/`)
- `EntryService` coordinates entry operations with constructor-injected repository
- Handles business logic: replacement entries, orphan cleanup, author visibility, contributor management

### Infrastructure (`src/php/Infrastructure/`)
- `ServiceContainer` provides lazy instantiation with request-scoped caching
- Supports swapping implementations for testing

This builds on the value objects from PR #817 and establishes the foundation for migrating `WPCOM_Liveblog_Entry`'s static methods to proper dependency-injected services.

## Test plan

- [x] All 124 unit tests pass
- [x] New repository tests (24 tests) verify persistence operations
- [x] New service tests (13 tests) verify application logic with mocked repository

🤖 Generated with [Claude Code](https://claude.com/claude-code)