### PR TITLE
refactor: wire up Entry CRUD operations to use EntryService

### DIFF
--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -241,9 +241,10 @@ final class RestApiTest extends TestCase {
 	 * Test the insert CRUD action.
 	 */
 	public function test_crud_action_insert(): void {
-		$user  = self::factory()->user->create_and_get();
-		$args  = array( 'user' => $user );
-		$entry = WPCOM_Liveblog::do_crud_entry( 'insert', $this->build_entry_args( $args ) );
+		$user = self::factory()->user->create_and_get();
+		wp_set_current_user( $user->ID );
+
+		$entry = WPCOM_Liveblog::do_crud_entry( 'insert', $this->build_entry_args() );
 
 		$this->assertIsArray( $entry );
 		$this->assertNotEmpty( $entry['entries'] );
@@ -709,7 +710,8 @@ final class RestApiTest extends TestCase {
 	private function insert_entries( int $number_of_entries = 1, array $args = array() ): array {
 		$entries = array();
 
-		$user         = self::factory()->user->create_and_get();
+		$user = self::factory()->user->create_and_get();
+		wp_set_current_user( $user->ID );
 		$args['user'] = $user;
 
 		for ( $i = 0; $i < $number_of_entries; $i++ ) {


### PR DESCRIPTION
## Summary

- Migrates `WPCOM_Liveblog_Entry::insert()`, `update()`, and `delete()` to delegate to the new `EntryService`
- The Entry class now acts as a WordPress integration layer, handling hooks while the service layer handles persistence
- Maintains full backwards compatibility with the existing public API

### Changes

**`WPCOM_Liveblog_Entry`**:
- Added use statements for `EntryId` and `ServiceContainer`
- CRUD methods now validate arguments upfront
- Catch service exceptions and convert to `WP_Error` for backwards compatibility
- WordPress-specific filters (`liveblog_before_insert_entry`, etc.) and actions (`liveblog_insert_entry`, etc.) remain in the Entry class

**`tests/Integration/RestApiTest.php`**:
- Added `wp_set_current_user()` calls to ensure tests have a logged-in user
- Required because the service layer properly validates that `user_id` is non-zero (stricter than before)

### Architecture

```
WPCOM_Liveblog_Entry::insert($args)
    ↓ (applies filters, validates)
    ↓
ServiceContainer::instance()->entry_service()->create()
    ↓
EntryRepositoryInterface::insert()
    ↓
CommentEntryRepository (wp_insert_comment)
```

This builds on PR #818 which introduced the repository pattern and service layer.

## Test plan

- [x] All 124 unit tests pass
- [x] Integration tests pass (2 pre-existing isolation failures unrelated to changes)
- [x] CRUD operations work correctly through the REST API

🤖 Generated with [Claude Code](https://claude.com/claude-code)