### PR TITLE
feat: add Entry domain entity with repository retrieval

### DIFF
--- a/src/php/Application/Service/EntryService.php
+++ b/src/php/Application/Service/EntryService.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Application\Service;
 
+use Automattic\Liveblog\Domain\Entity\Entry;
 use Automattic\Liveblog\Domain\Repository\EntryRepositoryInterface;
 use Automattic\Liveblog\Domain\ValueObject\EntryId;
 use InvalidArgumentException;
@@ -39,6 +40,27 @@ final class EntryService {
 	 */
 	public function __construct( EntryRepositoryInterface $repository ) {
 		$this->repository = $repository;
+	}
+
+	/**
+	 * Get an entry by ID.
+	 *
+	 * @param EntryId $entry_id Entry ID.
+	 * @return Entry|null The entry, or null if not found.
+	 */
+	public function get( EntryId $entry_id ): ?Entry {
+		return $this->repository->get_entry( $entry_id );
+	}
+
+	/**
+	 * Get entries for a liveblog post.
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param array $args    Optional query arguments.
+	 * @return Entry[] Array of entries.
+	 */
+	public function get_for_post( int $post_id, array $args = array() ): array {
+		return $this->repository->get_entries( $post_id, $args );
 	}
 
 	/**

--- a/src/php/Domain/Entity/Entry.php
+++ b/src/php/Domain/Entity/Entry.php
@@ -1,0 +1,295 @@
+<?php
+/**
+ * Entry entity representing a liveblog entry.
+ *
+ * @package Automattic\Liveblog\Domain\Entity
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Domain\Entity;
+
+use Automattic\Liveblog\Domain\ValueObject\AuthorCollection;
+use Automattic\Liveblog\Domain\ValueObject\EntryContent;
+use Automattic\Liveblog\Domain\ValueObject\EntryId;
+use Automattic\Liveblog\Domain\ValueObject\EntryType;
+use DateTimeImmutable;
+
+/**
+ * Immutable domain entity representing a liveblog entry.
+ *
+ * An Entry is the core domain object for liveblog content. It aggregates
+ * the entry's identity, content, authorship, and metadata into a single
+ * cohesive object.
+ *
+ * Entries are immutable - to modify an entry, create a new one that
+ * references the original via the replaces property.
+ */
+final class Entry {
+
+	/**
+	 * Entry ID.
+	 *
+	 * @var EntryId
+	 */
+	private EntryId $id;
+
+	/**
+	 * Post ID this entry belongs to.
+	 *
+	 * @var int
+	 */
+	private int $post_id;
+
+	/**
+	 * Entry content.
+	 *
+	 * @var EntryContent
+	 */
+	private EntryContent $content;
+
+	/**
+	 * Entry type (new, update, delete).
+	 *
+	 * @var EntryType
+	 */
+	private EntryType $type;
+
+	/**
+	 * Authors of this entry.
+	 *
+	 * @var AuthorCollection
+	 */
+	private AuthorCollection $authors;
+
+	/**
+	 * ID of the entry this one replaces, if any.
+	 *
+	 * @var EntryId|null
+	 */
+	private ?EntryId $replaces;
+
+	/**
+	 * When the entry was created.
+	 *
+	 * @var DateTimeImmutable
+	 */
+	private DateTimeImmutable $created_at;
+
+	/**
+	 * Private constructor - use factory methods.
+	 *
+	 * @param EntryId           $id         Entry ID.
+	 * @param int               $post_id    Post ID.
+	 * @param EntryContent      $content    Entry content.
+	 * @param EntryType         $type       Entry type.
+	 * @param AuthorCollection  $authors    Authors.
+	 * @param EntryId|null      $replaces   ID of entry this replaces.
+	 * @param DateTimeImmutable $created_at Creation timestamp.
+	 */
+	private function __construct(
+		EntryId $id,
+		int $post_id,
+		EntryContent $content,
+		EntryType $type,
+		AuthorCollection $authors,
+		?EntryId $replaces,
+		DateTimeImmutable $created_at
+	) {
+		$this->id         = $id;
+		$this->post_id    = $post_id;
+		$this->content    = $content;
+		$this->type       = $type;
+		$this->authors    = $authors;
+		$this->replaces   = $replaces;
+		$this->created_at = $created_at;
+	}
+
+	/**
+	 * Create an Entry from its constituent parts.
+	 *
+	 * @param EntryId           $id         Entry ID.
+	 * @param int               $post_id    Post ID.
+	 * @param EntryContent      $content    Entry content.
+	 * @param AuthorCollection  $authors    Authors.
+	 * @param EntryId|null      $replaces   ID of entry this replaces.
+	 * @param DateTimeImmutable $created_at Creation timestamp.
+	 * @return self
+	 */
+	public static function create(
+		EntryId $id,
+		int $post_id,
+		EntryContent $content,
+		AuthorCollection $authors,
+		?EntryId $replaces,
+		DateTimeImmutable $created_at
+	): self {
+		$type = EntryType::from_replaces_and_content(
+			$replaces?->to_int(),
+			$content->raw()
+		);
+
+		return new self( $id, $post_id, $content, $type, $authors, $replaces, $created_at );
+	}
+
+	/**
+	 * Get the entry ID.
+	 *
+	 * @return EntryId
+	 */
+	public function id(): EntryId {
+		return $this->id;
+	}
+
+	/**
+	 * Get the post ID.
+	 *
+	 * @return int
+	 */
+	public function post_id(): int {
+		return $this->post_id;
+	}
+
+	/**
+	 * Get the entry content.
+	 *
+	 * @return EntryContent
+	 */
+	public function content(): EntryContent {
+		return $this->content;
+	}
+
+	/**
+	 * Get the entry type.
+	 *
+	 * @return EntryType
+	 */
+	public function type(): EntryType {
+		return $this->type;
+	}
+
+	/**
+	 * Get the authors.
+	 *
+	 * @return AuthorCollection
+	 */
+	public function authors(): AuthorCollection {
+		return $this->authors;
+	}
+
+	/**
+	 * Get the ID of the entry this one replaces.
+	 *
+	 * @return EntryId|null
+	 */
+	public function replaces(): ?EntryId {
+		return $this->replaces;
+	}
+
+	/**
+	 * Get the creation timestamp.
+	 *
+	 * @return DateTimeImmutable
+	 */
+	public function created_at(): DateTimeImmutable {
+		return $this->created_at;
+	}
+
+	/**
+	 * Check if this entry is a new entry (not an update or delete).
+	 *
+	 * @return bool
+	 */
+	public function is_new(): bool {
+		return $this->type->is_new();
+	}
+
+	/**
+	 * Check if this entry is an update to another entry.
+	 *
+	 * @return bool
+	 */
+	public function is_update(): bool {
+		return $this->type->is_update();
+	}
+
+	/**
+	 * Check if this entry is a deletion marker.
+	 *
+	 * @return bool
+	 */
+	public function is_delete(): bool {
+		return $this->type->is_delete();
+	}
+
+	/**
+	 * Get the effective entry ID for display purposes.
+	 *
+	 * For updates and deletes, this returns the ID of the original entry
+	 * being replaced. For new entries, returns this entry's ID.
+	 *
+	 * @return EntryId
+	 */
+	public function display_id(): EntryId {
+		return $this->replaces ?? $this->id;
+	}
+
+	/**
+	 * Get the Unix timestamp for the entry.
+	 *
+	 * @return int
+	 */
+	public function timestamp(): int {
+		return $this->created_at->getTimestamp();
+	}
+
+	/**
+	 * Check if this entry has visible authors.
+	 *
+	 * @return bool
+	 */
+	public function has_authors(): bool {
+		return ! $this->authors->is_empty();
+	}
+
+	/**
+	 * Create a new Entry with different authors.
+	 *
+	 * Since Entry is immutable, this returns a new instance.
+	 *
+	 * @param AuthorCollection $authors New authors.
+	 * @return self
+	 */
+	public function with_authors( AuthorCollection $authors ): self {
+		return new self(
+			$this->id,
+			$this->post_id,
+			$this->content,
+			$this->type,
+			$authors,
+			$this->replaces,
+			$this->created_at
+		);
+	}
+
+	/**
+	 * Create a new Entry with different content.
+	 *
+	 * Since Entry is immutable, this returns a new instance.
+	 * Note: This does NOT change the entry type - use for display purposes only.
+	 *
+	 * @param EntryContent $content New content.
+	 * @return self
+	 */
+	public function with_content( EntryContent $content ): self {
+		return new self(
+			$this->id,
+			$this->post_id,
+			$content,
+			$this->type,
+			$this->authors,
+			$this->replaces,
+			$this->created_at
+		);
+	}
+}

--- a/src/php/Domain/Entity/Entry.php
+++ b/src/php/Domain/Entity/Entry.php
@@ -125,7 +125,7 @@ final class Entry {
 		DateTimeImmutable $created_at
 	): self {
 		$type = EntryType::from_replaces_and_content(
-			$replaces?->to_int(),
+			$replaces ? $replaces->to_int() : null,
 			$content->raw()
 		);
 

--- a/src/php/Domain/Repository/EntryRepositoryInterface.php
+++ b/src/php/Domain/Repository/EntryRepositoryInterface.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Domain\Repository;
 
+use Automattic\Liveblog\Domain\Entity\Entry;
 use Automattic\Liveblog\Domain\ValueObject\EntryId;
 use WP_Comment;
 
@@ -22,7 +23,33 @@ use WP_Comment;
 interface EntryRepositoryInterface {
 
 	/**
-	 * Find an entry by its ID.
+	 * Get an Entry entity by its ID.
+	 *
+	 * This is the preferred method for retrieving entries as it returns
+	 * a fully hydrated domain entity.
+	 *
+	 * @param EntryId $id Entry ID.
+	 * @return Entry|null The entry or null if not found.
+	 */
+	public function get_entry( EntryId $id ): ?Entry;
+
+	/**
+	 * Get Entry entities by post ID.
+	 *
+	 * This is the preferred method for retrieving multiple entries as it
+	 * returns fully hydrated domain entities.
+	 *
+	 * @param int   $post_id Post ID.
+	 * @param array $args    Optional query arguments.
+	 * @return Entry[] Array of entries.
+	 */
+	public function get_entries( int $post_id, array $args = array() ): array;
+
+	/**
+	 * Find raw comment data by entry ID.
+	 *
+	 * Lower-level method that returns the underlying WP_Comment.
+	 * Prefer get_entry() for most use cases.
 	 *
 	 * @param EntryId $id Entry ID.
 	 * @return WP_Comment|null The entry data or null if not found.
@@ -30,7 +57,10 @@ interface EntryRepositoryInterface {
 	public function find_by_id( EntryId $id ): ?WP_Comment;
 
 	/**
-	 * Find entries by post ID.
+	 * Find raw comment data by post ID.
+	 *
+	 * Lower-level method that returns underlying WP_Comments.
+	 * Prefer get_entries() for most use cases.
 	 *
 	 * @param int   $post_id Post ID.
 	 * @param array $args    Optional query arguments.

--- a/tests/Unit/Domain/Entity/EntryTest.php
+++ b/tests/Unit/Domain/Entity/EntryTest.php
@@ -103,7 +103,7 @@ final class EntryTest extends TestCase {
 	 * Test is_update helper.
 	 */
 	public function test_is_update(): void {
-		$entry = $this->create_entry( replaces: EntryId::from_int( 100 ) );
+		$entry = $this->create_entry( null, null, null, null, EntryId::from_int( 100 ) );
 
 		$this->assertFalse( $entry->is_new() );
 		$this->assertTrue( $entry->is_update() );
@@ -115,8 +115,11 @@ final class EntryTest extends TestCase {
 	 */
 	public function test_is_delete(): void {
 		$entry = $this->create_entry(
-			content: EntryContent::empty(),
-			replaces: EntryId::from_int( 100 )
+			null,
+			null,
+			EntryContent::empty(),
+			null,
+			EntryId::from_int( 100 )
 		);
 
 		$this->assertFalse( $entry->is_new() );
@@ -128,7 +131,7 @@ final class EntryTest extends TestCase {
 	 * Test display_id returns own ID for new entries.
 	 */
 	public function test_display_id_for_new_entry(): void {
-		$entry = $this->create_entry( id: EntryId::from_int( 123 ) );
+		$entry = $this->create_entry( EntryId::from_int( 123 ) );
 
 		$this->assertSame( 123, $entry->display_id()->to_int() );
 	}
@@ -138,8 +141,11 @@ final class EntryTest extends TestCase {
 	 */
 	public function test_display_id_for_update_entry(): void {
 		$entry = $this->create_entry(
-			id: EntryId::from_int( 124 ),
-			replaces: EntryId::from_int( 123 )
+			EntryId::from_int( 124 ),
+			null,
+			null,
+			null,
+			EntryId::from_int( 123 )
 		);
 
 		$this->assertSame( 123, $entry->display_id()->to_int() );
@@ -150,7 +156,7 @@ final class EntryTest extends TestCase {
 	 */
 	public function test_timestamp(): void {
 		$created_at = new DateTimeImmutable( '2024-01-15 10:30:00', new DateTimeZone( 'UTC' ) );
-		$entry      = $this->create_entry( created_at: $created_at );
+		$entry      = $this->create_entry( null, null, null, null, null, $created_at );
 
 		$this->assertSame( $created_at->getTimestamp(), $entry->timestamp() );
 	}
@@ -164,10 +170,10 @@ final class EntryTest extends TestCase {
 				array(
 					'id'   => 1,
 					'name' => 'Test',
-				) 
+				)
 			)
 		);
-		$entry   = $this->create_entry( authors: $authors );
+		$entry   = $this->create_entry( null, null, null, $authors );
 
 		$this->assertTrue( $entry->has_authors() );
 	}
@@ -176,7 +182,7 @@ final class EntryTest extends TestCase {
 	 * Test has_authors returns false when no authors.
 	 */
 	public function test_has_authors_false(): void {
-		$entry = $this->create_entry( authors: AuthorCollection::empty() );
+		$entry = $this->create_entry( null, null, null, AuthorCollection::empty() );
 
 		$this->assertFalse( $entry->has_authors() );
 	}
@@ -202,7 +208,7 @@ final class EntryTest extends TestCase {
 			)
 		);
 
-		$original = $this->create_entry( authors: $original_authors );
+		$original = $this->create_entry( null, null, null, $original_authors );
 		$modified = $original->with_authors( $new_authors );
 
 		// Original unchanged.
@@ -224,7 +230,7 @@ final class EntryTest extends TestCase {
 		$original_content = EntryContent::from_raw( 'Original content' );
 		$new_content      = EntryContent::from_raw( 'New content' );
 
-		$original = $this->create_entry( content: $original_content );
+		$original = $this->create_entry( null, null, $original_content );
 		$modified = $original->with_content( $new_content );
 
 		// Original unchanged.

--- a/tests/Unit/Domain/Entity/EntryTest.php
+++ b/tests/Unit/Domain/Entity/EntryTest.php
@@ -1,0 +1,297 @@
+<?php
+/**
+ * Tests for Entry entity.
+ *
+ * @package Automattic\Liveblog\Tests\Unit\Domain\Entity
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Tests\Unit\Domain\Entity;
+
+use Automattic\Liveblog\Domain\Entity\Entry;
+use Automattic\Liveblog\Domain\ValueObject\Author;
+use Automattic\Liveblog\Domain\ValueObject\AuthorCollection;
+use Automattic\Liveblog\Domain\ValueObject\EntryContent;
+use Automattic\Liveblog\Domain\ValueObject\EntryId;
+use DateTimeImmutable;
+use DateTimeZone;
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+
+/**
+ * Tests for the Entry entity.
+ *
+ * @covers \Automattic\Liveblog\Domain\Entity\Entry
+ */
+final class EntryTest extends TestCase {
+
+	/**
+	 * Test creating a new entry.
+	 */
+	public function test_create_new_entry(): void {
+		$id         = EntryId::from_int( 123 );
+		$post_id    = 456;
+		$content    = EntryContent::from_raw( 'Test content' );
+		$authors    = AuthorCollection::from_authors(
+			Author::from_array(
+				array(
+					'id'   => 1,
+					'name' => 'Test Author',
+				) 
+			)
+		);
+		$created_at = new DateTimeImmutable( '2024-01-15 10:30:00', new DateTimeZone( 'UTC' ) );
+
+		$entry = Entry::create( $id, $post_id, $content, $authors, null, $created_at );
+
+		$this->assertSame( 123, $entry->id()->to_int() );
+		$this->assertSame( 456, $entry->post_id() );
+		$this->assertSame( 'Test content', $entry->content()->raw() );
+		$this->assertTrue( $entry->type()->is_new() );
+		$this->assertFalse( $entry->authors()->is_empty() );
+		$this->assertNull( $entry->replaces() );
+		$this->assertSame( $created_at, $entry->created_at() );
+	}
+
+	/**
+	 * Test creating an update entry.
+	 */
+	public function test_create_update_entry(): void {
+		$id         = EntryId::from_int( 124 );
+		$replaces   = EntryId::from_int( 123 );
+		$content    = EntryContent::from_raw( 'Updated content' );
+		$authors    = AuthorCollection::empty();
+		$created_at = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+
+		$entry = Entry::create( $id, 456, $content, $authors, $replaces, $created_at );
+
+		$this->assertTrue( $entry->type()->is_update() );
+		$this->assertFalse( $entry->type()->is_new() );
+		$this->assertFalse( $entry->type()->is_delete() );
+		$this->assertSame( 123, $entry->replaces()->to_int() );
+	}
+
+	/**
+	 * Test creating a delete entry.
+	 */
+	public function test_create_delete_entry(): void {
+		$id         = EntryId::from_int( 125 );
+		$replaces   = EntryId::from_int( 123 );
+		$content    = EntryContent::empty();
+		$authors    = AuthorCollection::empty();
+		$created_at = new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) );
+
+		$entry = Entry::create( $id, 456, $content, $authors, $replaces, $created_at );
+
+		$this->assertTrue( $entry->type()->is_delete() );
+		$this->assertFalse( $entry->type()->is_new() );
+		$this->assertFalse( $entry->type()->is_update() );
+	}
+
+	/**
+	 * Test is_new helper.
+	 */
+	public function test_is_new(): void {
+		$entry = $this->create_entry();
+
+		$this->assertTrue( $entry->is_new() );
+		$this->assertFalse( $entry->is_update() );
+		$this->assertFalse( $entry->is_delete() );
+	}
+
+	/**
+	 * Test is_update helper.
+	 */
+	public function test_is_update(): void {
+		$entry = $this->create_entry( replaces: EntryId::from_int( 100 ) );
+
+		$this->assertFalse( $entry->is_new() );
+		$this->assertTrue( $entry->is_update() );
+		$this->assertFalse( $entry->is_delete() );
+	}
+
+	/**
+	 * Test is_delete helper.
+	 */
+	public function test_is_delete(): void {
+		$entry = $this->create_entry(
+			content: EntryContent::empty(),
+			replaces: EntryId::from_int( 100 )
+		);
+
+		$this->assertFalse( $entry->is_new() );
+		$this->assertFalse( $entry->is_update() );
+		$this->assertTrue( $entry->is_delete() );
+	}
+
+	/**
+	 * Test display_id returns own ID for new entries.
+	 */
+	public function test_display_id_for_new_entry(): void {
+		$entry = $this->create_entry( id: EntryId::from_int( 123 ) );
+
+		$this->assertSame( 123, $entry->display_id()->to_int() );
+	}
+
+	/**
+	 * Test display_id returns replaces ID for update entries.
+	 */
+	public function test_display_id_for_update_entry(): void {
+		$entry = $this->create_entry(
+			id: EntryId::from_int( 124 ),
+			replaces: EntryId::from_int( 123 )
+		);
+
+		$this->assertSame( 123, $entry->display_id()->to_int() );
+	}
+
+	/**
+	 * Test timestamp returns Unix timestamp.
+	 */
+	public function test_timestamp(): void {
+		$created_at = new DateTimeImmutable( '2024-01-15 10:30:00', new DateTimeZone( 'UTC' ) );
+		$entry      = $this->create_entry( created_at: $created_at );
+
+		$this->assertSame( $created_at->getTimestamp(), $entry->timestamp() );
+	}
+
+	/**
+	 * Test has_authors returns true when authors exist.
+	 */
+	public function test_has_authors_true(): void {
+		$authors = AuthorCollection::from_authors(
+			Author::from_array(
+				array(
+					'id'   => 1,
+					'name' => 'Test',
+				) 
+			)
+		);
+		$entry   = $this->create_entry( authors: $authors );
+
+		$this->assertTrue( $entry->has_authors() );
+	}
+
+	/**
+	 * Test has_authors returns false when no authors.
+	 */
+	public function test_has_authors_false(): void {
+		$entry = $this->create_entry( authors: AuthorCollection::empty() );
+
+		$this->assertFalse( $entry->has_authors() );
+	}
+
+	/**
+	 * Test with_authors returns new instance.
+	 */
+	public function test_with_authors_returns_new_instance(): void {
+		$original_authors = AuthorCollection::from_authors(
+			Author::from_array(
+				array(
+					'id'   => 1,
+					'name' => 'Original',
+				) 
+			)
+		);
+		$new_authors      = AuthorCollection::from_authors(
+			Author::from_array(
+				array(
+					'id'   => 2,
+					'name' => 'New',
+				) 
+			)
+		);
+
+		$original = $this->create_entry( authors: $original_authors );
+		$modified = $original->with_authors( $new_authors );
+
+		// Original unchanged.
+		$this->assertSame( 'Original', $original->authors()->primary()->display_name() );
+
+		// New instance has new authors.
+		$this->assertSame( 'New', $modified->authors()->primary()->display_name() );
+
+		// Other properties preserved.
+		$this->assertSame( $original->id()->to_int(), $modified->id()->to_int() );
+		$this->assertSame( $original->post_id(), $modified->post_id() );
+		$this->assertSame( $original->content()->raw(), $modified->content()->raw() );
+	}
+
+	/**
+	 * Test with_content returns new instance.
+	 */
+	public function test_with_content_returns_new_instance(): void {
+		$original_content = EntryContent::from_raw( 'Original content' );
+		$new_content      = EntryContent::from_raw( 'New content' );
+
+		$original = $this->create_entry( content: $original_content );
+		$modified = $original->with_content( $new_content );
+
+		// Original unchanged.
+		$this->assertSame( 'Original content', $original->content()->raw() );
+
+		// New instance has new content.
+		$this->assertSame( 'New content', $modified->content()->raw() );
+
+		// Other properties preserved.
+		$this->assertSame( $original->id()->to_int(), $modified->id()->to_int() );
+		$this->assertSame( $original->post_id(), $modified->post_id() );
+	}
+
+	/**
+	 * Test all getters.
+	 */
+	public function test_getters(): void {
+		$id         = EntryId::from_int( 999 );
+		$post_id    = 888;
+		$content    = EntryContent::from_raw( 'Getter test' );
+		$authors    = AuthorCollection::empty();
+		$replaces   = EntryId::from_int( 777 );
+		$created_at = new DateTimeImmutable( '2024-06-01 12:00:00', new DateTimeZone( 'UTC' ) );
+
+		$entry = Entry::create( $id, $post_id, $content, $authors, $replaces, $created_at );
+
+		$this->assertSame( $id, $entry->id() );
+		$this->assertSame( $post_id, $entry->post_id() );
+		$this->assertSame( $content, $entry->content() );
+		$this->assertSame( $authors, $entry->authors() );
+		$this->assertSame( $replaces, $entry->replaces() );
+		$this->assertSame( $created_at, $entry->created_at() );
+	}
+
+	/**
+	 * Helper to create an entry with defaults.
+	 *
+	 * @param EntryId|null           $id         Entry ID.
+	 * @param int|null               $post_id    Post ID.
+	 * @param EntryContent|null      $content    Content.
+	 * @param AuthorCollection|null  $authors    Authors.
+	 * @param EntryId|null           $replaces   Replaces ID.
+	 * @param DateTimeImmutable|null $created_at Created timestamp.
+	 * @return Entry
+	 */
+	private function create_entry(
+		?EntryId $id = null,
+		?int $post_id = null,
+		?EntryContent $content = null,
+		?AuthorCollection $authors = null,
+		?EntryId $replaces = null,
+		?DateTimeImmutable $created_at = null
+	): Entry {
+		return Entry::create(
+			$id ?? EntryId::from_int( 1 ),
+			$post_id ?? 1,
+			$content ?? EntryContent::from_raw( 'Test content' ),
+			$authors ?? AuthorCollection::from_authors(
+				Author::from_array(
+					array(
+						'id'   => 1,
+						'name' => 'Test Author',
+					) 
+				)
+			),
+			$replaces,
+			$created_at ?? new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) )
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- Adds an immutable `Entry` domain entity that aggregates all entry-related value objects
- Adds `get_entry()` and `get_entries()` methods to the repository for retrieving hydrated Entry entities
- Adds `get()` and `get_for_post()` convenience methods to EntryService
- Repository handles hydration from WP_Comment to Entry, keeping WordPress coupling in the Infrastructure layer

## Entry Entity

The Entry entity is the core domain object for liveblog content, aggregating:
- `EntryId` - unique identifier
- `EntryContent` - raw content with lazy rendering
- `EntryType` - automatically inferred (new/update/delete) from replaces and content
- `AuthorCollection` - primary author plus contributors
- `replaces` - optional reference to entry being updated/deleted
- `created_at` - timestamp

The entity is immutable with `with_*` methods for creating modified copies.

## Usage Example

```php
// Get a single entry as a domain entity
$entry = $entryService->get(EntryId::from_int(123));
if ($entry && $entry->is_new()) {
    echo $entry->content()->rendered();
}

// Get all entries for a liveblog
$entries = $entryService->get_for_post($postId);
foreach ($entries as $entry) {
    if ($entry->has_authors()) {
        echo $entry->authors()->primary()->display_name();
    }
}
```

## Test plan

- [x] All 149 unit tests pass
- [x] Entry entity tests cover creation, type inference, immutability
- [x] Repository tests cover hydration, hidden authors, update/delete types
- [x] Service tests cover delegation to repository
- [x] PHPCS passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)