### PR TITLE
refactor: remove superseded methods from entry class

### DIFF
--- a/src/php/Domain/ValueObject/Author.php
+++ b/src/php/Domain/ValueObject/Author.php
@@ -280,7 +280,7 @@ final class Author {
 	/**
 	 * Convert to array for backwards compatibility.
 	 *
-	 * Matches the format used by WPCOM_Liveblog_Entry::get_user_data_for_json().
+	 * Matches the format used by the legacy liveblog entry author arrays.
 	 *
 	 * @param int $avatar_size Avatar size in pixels.
 	 * @return array


### PR DESCRIPTION
The domain-driven design layer introduced in PR #820 superseded several methods in the legacy `WPCOM_Liveblog_Entry` class. These methods are no longer called anywhere in the codebase, as their responsibilities have been absorbed by more specialised domain objects and services.

## Removed Methods

**Entry Creation** (superseded by `EntryService::create()`):
- `insert_comment()` - Entry creation now happens through the service layer, which properly handles validation, persistence, and cache invalidation whilst keeping domain logic separate from WordPress coupling
- `validate_args()` - Validation is now enforced at the domain layer through value objects with typed constructors

**Author Handling** (superseded by `AuthorCollection`):
- `get_contributors_for_json()` - The `AuthorCollection` value object now handles aggregating primary authors and contributors with proper encapsulation
- `get_user_data_for_json()` - Individual author formatting is handled by the `Author` value object's `to_array()` method

## Consolidated Method

The `get_authors()` method remains as the public interface but has been simplified to delegate to `AuthorCollection::to_array()`, maintaining backwards compatibility whilst leveraging the new domain layer.

## Context

This cleanup is part of the ongoing DDD refactoring to progressively migrate logic from the legacy entry class into proper domain objects and services. By removing dead code, we reduce maintenance burden and make it clearer where logic resides.