### PR TITLE
Fix fatal error in /entries endpoint

### DIFF
--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -182,7 +182,7 @@ class WPCOM_Liveblog_Entry {
 		$comment = get_comment( $comment_id );
 
 		// For Unix timestamp format, use DateTimeImmutable to avoid timezone issues with mysql2date.
-		if ( 'U' === $d || 'G' === $d ) {
+		if ( ( 'U' === $d || 'G' === $d ) && ! empty( $comment->comment_date_gmt ) ) {
 			$datetime = DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $comment->comment_date_gmt, new DateTimeZone( 'UTC' ) );
 			return $datetime->getTimestamp();
 		}

--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -182,9 +182,12 @@ class WPCOM_Liveblog_Entry {
 		$comment = get_comment( $comment_id );
 
 		// For Unix timestamp format, use DateTimeImmutable to avoid timezone issues with mysql2date.
-		if ( ( 'U' === $d || 'G' === $d ) && ! empty( $comment->comment_date_gmt ) ) {
+		// Fall through to mysql2date if the date is empty or malformed (e.g. deleted entries).
+		if ( 'U' === $d || 'G' === $d ) {
 			$datetime = DateTimeImmutable::createFromFormat( 'Y-m-d H:i:s', $comment->comment_date_gmt, new DateTimeZone( 'UTC' ) );
-			return $datetime->getTimestamp();
+			if ( false !== $datetime ) {
+				return $datetime->getTimestamp();
+			}
 		}
 
 		if ( '' === $d ) {

--- a/tests/Integration/EntryTest.php
+++ b/tests/Integration/EntryTest.php
@@ -299,6 +299,40 @@ final class EntryTest extends TestCase {
 	}
 
 	/**
+	 * Test that get_comment_date_gmt falls back to mysql2date when date is empty.
+	 *
+	 * Regression test for https://github.com/Automattic/liveblog/pull/829 — deleted
+	 * entries have an empty comment_date_gmt, which caused a fatal error when passed
+	 * to DateTimeImmutable::createFromFormat(). The DB schema coerces empty values
+	 * back to '0000-00-00 00:00:00', so the scenario is forced via the get_comment
+	 * filter instead.
+	 */
+	public function test_get_comment_date_gmt_falls_back_when_date_is_empty(): void {
+		$comment    = self::factory()->comment->create_and_get();
+		$comment_id = (int) $comment->comment_ID;
+
+		$blank_date = function ( $fetched ) use ( $comment_id ) {
+			if ( $fetched && (int) $fetched->comment_ID === $comment_id ) {
+				$fetched->comment_date_gmt = '';
+			}
+			return $fetched;
+		};
+		add_filter( 'get_comment', $blank_date );
+
+		try {
+			// The important assertion is that this does not fatal. mysql2date() returns
+			// false for an empty input; the exact return contract for deleted entries
+			// is the subject of the follow-up root-cause work.
+			$timestamp = ( new WPCOM_Liveblog_Entry( get_comment( $comment_id ) ) )
+				->get_comment_date_gmt( 'U', $comment_id );
+
+			$this->assertFalse( $timestamp );
+		} finally {
+			remove_filter( 'get_comment', $blank_date );
+		}
+	}
+
+	/**
 	 * Test that get_comment_date_gmt still works with other formats.
 	 */
 	public function test_get_comment_date_gmt_with_date_format_returns_formatted_string(): void {


### PR DESCRIPTION
In the /entries endpoint it fetches all the entries including deleted comment. The delete entries don't have `$comment->comment_date_gmt` set and hence the `DateTimeImmutable` approach introduced in this commit https://github.com/Automattic/liveblog/commit/1dbcf5edd22601f2bf06a7f6e5f77f84ef742f1a doesn't work and throws a fatal error for /entries endpoint.

This fix checks whether `$comment->comment_date_gmt` is not empty and only then uses `DateTimeImmutable` otherwise falls back to use `mysql2date`.