### PR TITLE
Fix duplicate class name PHPCS warning in test stub

### DIFF
--- a/tests/Unit/wp-stubs.php
+++ b/tests/Unit/wp-stubs.php
@@ -57,6 +57,7 @@ if ( ! function_exists( 'get_comment_meta' ) ) {
 
 // phpcs:enable
 
+// phpcs:disable Generic.Classes.DuplicateClassName.Found, Generic.Files.OneObjectStructurePerFile.MultipleFound, PEAR.NamingConventions.ValidClassName.Invalid
 if ( ! class_exists( 'WPCOM_Liveblog' ) ) {
 	/**
 	 * Minimal WPCOM_Liveblog stub for unit testing.
@@ -66,7 +67,6 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) {
 	 * WordPress dependencies to load for unit tests.
 	 */
 	final class WPCOM_Liveblog {
- // phpcs:ignore Generic.Files.OneObjectStructurePerFile.MultipleFound, PEAR.NamingConventions.ValidClassName.Invalid
 		public const KEY = 'liveblog';
 
 		/**
@@ -80,3 +80,4 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) {
 		}
 	}
 }
+// phpcs:enable Generic.Classes.DuplicateClassName.Found, Generic.Files.OneObjectStructurePerFile.MultipleFound, PEAR.NamingConventions.ValidClassName.Invalid


### PR DESCRIPTION
## Summary

- Adds `Generic.Classes.DuplicateClassName.Found` to the `phpcs:ignore` directive on the `WPCOM_Liveblog` stub class in `tests/Unit/wp-stubs.php`
- Fixes the [failing CI check on `develop`](https://github.com/Automattic/liveblog/actions/runs/23977077614), where PHPCS flags the stub as a duplicate of the real class in `liveblog.php`

## Test plan

- [ ] Verify the PHPCS CI check passes on this PR