### PR TITLE
Require post read permission on public Liveblog REST endpoints

### DIFF
--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -410,6 +410,13 @@ class WPCOM_Liveblog_Rest_Api {
 	 * @return true|WP_Error True when the request is permitted, otherwise a 404 error.
 	 */
 	public static function can_read_liveblog( WP_REST_Request $request ) {
+		// Flag the REST API context before calling is_liveblog_post(). Without this,
+		// WPCOM_Liveblog::get_liveblog_state() short-circuits to false because none
+		// of is_singular(), is_admin() or $is_rest_api_call is truthy yet at
+		// permission-callback time (set_liveblog_vars() only runs inside the route
+		// callback, after the permission check has already passed).
+		WPCOM_Liveblog::$is_rest_api_call = true;
+
 		$post_id = (int) $request->get_param( 'post_id' );
 		$post    = $post_id > 0 ? get_post( $post_id ) : null;
 

--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -91,6 +91,10 @@ class WPCOM_Liveblog_Rest_Api {
 	 * Register all of our endpoints.
 	 * Any validation, sanitization, and permission checks can be done here using callbacks.
 	 *
+	 * Public read endpoints share the `can_read_liveblog` permission callback so that
+	 * liveblog entries are not returned for posts the current request cannot otherwise
+	 * read. Any new public read route should use the same callback.
+	 *
 	 * @return void
 	 */
 	public static function register_routes() {
@@ -116,7 +120,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => true,
 					),
 				),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( __CLASS__, 'can_read_liveblog' ),
 			)
 		);
 
@@ -177,7 +181,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => true,
 					),
 				),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( __CLASS__, 'can_read_liveblog' ),
 			)
 		);
 
@@ -201,7 +205,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => true,
 					),
 				),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( __CLASS__, 'can_read_liveblog' ),
 			)
 		);
 
@@ -332,7 +336,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => true,
 					),
 				),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( __CLASS__, 'can_read_liveblog' ),
 			)
 		);
 
@@ -353,7 +357,7 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => true,
 					),
 				),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( __CLASS__, 'can_read_liveblog' ),
 			)
 		);
 
@@ -380,8 +384,63 @@ class WPCOM_Liveblog_Rest_Api {
 						'required' => true,
 					),
 				),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( __CLASS__, 'can_read_liveblog' ),
 			)
+		);
+	}
+
+	/**
+	 * Permission callback for public liveblog read endpoints.
+	 *
+	 * Liveblog entries inherit their access rules from the parent post. To avoid leaking
+	 * entries that belong to draft, private, scheduled, trashed, or otherwise non-public
+	 * posts, this callback requires:
+	 *
+	 * - The referenced post to exist.
+	 * - Liveblog to be enabled (or archived) on the post.
+	 * - The post to be published, or the current user to have the `read_post` capability
+	 *   for it.
+	 *
+	 * All failure paths return a 404 so the endpoint cannot be used as an oracle for
+	 * post existence or status.
+	 *
+	 * @since 1.12.0
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return true|WP_Error True when the request is permitted, otherwise a 404 error.
+	 */
+	public static function can_read_liveblog( WP_REST_Request $request ) {
+		$post_id = (int) $request->get_param( 'post_id' );
+		$post    = $post_id > 0 ? get_post( $post_id ) : null;
+
+		$allowed = (
+			$post instanceof WP_Post
+			&& WPCOM_Liveblog::is_liveblog_post( $post_id )
+			&& ( 'publish' === $post->post_status || current_user_can( 'read_post', $post_id ) )
+		);
+
+		/**
+		 * Filters whether the current request may read liveblog entries for a given post.
+		 *
+		 * Default behaviour requires that the post exists, has liveblog enabled, and is
+		 * either published or readable by the current user. Filter to loosen or tighten.
+		 *
+		 * @since 1.12.0
+		 *
+		 * @param bool            $allowed Whether the request is allowed.
+		 * @param int             $post_id The post ID being queried (0 when not supplied).
+		 * @param WP_REST_Request $request The current REST request.
+		 */
+		$allowed = (bool) apply_filters( 'liveblog_rest_read_permission', $allowed, $post_id, $request );
+
+		if ( $allowed ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_liveblog_not_found',
+			__( 'Liveblog not found.', 'liveblog' ),
+			array( 'status' => 404 )
 		);
 	}
 

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -384,15 +384,15 @@ final class RestApiTest extends TestCase {
 	 * Integration test - Test accessing the get entries endpoint.
 	 */
 	public function test_endpoint_get_entries(): void {
-		// Insert 1 entry.
-		$this->insert_entries();
+		$post_id = $this->create_liveblog_post();
+		$this->insert_entries( 1, array( 'post_id' => $post_id ) );
 
 		// A time window with entries.
 		$start_time = strtotime( '-1 hour' );
 		$end_time   = strtotime( '+1 hour' );
 
 		// Try to access the endpoint.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/1/entries/' . $start_time . '/' . $end_time );
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/entries/' . $start_time . '/' . $end_time );
 		$response = $this->server->dispatch( $request );
 
 		// Assert successful response.
@@ -436,15 +436,15 @@ final class RestApiTest extends TestCase {
 	 * Integration test - Test accessing the lazyload endpoint.
 	 */
 	public function test_endpoint_lazyload(): void {
-		// Insert 1 entry.
-		$this->insert_entries();
+		$post_id = $this->create_liveblog_post();
+		$this->insert_entries( 1, array( 'post_id' => $post_id ) );
 
 		// A time window with entries.
 		$max_timestamp = strtotime( '+1 day' );
 		$min_timestamp = 0;
 
 		// Try to access the endpoint.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/1/lazyload/' . $max_timestamp . '/' . $min_timestamp );
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/lazyload/' . $max_timestamp . '/' . $min_timestamp );
 		$response = $this->server->dispatch( $request );
 
 		// Assert successful response.
@@ -460,11 +460,11 @@ final class RestApiTest extends TestCase {
 	 * Integration test - Test accessing the get single entry endpoint.
 	 */
 	public function test_endpoint_get_single_entry(): void {
-		// Insert 1 entry.
-		$new_entries = $this->insert_entries();
+		$post_id     = $this->create_liveblog_post();
+		$new_entries = $this->insert_entries( 1, array( 'post_id' => $post_id ) );
 
 		// Try to access the endpoint.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/1/entry/' . $new_entries[0]->get_id() );
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/entry/' . $new_entries[0]->get_id() );
 		$response = $this->server->dispatch( $request );
 
 		// Assert successful response.
@@ -745,11 +745,12 @@ final class RestApiTest extends TestCase {
 	/**
 	 * Create a new post and make it a liveblog.
 	 *
+	 * @param array $post_args Optional post arguments to override the defaults (e.g. post_status).
 	 * @return int The ID of the new liveblog post.
 	 */
-	private function create_liveblog_post(): int {
+	private function create_liveblog_post( array $post_args = array() ): int {
 		// Create a new post.
-		$post_id = self::factory()->post->create();
+		$post_id = self::factory()->post->create( $post_args );
 
 		// Make the new post a liveblog.
 		$state        = 'enable';
@@ -757,5 +758,163 @@ final class RestApiTest extends TestCase {
 		WPCOM_Liveblog::admin_set_liveblog_state_for_post( $post_id, $state, $request_vars );
 
 		return $post_id;
+	}
+
+	/**
+	 * Data provider for non-public liveblog posts.
+	 *
+	 * Each entry is a post_status that should not expose liveblog entries to anonymous
+	 * callers of the public read endpoints.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function non_public_post_statuses(): array {
+		return array(
+			'draft'   => array( 'draft' ),
+			'private' => array( 'private' ),
+			'future'  => array( 'future' ),
+			'trash'   => array( 'trash' ),
+		);
+	}
+
+	/**
+	 * Anonymous requests must not retrieve liveblog entries for non-public posts.
+	 *
+	 * Covers HackerOne reports #3683538 and #3615321 (CWE-639, IDOR).
+	 *
+	 * @dataProvider non_public_post_statuses
+	 *
+	 * @param string $post_status Post status to test.
+	 */
+	public function test_public_read_endpoints_deny_anonymous_for_non_public_posts( string $post_status ): void {
+		// Create as a published liveblog post with entries, then transition to the target
+		// status. This avoids WordPress rewriting the status during insert (e.g. future
+		// posts with no future date, or liveblog enablement refusing non-publish states).
+		$post_id = $this->create_liveblog_post();
+		$entry   = $this->insert_entries( 1, array( 'post_id' => $post_id ) )[0];
+
+		$update = array(
+			'ID'          => $post_id,
+			'post_status' => $post_status,
+		);
+		if ( 'future' === $post_status ) {
+			$update['post_date']     = gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) );
+			$update['post_date_gmt'] = gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) );
+		}
+		wp_update_post( $update );
+
+		foreach ( $this->public_read_urls_for_post( $post_id, $entry->get_id() ) as $url ) {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+
+			$this->assertEquals(
+				404,
+				$response->get_status(),
+				sprintf( 'Expected 404 on %s for post_status=%s', $url, $post_status )
+			);
+		}
+	}
+
+	/**
+	 * Anonymous requests for a post that does not exist must receive a 404.
+	 */
+	public function test_public_read_endpoints_deny_anonymous_for_missing_post(): void {
+		$missing_post_id = 999999;
+
+		foreach ( $this->public_read_urls_for_post( $missing_post_id, 1 ) as $url ) {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+			$this->assertEquals( 404, $response->get_status(), sprintf( 'Expected 404 on %s', $url ) );
+		}
+	}
+
+	/**
+	 * Anonymous requests for a published post that is not a liveblog must receive a 404.
+	 *
+	 * This prevents the endpoints from being used as an oracle to distinguish liveblog
+	 * posts from regular posts.
+	 */
+	public function test_public_read_endpoints_deny_anonymous_for_non_liveblog_post(): void {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		foreach ( $this->public_read_urls_for_post( $post_id, 1 ) as $url ) {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+			$this->assertEquals( 404, $response->get_status(), sprintf( 'Expected 404 on %s', $url ) );
+		}
+	}
+
+	/**
+	 * An editor user can read liveblog entries on a draft post they have permission to read.
+	 */
+	public function test_public_read_endpoints_allow_editor_on_draft_post(): void {
+		$post_id = $this->create_liveblog_post();
+		$entry   = $this->insert_entries( 1, array( 'post_id' => $post_id ) )[0];
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$request  = new WP_REST_Request(
+			'GET',
+			self::ENDPOINT_BASE . '/' . $post_id . '/entries/' . strtotime( '-1 hour' ) . '/' . strtotime( '+1 hour' )
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $response->get_data()['entries'] );
+	}
+
+	/**
+	 * The liveblog_rest_read_permission filter can override the default denial.
+	 *
+	 * Useful for headless setups that want to expose entries for drafts without granting
+	 * `read_post` to the anonymous caller.
+	 */
+	public function test_liveblog_rest_read_permission_filter_can_allow(): void {
+		$post_id = $this->create_liveblog_post();
+		$this->insert_entries( 1, array( 'post_id' => $post_id ) );
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		add_filter( 'liveblog_rest_read_permission', '__return_true' );
+
+		$url      = self::ENDPOINT_BASE . '/' . $post_id . '/entries/' . strtotime( '-1 hour' ) . '/' . strtotime( '+1 hour' );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+
+		remove_filter( 'liveblog_rest_read_permission', '__return_true' );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Build the list of public read endpoint URLs that accept a post_id for testing.
+	 *
+	 * @param int $post_id  Post ID to embed.
+	 * @param int $entry_id Entry ID to embed for routes that accept one.
+	 * @return string[]
+	 */
+	private function public_read_urls_for_post( int $post_id, int $entry_id ): array {
+		$base    = self::ENDPOINT_BASE . '/' . $post_id;
+		$start   = strtotime( '-1 hour' );
+		$end     = strtotime( '+1 hour' );
+		$max_ts  = strtotime( '+1 day' );
+		$min_ts  = 0;
+		$last_id = 0;
+
+		return array(
+			$base . '/entries/' . $start . '/' . $end,
+			$base . '/lazyload/' . $max_ts . '/' . $min_ts,
+			$base . '/entry/' . $entry_id,
+			$base . '/get-entries/1/' . $last_id,
+			$base . '/get-key-events/' . $last_id,
+			$base . '/jump-to-key-event/' . $entry_id . '/' . $last_id,
+		);
 	}
 }

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -9,6 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Tests\Integration;
 
+use ReflectionClass;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 use WP_REST_Request;
 use WPCOM_Liveblog;
@@ -36,6 +37,18 @@ final class RestApiTest extends TestCase {
 	 */
 	public function set_up(): void {
 		parent::set_up();
+
+		// Reset WPCOM_Liveblog static state that leaks between tests. The private
+		// $entry_query is cached on first use and bound to whatever $post_id was
+		// current at that moment, so subsequent tests against a different post
+		// would otherwise see zero entries via the stale query.
+		$reflection  = new ReflectionClass( WPCOM_Liveblog::class );
+		$entry_query = $reflection->getProperty( 'entry_query' );
+		$entry_query->setAccessible( true );
+		$entry_query->setValue( null, null );
+
+		WPCOM_Liveblog::$post_id          = null;
+		WPCOM_Liveblog::$is_rest_api_call = false;
 
 		global $wp_rest_server;
 		$wp_rest_server = new SpyRestServer();
@@ -803,7 +816,7 @@ final class RestApiTest extends TestCase {
 		}
 		wp_update_post( $update );
 
-		foreach ( $this->public_read_urls_for_post( $post_id, $entry->get_id() ) as $url ) {
+		foreach ( $this->public_read_urls_for_post( $post_id, (int) $entry->get_id() ) as $url ) {
 			$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
 
 			$this->assertEquals(


### PR DESCRIPTION
## Summary

The public Liveblog read endpoints registered `__return_true` as their permission callback, so unauthenticated callers could retrieve Liveblog entries for any post by supplying the numeric post ID in the route. Entries on draft, private, scheduled, and trashed posts were returned in full, even when the parent post itself returned a 404 to the same caller. On a newsroom deployment that means embargoed reporting, unpublished source notes, and editorial planning could be enumerated ahead of publication.

The fix routes every public read endpoint through a shared `can_read_liveblog` permission callback. The callback requires the post to exist, to have Liveblog enabled, and to be either published or readable by the current user under the `read_post` capability. All failure paths return a 404 rather than 403 so the endpoints cannot be used as an oracle to distinguish missing posts from forbidden ones. A `liveblog_rest_read_permission` filter is provided so sites with headless or other unusual setups can loosen the default if they need to.

The two reports between them only exercised three of the six public read routes (`/entries`, `/get-entries`, `/entry`), but the same `__return_true` pattern existed on `/lazyload`, `/get-key-events`, and `/jump-to-key-event`. All six now share the callback so a follow-up report does not land on us a month from now.

Integration tests cover each failing status (draft, private, future, trash), a missing post, a published non-Liveblog post, and an editor reading a draft they have permission for. The existing endpoint tests were hardcoding post ID 1 without creating the post, which silently worked under `__return_true` and would have broken here; they now create a real Liveblog post first. A separate test verifies the filter can grant access.

Reported via HackerOne as reports #3683538 and #3615321 (CWE-639, IDOR).

The equivalent change needs to land on the `2.x` branch too — that will follow in a separate PR once this is released.

## Test plan

- [ ] CI integration suite passes on WordPress trunk and the supported minimums.
- [ ] Manual smoke test on a local install: anonymous `GET /wp-json/liveblog/v1/<draft_post_id>/entries/0/9999999999` returns 404.
- [ ] Same request as an editor returns 200 with the draft entries.
- [ ] Published Liveblog posts continue to serve entries to anonymous callers (no regression).