### PR TITLE
Require post read permission on public REST endpoints (2.x)

### DIFF
--- a/src/php/Infrastructure/WordPress/RestApiController.php
+++ b/src/php/Infrastructure/WordPress/RestApiController.php
@@ -17,6 +17,7 @@ use Automattic\Liveblog\Application\Service\EntryOperations;
 use Automattic\Liveblog\Application\Service\EntryQueryService;
 use Automattic\Liveblog\Application\Service\KeyEventService;
 use Automattic\Liveblog\Domain\Entity\Entry;
+use Automattic\Liveblog\Domain\Entity\LiveblogPost;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;
@@ -136,6 +137,62 @@ final class RestApiController {
 	}
 
 	/**
+	 * Permission callback for the public read REST endpoints.
+	 *
+	 * Public read endpoints (entries, lazyload, single entry, paged entries, key
+	 * events, jump-to-key-event) accept a post_id from the URL, so they are the
+	 * gateway for CWE-639 (IDOR). Without this check, an unauthenticated caller
+	 * could retrieve entries from a draft, private, future or trashed parent
+	 * post simply by enumerating post IDs.
+	 *
+	 * Access is permitted when all of the following are true:
+	 *
+	 * - The post exists and its post type supports liveblog.
+	 * - Liveblog is enabled or archived on the post.
+	 * - The post is published, or the current user has `read_post` for it.
+	 *
+	 * All failure paths return a 404 so the endpoint cannot be used as an oracle
+	 * for post existence, status or liveblog-ness.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return true|WP_Error True when the request is permitted, otherwise a 404 error.
+	 */
+	public static function can_read_liveblog( WP_REST_Request $request ) {
+		$post_id       = (int) $request->get_param( 'post_id' );
+		$liveblog_post = $post_id > 0 ? LiveblogPost::from_id( $post_id ) : null;
+
+		$allowed = (
+			$liveblog_post instanceof LiveblogPost
+			&& $liveblog_post->is_liveblog()
+			&& ( $liveblog_post->is_published() || current_user_can( 'read_post', $post_id ) )
+		);
+
+		/**
+		 * Filters whether the current request may read liveblog entries for a given post.
+		 *
+		 * Default behaviour requires that the post exists, supports liveblog,
+		 * has liveblog enabled or archived, and is either published or readable
+		 * by the current user. Filter to loosen (e.g. for a headless front end
+		 * serving drafts) or tighten.
+		 *
+		 * @param bool            $allowed Whether the request is allowed.
+		 * @param int             $post_id The post ID being queried (0 when not supplied).
+		 * @param WP_REST_Request $request The current REST request.
+		 */
+		$allowed = (bool) apply_filters( 'liveblog_rest_read_permission', $allowed, $post_id, $request );
+
+		if ( $allowed ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_liveblog_not_found',
+			__( 'Liveblog not found.', 'liveblog' ),
+			array( 'status' => 404 )
+		);
+	}
+
+	/**
 	 * Initialize the REST API controller.
 	 *
 	 * Called from PluginBootstrapper to wire up the controller.
@@ -209,7 +266,7 @@ final class RestApiController {
 					'start_time' => array( 'required' => true ),
 					'end_time'   => array( 'required' => true ),
 				),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( self::class, 'can_read_liveblog' ),
 			)
 		);
 
@@ -251,7 +308,7 @@ final class RestApiController {
 					'max_time' => array( 'required' => true ),
 					'min_time' => array( 'required' => true ),
 				),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( self::class, 'can_read_liveblog' ),
 			)
 		);
 
@@ -266,7 +323,7 @@ final class RestApiController {
 					'post_id'  => array( 'required' => true ),
 					'entry_id' => array( 'required' => true ),
 				),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( self::class, 'can_read_liveblog' ),
 			)
 		);
 
@@ -342,7 +399,7 @@ final class RestApiController {
 					'page'             => array( 'required' => true ),
 					'last_known_entry' => array( 'required' => true ),
 				),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( self::class, 'can_read_liveblog' ),
 			)
 		);
 
@@ -356,7 +413,7 @@ final class RestApiController {
 				'args'                => array(
 					'last_known_entry' => array( 'required' => true ),
 				),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( self::class, 'can_read_liveblog' ),
 			)
 		);
 
@@ -372,7 +429,7 @@ final class RestApiController {
 					'id'               => array( 'required' => true ),
 					'last_known_entry' => array( 'required' => true ),
 				),
-				'permission_callback' => '__return_true',
+				'permission_callback' => array( self::class, 'can_read_liveblog' ),
 			)
 		);
 	}

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -416,15 +416,15 @@ final class RestApiTest extends IntegrationTestCase {
 	 * Integration test - Test accessing the get entries endpoint.
 	 */
 	public function test_endpoint_get_entries(): void {
-		// Insert 1 entry.
-		$this->insert_entries();
+		$post_id = $this->create_liveblog_post();
+		$this->insert_entries( 1, array( 'post_id' => $post_id ) );
 
 		// A time window with entries.
 		$start_time = strtotime( '-1 hour' );
 		$end_time   = strtotime( '+1 hour' );
 
 		// Try to access the endpoint.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/1/entries/' . $start_time . '/' . $end_time );
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/entries/' . $start_time . '/' . $end_time );
 		$response = $this->server->dispatch( $request );
 
 		// Assert successful response.
@@ -468,15 +468,15 @@ final class RestApiTest extends IntegrationTestCase {
 	 * Integration test - Test accessing the lazyload endpoint.
 	 */
 	public function test_endpoint_lazyload(): void {
-		// Insert 1 entry.
-		$this->insert_entries();
+		$post_id = $this->create_liveblog_post();
+		$this->insert_entries( 1, array( 'post_id' => $post_id ) );
 
 		// A time window with entries.
 		$max_timestamp = strtotime( '+1 day' );
 		$min_timestamp = 0;
 
 		// Try to access the endpoint.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/1/lazyload/' . $max_timestamp . '/' . $min_timestamp );
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/lazyload/' . $max_timestamp . '/' . $min_timestamp );
 		$response = $this->server->dispatch( $request );
 
 		// Assert successful response.
@@ -492,11 +492,11 @@ final class RestApiTest extends IntegrationTestCase {
 	 * Integration test - Test accessing the get single entry endpoint.
 	 */
 	public function test_endpoint_get_single_entry(): void {
-		// Insert 1 entry.
-		$new_entries = $this->insert_entries();
+		$post_id     = $this->create_liveblog_post();
+		$new_entries = $this->insert_entries( 1, array( 'post_id' => $post_id ) );
 
 		// Try to access the endpoint.
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/1/entry/' . $new_entries[0]->id()->to_int() );
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/entry/' . $new_entries[0]->id()->to_int() );
 		$response = $this->server->dispatch( $request );
 
 		// Assert successful response.
@@ -777,11 +777,12 @@ final class RestApiTest extends IntegrationTestCase {
 	/**
 	 * Create a new post and make it a liveblog.
 	 *
+	 * @param array $post_args Optional post arguments to override the defaults (e.g. post_status).
 	 * @return int The ID of the new liveblog post.
 	 */
-	private function create_liveblog_post(): int {
+	private function create_liveblog_post( array $post_args = array() ): int {
 		// Create a new post.
-		$post_id = self::factory()->post->create();
+		$post_id = self::factory()->post->create( $post_args );
 
 		// Make the new post a liveblog.
 		$state            = 'enable';
@@ -790,5 +791,164 @@ final class RestApiTest extends IntegrationTestCase {
 		$admin_controller->set_liveblog_state( $post_id, $state, $request_vars );
 
 		return $post_id;
+	}
+
+	/**
+	 * Data provider for non-public liveblog posts.
+	 *
+	 * Each entry is a post_status that should not expose liveblog entries to
+	 * anonymous callers of the public read endpoints.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public static function non_public_post_statuses(): array {
+		return array(
+			'draft'   => array( 'draft' ),
+			'private' => array( 'private' ),
+			'future'  => array( 'future' ),
+			'trash'   => array( 'trash' ),
+		);
+	}
+
+	/**
+	 * Anonymous requests must not retrieve liveblog entries for non-public posts.
+	 *
+	 * Covers HackerOne reports #3683538 and #3615321 (CWE-639, IDOR).
+	 *
+	 * @dataProvider non_public_post_statuses
+	 *
+	 * @param string $post_status Post status to test.
+	 */
+	public function test_public_read_endpoints_deny_anonymous_for_non_public_posts( string $post_status ): void {
+		// Create as a published liveblog post with entries, then transition to
+		// the target status. This avoids WordPress rewriting the status during
+		// insert (e.g. future posts with no future date, or liveblog enablement
+		// refusing non-publish states).
+		$post_id = $this->create_liveblog_post();
+		$entry   = $this->insert_entries( 1, array( 'post_id' => $post_id ) )[0];
+
+		$update = array(
+			'ID'          => $post_id,
+			'post_status' => $post_status,
+		);
+		if ( 'future' === $post_status ) {
+			$update['post_date']     = gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) );
+			$update['post_date_gmt'] = gmdate( 'Y-m-d H:i:s', strtotime( '+1 day' ) );
+		}
+		wp_update_post( $update );
+
+		foreach ( $this->public_read_urls_for_post( $post_id, $entry->id()->to_int() ) as $url ) {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+
+			$this->assertEquals(
+				404,
+				$response->get_status(),
+				sprintf( 'Expected 404 on %s for post_status=%s', $url, $post_status )
+			);
+		}
+	}
+
+	/**
+	 * Anonymous requests for a post that does not exist must receive a 404.
+	 */
+	public function test_public_read_endpoints_deny_anonymous_for_missing_post(): void {
+		$missing_post_id = 999999;
+
+		foreach ( $this->public_read_urls_for_post( $missing_post_id, 1 ) as $url ) {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+			$this->assertEquals( 404, $response->get_status(), sprintf( 'Expected 404 on %s', $url ) );
+		}
+	}
+
+	/**
+	 * Anonymous requests for a published post that is not a liveblog must receive a 404.
+	 *
+	 * This prevents the endpoints from being used as an oracle to distinguish
+	 * liveblog posts from regular posts.
+	 */
+	public function test_public_read_endpoints_deny_anonymous_for_non_liveblog_post(): void {
+		$post_id = self::factory()->post->create( array( 'post_status' => 'publish' ) );
+
+		foreach ( $this->public_read_urls_for_post( $post_id, 1 ) as $url ) {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+			$this->assertEquals( 404, $response->get_status(), sprintf( 'Expected 404 on %s', $url ) );
+		}
+	}
+
+	/**
+	 * An editor user can read liveblog entries on a draft post they have permission to read.
+	 */
+	public function test_public_read_endpoints_allow_editor_on_draft_post(): void {
+		$post_id = $this->create_liveblog_post();
+		$this->insert_entries( 1, array( 'post_id' => $post_id ) );
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$request  = new WP_REST_Request(
+			'GET',
+			self::ENDPOINT_BASE . '/' . $post_id . '/entries/' . strtotime( '-1 hour' ) . '/' . strtotime( '+1 hour' )
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertCount( 1, $response->get_data()['entries'] );
+	}
+
+	/**
+	 * The liveblog_rest_read_permission filter can override the default denial.
+	 *
+	 * Useful for headless setups that want to expose entries for drafts without
+	 * granting `read_post` to the anonymous caller.
+	 */
+	public function test_liveblog_rest_read_permission_filter_can_allow(): void {
+		$post_id = $this->create_liveblog_post();
+		$this->insert_entries( 1, array( 'post_id' => $post_id ) );
+		wp_update_post(
+			array(
+				'ID'          => $post_id,
+				'post_status' => 'draft',
+			)
+		);
+
+		add_filter( 'liveblog_rest_read_permission', '__return_true' );
+
+		$url      = self::ENDPOINT_BASE . '/' . $post_id . '/entries/' . strtotime( '-1 hour' ) . '/' . strtotime( '+1 hour' );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+
+		remove_filter( 'liveblog_rest_read_permission', '__return_true' );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Build the list of public read endpoint URLs that accept a post_id for testing.
+	 *
+	 * @param int $post_id  Post ID to embed.
+	 * @param int $entry_id Entry ID to embed for routes that accept one.
+	 * @return string[]
+	 */
+	private function public_read_urls_for_post( int $post_id, int $entry_id ): array {
+		$base    = self::ENDPOINT_BASE . '/' . $post_id;
+		$start   = strtotime( '-1 hour' );
+		$end     = strtotime( '+1 hour' );
+		$max_ts  = strtotime( '+1 day' );
+		$min_ts  = 0;
+		$last_id = 0;
+
+		return array(
+			$base . '/entries/' . $start . '/' . $end,
+			$base . '/lazyload/' . $max_ts . '/' . $min_ts,
+			$base . '/entry/' . $entry_id,
+			$base . '/get-entries/1/' . $last_id,
+			$base . '/get-key-events/' . $last_id,
+			$base . '/jump-to-key-event/' . $entry_id . '/' . $last_id,
+		);
 	}
 }


### PR DESCRIPTION
## Summary

The six public read REST endpoints accepted a post_id straight from the URL and returned the associated liveblog entries without first verifying that the caller was allowed to read the parent post. An unauthenticated attacker could therefore enumerate post IDs and pull entries from draft, private, future or trashed posts, leaking unpublished editorial content. This was reported on HackerOne as #3683538 and #3615321 (CWE-639, IDOR) and has already been addressed on the 1.x line in #857. This PR ports the same fix to 2.x ahead of the upcoming 2.0 release so the new DDD architecture lands with the same protection.

The six affected routes (`entries`, `lazyload`, `entry`, `get-entries`, `get-key-events`, `jump-to-key-event`) now share a new `can_read_liveblog` permission callback on `RestApiController`. The callback uses the `LiveblogPost` domain entity to confirm the post exists, supports liveblog and is enabled or archived, and then requires either `post_status === 'publish'` or that the current user has `read_post` for the post. All failure paths return 404 rather than 403 so the endpoints cannot be used as an oracle for post existence, status or liveblog-ness. A new `liveblog_rest_read_permission` filter is exposed for headless setups that want to surface entries for drafts without granting `read_post` to anonymous callers.

The implementation reads cleaner than 1.x: `LiveblogPost::from_id()` and `is_liveblog()` / `is_published()` replace the static `WPCOM_Liveblog` helpers and their `$is_rest_api_call` short-circuit, so the permission-callback-runs-before-route ordering issue that had to be worked around on 1.x does not exist here.

Integration tests cover the four non-public statuses (draft, private, future, trash) via a data provider, plus missing posts, non-liveblog posts, editor access to a draft, and the filter override. The three existing endpoint tests have been updated to create a real liveblog post instead of hard-coding post ID 1 so they now exercise the permission callback end to end.

Related: #857 (1.x fix).

## Test plan

- [ ] CI integration tests pass on WP 6.4 / PHP 7.4 and WP master / PHP latest.
- [ ] Manual check: anonymous `GET /wp-json/liveblog/v1/<draft_post_id>/entries/0/9999999999` returns 404.
- [ ] Manual check: anonymous `GET /wp-json/liveblog/v1/<published_liveblog_post_id>/entries/0/9999999999` still returns 200 with entries.
- [ ] Manual check: editor-logged-in user can read entries for a draft liveblog post they have `read_post` for.