### PR TITLE
Clear the PHPCS backlog on 2.x

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -51,6 +51,7 @@
 		<properties>
 			<property name="prefixes" type="array">
 				<element value="liveblog"/>
+				<element value="Automattic\Liveblog"/>
 			</property>
 		</properties>
 	</rule>

--- a/liveblog.php
+++ b/liveblog.php
@@ -39,8 +39,7 @@ require_once __DIR__ . '/src/php/functions.php';
 PluploadCompat::ensure_functions();
 
 // Initialise the plugin.
-$container = Container::instance();
-( new PluginBootstrapper( $container ) )->init();
+( new PluginBootstrapper( Container::instance() ) )->init();
 
 /**
  * Get the DI container.

--- a/src/php/Application/Service/KeyEventService.php
+++ b/src/php/Application/Service/KeyEventService.php
@@ -182,7 +182,7 @@ final class KeyEventService {
 	 * @return string Content with key command removed.
 	 */
 	public function strip_key_command_from_content( string $content ): string {
-		// Remove the command span: <span class="liveblog-command type-key">key</span>
+		// Remove the command span: <span class="liveblog-command type-key">key</span>.
 		$content = preg_replace(
 			'/<span[^>]*class="[^"]*liveblog-command[^"]*type-key[^"]*"[^>]*>.*?<\/span>\s*/i',
 			'',

--- a/src/php/Domain/ValueObject/EntryContent.php
+++ b/src/php/Domain/ValueObject/EntryContent.php
@@ -169,7 +169,7 @@ final class EntryContent {
 	 * @param string $ellipsis   String to append if truncated.
 	 * @return string
 	 */
-	public function truncate( int $word_count = 10, string $ellipsis = "…" ): string {
+	public function truncate( int $word_count = 10, string $ellipsis = '…' ): string {
 		$plain = $this->plain();
 		$words = preg_split( '/\s+/', $plain, -1, PREG_SPLIT_NO_EMPTY );
 

--- a/src/php/Infrastructure/CLI/ArchiveCommand.php
+++ b/src/php/Infrastructure/CLI/ArchiveCommand.php
@@ -38,7 +38,7 @@ final class ArchiveCommand {
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.
 	 */
-	public function __invoke( array $args, array $assoc_args ): void {
+	public function __invoke( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- WP-CLI requires this signature.
 		$post_id = absint( $args[0] ?? 0 );
 
 		if ( 0 === $post_id ) {

--- a/src/php/Infrastructure/CLI/ArchiveOldCommand.php
+++ b/src/php/Infrastructure/CLI/ArchiveOldCommand.php
@@ -177,7 +177,7 @@ final class ArchiveOldCommand {
 			)
 		);
 
-		return $date ?: null;
+		return $date ? $date : null;
 	}
 
 	/**

--- a/src/php/Infrastructure/CLI/EnableCommand.php
+++ b/src/php/Infrastructure/CLI/EnableCommand.php
@@ -35,7 +35,7 @@ final class EnableCommand {
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.
 	 */
-	public function __invoke( array $args, array $assoc_args ): void {
+	public function __invoke( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- WP-CLI requires this signature.
 		$post_id = absint( $args[0] ?? 0 );
 
 		if ( 0 === $post_id ) {

--- a/src/php/Infrastructure/CLI/UnarchiveCommand.php
+++ b/src/php/Infrastructure/CLI/UnarchiveCommand.php
@@ -38,7 +38,7 @@ final class UnarchiveCommand {
 	 * @param array $args       Positional arguments.
 	 * @param array $assoc_args Associative arguments.
 	 */
-	public function __invoke( array $args, array $assoc_args ): void {
+	public function __invoke( array $args, array $assoc_args ): void { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter -- WP-CLI requires this signature.
 		$post_id = absint( $args[0] ?? 0 );
 
 		if ( 0 === $post_id ) {

--- a/src/php/Infrastructure/WordPress/AmpIntegration.php
+++ b/src/php/Infrastructure/WordPress/AmpIntegration.php
@@ -224,7 +224,7 @@ final class AmpIntegration {
 			return;
 		}
 
-		$css = file_get_contents( $css_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- Local file read.
+		$css = file_get_contents( $css_path ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents,WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown -- Local file read.
 
 		if ( false === $css ) {
 			return;

--- a/src/php/Infrastructure/WordPress/CommentEmbed.php
+++ b/src/php/Infrastructure/WordPress/CommentEmbed.php
@@ -231,16 +231,16 @@ class CommentEmbed extends WP_Embed implements EmbedHandlerInterface {
 	/**
 	 * Callback for autoembed regex.
 	 *
-	 * @param string[] $match Regex match array.
+	 * @param string[] $matches Regex match array.
 	 * @return string The embed HTML or original URL.
 	 */
-	public function autoembed_callback( $match ) {
+	public function autoembed_callback( $matches ) {
 		$oldval              = $this->linkifunknown;
 		$this->linkifunknown = false;
-		$return              = $this->shortcode( array(), $match[2] );
+		$return              = $this->shortcode( array(), $matches[2] );
 		$this->linkifunknown = $oldval;
 
-		return $match[1] . $return . $match[3];
+		return $matches[1] . $return . $matches[3];
 	}
 
 	/**

--- a/tests/Integration/Cli/AddCommandTest.php
+++ b/tests/Integration/Cli/AddCommandTest.php
@@ -36,7 +36,7 @@ final class AddCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new AddCommand( $this->container()->entry_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id, 'Test entry content' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id, 'Test entry content' ) );
 
 		$this->assert_command_success( 'Entry' );
 		$this->assert_success_contains( 'added to liveblog' );
@@ -49,13 +49,13 @@ final class AddCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new AddCommand( $this->container()->entry_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id, 'Test entry content' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id, 'Test entry content' ) );
 
 		$comments = get_comments(
-			[
+			array(
 				'post_id' => $post_id,
 				'status'  => 'liveblog',
-			]
+			)
 		);
 
 		$this->assertCount( 1, $comments );
@@ -67,20 +67,20 @@ final class AddCommandTest extends CliTestCase {
 	 */
 	public function test_add_with_author(): void {
 		$post_id = $this->create_liveblog();
-		$user    = $this->create_user( [ 'display_name' => 'Test Author' ] );
+		$user    = $this->create_user( array( 'display_name' => 'Test Author' ) );
 		$command = new AddCommand( $this->container()->entry_service() );
 
 		$this->invoke_expecting_success(
 			$command,
-			[ (string) $post_id, 'Test entry' ],
-			[ 'author' => (string) $user->ID ]
+			array( (string) $post_id, 'Test entry' ),
+			array( 'author' => (string) $user->ID )
 		);
 
 		$comments = get_comments(
-			[
+			array(
 				'post_id' => $post_id,
 				'status'  => 'liveblog',
-			]
+			)
 		);
 
 		$this->assertSame( (int) $user->ID, (int) $comments[0]->user_id );
@@ -97,15 +97,15 @@ final class AddCommandTest extends CliTestCase {
 
 		$this->invoke_expecting_success(
 			$command,
-			[ (string) $post_id, 'Test entry' ],
-			[ 'contributors' => sprintf( '%d,%d', $user1->ID, $user2->ID ) ]
+			array( (string) $post_id, 'Test entry' ),
+			array( 'contributors' => sprintf( '%d,%d', $user1->ID, $user2->ID ) )
 		);
 
 		$comments = get_comments(
-			[
+			array(
 				'post_id' => $post_id,
 				'status'  => 'liveblog',
-			]
+			)
 		);
 
 		$contributors = get_comment_meta( $comments[0]->comment_ID, 'liveblog_contributors', true );
@@ -122,15 +122,15 @@ final class AddCommandTest extends CliTestCase {
 
 		$this->invoke_expecting_success(
 			$command,
-			[ (string) $post_id, 'Test entry' ],
-			[ 'hide-authors' => true ]
+			array( (string) $post_id, 'Test entry' ),
+			array( 'hide-authors' => true )
 		);
 
 		$comments = get_comments(
-			[
+			array(
 				'post_id' => $post_id,
 				'status'  => 'liveblog',
-			]
+			)
 		);
 
 		$hide_authors = get_comment_meta( $comments[0]->comment_ID, 'liveblog_hide_authors', true );
@@ -146,17 +146,17 @@ final class AddCommandTest extends CliTestCase {
 
 		$this->invoke_expecting_success(
 			$command,
-			[ (string) $post_id, 'Test entry' ],
-			[ 'key-event' => true ]
+			array( (string) $post_id, 'Test entry' ),
+			array( 'key-event' => true )
 		);
 
 		$this->assert_success_contains( 'Key event' );
 
 		$comments = get_comments(
-			[
+			array(
 				'post_id' => $post_id,
 				'status'  => 'liveblog',
-			]
+			)
 		);
 
 		$key_event = get_comment_meta( $comments[0]->comment_ID, 'liveblog_key_entry', true );
@@ -172,8 +172,8 @@ final class AddCommandTest extends CliTestCase {
 
 		$this->invoke_expecting_success(
 			$command,
-			[ (string) $post_id, 'Test entry' ],
-			[ 'porcelain' => true ]
+			array( (string) $post_id, 'Test entry' ),
+			array( 'porcelain' => true )
 		);
 
 		// Should output just the ID via log, not success message.
@@ -190,7 +190,7 @@ final class AddCommandTest extends CliTestCase {
 	public function test_add_with_invalid_post_id(): void {
 		$command = new AddCommand( $this->container()->entry_service() );
 
-		$this->invoke_expecting_error( $command, [ '0', 'Test entry' ] );
+		$this->invoke_expecting_error( $command, array( '0', 'Test entry' ) );
 
 		$this->assert_error_contains( 'valid post ID' );
 	}
@@ -202,7 +202,7 @@ final class AddCommandTest extends CliTestCase {
 		$post_id = self::factory()->post->create();
 		$command = new AddCommand( $this->container()->entry_service() );
 
-		$this->invoke_expecting_error( $command, [ (string) $post_id, 'Test entry' ] );
+		$this->invoke_expecting_error( $command, array( (string) $post_id, 'Test entry' ) );
 
 		$this->assert_error_contains( 'not an enabled liveblog' );
 	}
@@ -215,7 +215,7 @@ final class AddCommandTest extends CliTestCase {
 		$this->archive_liveblog( $post_id );
 		$command = new AddCommand( $this->container()->entry_service() );
 
-		$this->invoke_expecting_error( $command, [ (string) $post_id, 'Test entry' ] );
+		$this->invoke_expecting_error( $command, array( (string) $post_id, 'Test entry' ) );
 
 		$this->assert_error_contains( 'archived' );
 		$this->assert_error_contains( 'Unarchive it first' );
@@ -228,7 +228,7 @@ final class AddCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new AddCommand( $this->container()->entry_service() );
 
-		$this->invoke_expecting_error( $command, [ (string) $post_id, '' ] );
+		$this->invoke_expecting_error( $command, array( (string) $post_id, '' ) );
 
 		$this->assert_error_contains( 'provide entry content' );
 	}
@@ -239,15 +239,15 @@ final class AddCommandTest extends CliTestCase {
 	public function test_add_with_invalid_author_shows_warning(): void {
 		$post_id = $this->create_liveblog();
 		// Create a user so there's a fallback admin.
-		$admin = self::factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		$admin = self::factory()->user->create_and_get( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $admin->ID );
 
 		$command = new AddCommand( $this->container()->entry_service() );
 
 		$this->invoke_expecting_success(
 			$command,
-			[ (string) $post_id, 'Test entry' ],
-			[ 'author' => '999999' ]
+			array( (string) $post_id, 'Test entry' ),
+			array( 'author' => '999999' )
 		);
 
 		$this->assert_warning_contains( 'not found' );
@@ -261,7 +261,7 @@ final class AddCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new AddCommand( $this->container()->entry_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id, 'Test entry' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id, 'Test entry' ) );
 
 		$this->assert_success_contains( (string) $post_id );
 	}

--- a/tests/Integration/Cli/ArchiveCommandTest.php
+++ b/tests/Integration/Cli/ArchiveCommandTest.php
@@ -26,7 +26,7 @@ final class ArchiveCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new ArchiveCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assert_command_success( 'archived' );
 
@@ -41,7 +41,7 @@ final class ArchiveCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new ArchiveCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assertSame( 'archive', $this->get_liveblog_meta( $post_id ) );
 	}
@@ -52,7 +52,7 @@ final class ArchiveCommandTest extends CliTestCase {
 	public function test_archive_with_invalid_id(): void {
 		$command = new ArchiveCommand();
 
-		$this->invoke_expecting_error( $command, [ '0' ] );
+		$this->invoke_expecting_error( $command, array( '0' ) );
 
 		$this->assert_error_contains( 'valid post ID' );
 	}
@@ -63,7 +63,7 @@ final class ArchiveCommandTest extends CliTestCase {
 	public function test_archive_non_existent_post(): void {
 		$command = new ArchiveCommand();
 
-		$this->invoke_expecting_error( $command, [ '999999' ] );
+		$this->invoke_expecting_error( $command, array( '999999' ) );
 
 		$this->assert_error_contains( 'not found' );
 	}
@@ -75,7 +75,7 @@ final class ArchiveCommandTest extends CliTestCase {
 		$post_id = self::factory()->post->create();
 		$command = new ArchiveCommand();
 
-		$this->invoke_expecting_error( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_error( $command, array( (string) $post_id ) );
 
 		$this->assert_error_contains( 'not a liveblog' );
 	}
@@ -88,7 +88,7 @@ final class ArchiveCommandTest extends CliTestCase {
 		$this->archive_liveblog( $post_id );
 		$command = new ArchiveCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assert_command_warning( 'already archived' );
 	}
@@ -100,7 +100,7 @@ final class ArchiveCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new ArchiveCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assert_success_contains( (string) $post_id );
 	}

--- a/tests/Integration/Cli/ArchiveOldCommandTest.php
+++ b/tests/Integration/Cli/ArchiveOldCommandTest.php
@@ -37,14 +37,21 @@ final class ArchiveOldCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		// Create old post and entry.
 		wp_update_post(
-			[
+			array(
 				'ID'        => $post_id,
 				'post_date' => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
-			]
+			)
 		);
 		$command = new ArchiveOldCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'days' => '30', 'dry-run' => true ] );
+		$this->invoke_expecting_success(
+			$command,
+			array(),
+			array(
+				'days'    => '30',
+				'dry-run' => true,
+			) 
+		);
 
 		$this->assert_success_contains( 'Dry run complete' );
 		$this->assert_success_contains( 'No changes made' );
@@ -61,14 +68,21 @@ final class ArchiveOldCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		// Create old post.
 		wp_update_post(
-			[
+			array(
 				'ID'        => $post_id,
 				'post_date' => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
-			]
+			)
 		);
 		$command = new ArchiveOldCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'days' => '30', 'yes' => true ] );
+		$this->invoke_expecting_success(
+			$command,
+			array(),
+			array(
+				'days' => '30',
+				'yes'  => true,
+			) 
+		);
 
 		$this->assert_command_success( 'Archived' );
 		$this->assert_confirm_not_called();
@@ -85,14 +99,14 @@ final class ArchiveOldCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		// Create old post.
 		wp_update_post(
-			[
+			array(
 				'ID'        => $post_id,
 				'post_date' => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
-			]
+			)
 		);
 		$command = new ArchiveOldCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'days' => '30' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'days' => '30' ) );
 
 		$this->assert_confirm_called();
 	}
@@ -103,7 +117,7 @@ final class ArchiveOldCommandTest extends CliTestCase {
 	public function test_archive_old_invalid_days(): void {
 		$command = new ArchiveOldCommand();
 
-		$this->invoke_expecting_error( $command, [], [ 'days' => '0' ] );
+		$this->invoke_expecting_error( $command, array(), array( 'days' => '0' ) );
 
 		$this->assert_error_contains( 'at least 1' );
 	}
@@ -113,21 +127,28 @@ final class ArchiveOldCommandTest extends CliTestCase {
 	 */
 	public function test_archive_old_finds_inactive_liveblogs(): void {
 		// Create an old inactive liveblog.
-		$old_id = $this->create_liveblog( [ 'post_title' => 'Old Liveblog' ] );
+		$old_id = $this->create_liveblog( array( 'post_title' => 'Old Liveblog' ) );
 		wp_update_post(
-			[
+			array(
 				'ID'        => $old_id,
 				'post_date' => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
-			]
+			)
 		);
 
 		// Create a recent liveblog.
-		$recent_id = $this->create_liveblog( [ 'post_title' => 'Recent Liveblog' ] );
+		$recent_id = $this->create_liveblog( array( 'post_title' => 'Recent Liveblog' ) );
 		$this->add_entry( $recent_id, 'Recent entry' );
 
 		$command = new ArchiveOldCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'days' => '30', 'dry-run' => true ] );
+		$this->invoke_expecting_success(
+			$command,
+			array(),
+			array(
+				'days'    => '30',
+				'dry-run' => true,
+			) 
+		);
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -150,20 +171,27 @@ final class ArchiveOldCommandTest extends CliTestCase {
 		// Update the comment date directly.
 		$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 			$wpdb->comments,
-			[
+			array(
 				'comment_date'     => $entry_date,
 				'comment_date_gmt' => $entry_date,
-			],
-			[
-				'comment_post_ID'   => $post_id,
-				'comment_approved'  => 'liveblog',
-			]
+			),
+			array(
+				'comment_post_ID'  => $post_id,
+				'comment_approved' => 'liveblog',
+			)
 		);
 		clean_comment_cache( $post_id );
 
 		$command = new ArchiveOldCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'days' => '30', 'dry-run' => true ] );
+		$this->invoke_expecting_success(
+			$command,
+			array(),
+			array(
+				'days'    => '30',
+				'dry-run' => true,
+			) 
+		);
 
 		$this->assert_success_contains( 'No inactive liveblogs found' );
 	}
@@ -174,7 +202,7 @@ final class ArchiveOldCommandTest extends CliTestCase {
 	public function test_archive_old_no_liveblogs(): void {
 		$command = new ArchiveOldCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'days' => '30' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'days' => '30' ) );
 
 		$this->assert_success_contains( 'No inactive liveblogs found' );
 	}
@@ -183,16 +211,23 @@ final class ArchiveOldCommandTest extends CliTestCase {
 	 * Test archive-old shows preview table.
 	 */
 	public function test_archive_old_shows_preview(): void {
-		$post_id = $this->create_liveblog( [ 'post_title' => 'Old Liveblog' ] );
+		$post_id = $this->create_liveblog( array( 'post_title' => 'Old Liveblog' ) );
 		wp_update_post(
-			[
+			array(
 				'ID'        => $post_id,
 				'post_date' => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
-			]
+			)
 		);
 		$command = new ArchiveOldCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'days' => '30', 'dry-run' => true ] );
+		$this->invoke_expecting_success(
+			$command,
+			array(),
+			array(
+				'days'    => '30',
+				'dry-run' => true,
+			) 
+		);
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -208,20 +243,27 @@ final class ArchiveOldCommandTest extends CliTestCase {
 		$post_id1 = $this->create_liveblog();
 		$post_id2 = $this->create_liveblog();
 		wp_update_post(
-			[
+			array(
 				'ID'        => $post_id1,
 				'post_date' => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
-			]
+			)
 		);
 		wp_update_post(
-			[
+			array(
 				'ID'        => $post_id2,
 				'post_date' => gmdate( 'Y-m-d H:i:s', strtotime( '-60 days' ) ),
-			]
+			)
 		);
 		$command = new ArchiveOldCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'days' => '30', 'yes' => true ] );
+		$this->invoke_expecting_success(
+			$command,
+			array(),
+			array(
+				'days' => '30',
+				'yes'  => true,
+			) 
+		);
 
 		$this->assert_success_contains( '2 liveblog' );
 

--- a/tests/Integration/Cli/CliTestCase.php
+++ b/tests/Integration/Cli/CliTestCase.php
@@ -58,7 +58,7 @@ abstract class CliTestCase extends IntegrationTestCase {
 	 * @return void
 	 * @throws WP_CLI_ExitException When command calls WP_CLI::error().
 	 */
-	protected function invoke_command( object $command, array $args = [], array $assoc_args = [] ): void {
+	protected function invoke_command( object $command, array $args = array(), array $assoc_args = array() ): void {
 		$command( $args, $assoc_args );
 	}
 
@@ -70,7 +70,7 @@ abstract class CliTestCase extends IntegrationTestCase {
 	 * @param array  $assoc_args Associative arguments.
 	 * @return void
 	 */
-	protected function invoke_expecting_success( object $command, array $args = [], array $assoc_args = [] ): void {
+	protected function invoke_expecting_success( object $command, array $args = array(), array $assoc_args = array() ): void {
 		try {
 			$this->invoke_command( $command, $args, $assoc_args );
 		} catch ( WP_CLI_ExitException $e ) {
@@ -86,7 +86,7 @@ abstract class CliTestCase extends IntegrationTestCase {
 	 * @param array  $assoc_args Associative arguments.
 	 * @return WP_CLI_ExitException The caught exception.
 	 */
-	protected function invoke_expecting_error( object $command, array $args = [], array $assoc_args = [] ): WP_CLI_ExitException {
+	protected function invoke_expecting_error( object $command, array $args = array(), array $assoc_args = array() ): WP_CLI_ExitException {
 		try {
 			$this->invoke_command( $command, $args, $assoc_args );
 			$this->fail( 'Command should have failed with an error.' );
@@ -282,11 +282,11 @@ abstract class CliTestCase extends IntegrationTestCase {
 	 * @param array $args Post arguments.
 	 * @return int Post ID.
 	 */
-	protected function create_liveblog( array $args = [] ): int {
-		$defaults = [
+	protected function create_liveblog( array $args = array() ): int {
+		$defaults = array(
 			'post_title'  => 'Test Liveblog',
 			'post_status' => 'publish',
-		];
+		);
 
 		$post_id = self::factory()->post->create( array_merge( $defaults, $args ) );
 		$this->enable_liveblog( $post_id );
@@ -328,7 +328,7 @@ abstract class CliTestCase extends IntegrationTestCase {
 	 * @param array  $args    Additional arguments.
 	 * @return int Entry ID.
 	 */
-	protected function add_entry( int $post_id, string $content, array $args = [] ): int {
+	protected function add_entry( int $post_id, string $content, array $args = array() ): int {
 		$user = $args['user'] ?? self::factory()->user->create_and_get();
 
 		$entry_service = $this->container()->entry_service();
@@ -347,7 +347,7 @@ abstract class CliTestCase extends IntegrationTestCase {
 	 * @param array $args User arguments.
 	 * @return \WP_User
 	 */
-	protected function create_user( array $args = [] ): \WP_User {
+	protected function create_user( array $args = array() ): \WP_User {
 		return self::factory()->user->create_and_get( $args );
 	}
 

--- a/tests/Integration/Cli/DisableCommandTest.php
+++ b/tests/Integration/Cli/DisableCommandTest.php
@@ -27,7 +27,7 @@ final class DisableCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new DisableCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'yes' => true ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'yes' => true ) );
 
 		$this->assert_command_success( 'Liveblog disabled' );
 		$this->assert_confirm_not_called();
@@ -44,7 +44,7 @@ final class DisableCommandTest extends CliTestCase {
 		$command = new DisableCommand();
 
 		// Confirm will auto-return true by default.
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assert_confirm_called();
 		$this->assert_command_success( 'Liveblog disabled' );
@@ -57,7 +57,7 @@ final class DisableCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new DisableCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'yes' => true ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'yes' => true ) );
 
 		// Meta should be removed after disable.
 		$meta = $this->get_liveblog_meta( $post_id );
@@ -70,7 +70,7 @@ final class DisableCommandTest extends CliTestCase {
 	public function test_disable_with_invalid_id(): void {
 		$command = new DisableCommand();
 
-		$this->invoke_expecting_error( $command, [ '0' ] );
+		$this->invoke_expecting_error( $command, array( '0' ) );
 
 		$this->assert_error_contains( 'valid post ID' );
 	}
@@ -81,7 +81,7 @@ final class DisableCommandTest extends CliTestCase {
 	public function test_disable_non_existent_post(): void {
 		$command = new DisableCommand();
 
-		$this->invoke_expecting_error( $command, [ '999999' ] );
+		$this->invoke_expecting_error( $command, array( '999999' ) );
 
 		$this->assert_error_contains( 'not found' );
 	}
@@ -93,7 +93,7 @@ final class DisableCommandTest extends CliTestCase {
 		$post_id = self::factory()->post->create();
 		$command = new DisableCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assert_command_warning( 'not a liveblog' );
 	}
@@ -106,7 +106,7 @@ final class DisableCommandTest extends CliTestCase {
 		$entry_id = $this->add_entry( $post_id, 'Test entry content' );
 		$command  = new DisableCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'yes' => true ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'yes' => true ) );
 
 		// Entry should still exist.
 		$comment = get_comment( $entry_id );
@@ -121,7 +121,7 @@ final class DisableCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new DisableCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'yes' => true ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'yes' => true ) );
 
 		$this->assert_success_contains( 'preserved' );
 	}
@@ -134,7 +134,7 @@ final class DisableCommandTest extends CliTestCase {
 		$this->archive_liveblog( $post_id );
 		$command = new DisableCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'yes' => true ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'yes' => true ) );
 
 		$this->assert_command_success( 'Liveblog disabled' );
 

--- a/tests/Integration/Cli/EnableCommandTest.php
+++ b/tests/Integration/Cli/EnableCommandTest.php
@@ -26,7 +26,7 @@ final class EnableCommandTest extends CliTestCase {
 		$post_id = self::factory()->post->create();
 		$command = new EnableCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assert_command_success( 'Liveblog enabled' );
 		$this->assertSame( 'enable', $this->get_liveblog_meta( $post_id ) );
@@ -39,7 +39,7 @@ final class EnableCommandTest extends CliTestCase {
 		$post_id = self::factory()->post->create();
 		$command = new EnableCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$liveblog = LiveblogPost::from_id( $post_id );
 		$this->assertNotNull( $liveblog );
@@ -53,7 +53,7 @@ final class EnableCommandTest extends CliTestCase {
 	public function test_enable_with_invalid_id(): void {
 		$command = new EnableCommand();
 
-		$this->invoke_expecting_error( $command, [ '0' ] );
+		$this->invoke_expecting_error( $command, array( '0' ) );
 
 		$this->assert_error_contains( 'valid post ID' );
 	}
@@ -64,7 +64,7 @@ final class EnableCommandTest extends CliTestCase {
 	public function test_enable_with_non_existent_post(): void {
 		$command = new EnableCommand();
 
-		$this->invoke_expecting_error( $command, [ '999999' ] );
+		$this->invoke_expecting_error( $command, array( '999999' ) );
 
 		$this->assert_error_contains( 'not found' );
 	}
@@ -76,7 +76,7 @@ final class EnableCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new EnableCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assert_command_warning( 'already an enabled liveblog' );
 	}
@@ -93,7 +93,7 @@ final class EnableCommandTest extends CliTestCase {
 		$this->assertTrue( $liveblog->is_archived() );
 
 		$command = new EnableCommand();
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assert_command_success( 'Liveblog enabled' );
 
@@ -110,7 +110,7 @@ final class EnableCommandTest extends CliTestCase {
 		$command = new EnableCommand();
 
 		// 'abc' converts to 0 via absint, which triggers the invalid ID error.
-		$this->invoke_expecting_error( $command, [ 'abc' ] );
+		$this->invoke_expecting_error( $command, array( 'abc' ) );
 
 		$this->assert_error_contains( 'valid post ID' );
 	}

--- a/tests/Integration/Cli/EntriesCommandTest.php
+++ b/tests/Integration/Cli/EntriesCommandTest.php
@@ -27,7 +27,7 @@ final class EntriesCommandTest extends CliTestCase {
 		$this->add_entry( $post_id, 'Second entry' );
 		$command = new EntriesCommand( $this->container()->entry_query_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -43,7 +43,7 @@ final class EntriesCommandTest extends CliTestCase {
 		$this->add_entry( $post_id, 'Test entry' );
 		$command = new EntriesCommand( $this->container()->entry_query_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'format' => 'json' ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -58,7 +58,7 @@ final class EntriesCommandTest extends CliTestCase {
 		$this->add_entry( $post_id, 'Test entry' );
 		$command = new EntriesCommand( $this->container()->entry_query_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'format' => 'csv' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'format' => 'csv' ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -73,7 +73,7 @@ final class EntriesCommandTest extends CliTestCase {
 		$entry_id = $this->add_entry( $post_id, 'Test entry' );
 		$command  = new EntriesCommand( $this->container()->entry_query_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'format' => 'ids' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'format' => 'ids' ) );
 
 		// IDs format outputs via WP_CLI::log() and format_items is not called.
 		$this->assertTrue( \WP_CLI::was_called( 'log' ) );
@@ -91,7 +91,7 @@ final class EntriesCommandTest extends CliTestCase {
 		$this->add_entry( $post_id, 'Entry 3' );
 		$command = new EntriesCommand( $this->container()->entry_query_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'limit' => '2' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'limit' => '2' ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -104,10 +104,10 @@ final class EntriesCommandTest extends CliTestCase {
 	public function test_entries_key_events_filter(): void {
 		$post_id = $this->create_liveblog();
 		$this->add_entry( $post_id, 'Regular entry' );
-		$this->add_entry( $post_id, 'Key event entry', [ 'key_event' => true ] );
+		$this->add_entry( $post_id, 'Key event entry', array( 'key_event' => true ) );
 		$command = new EntriesCommand( $this->container()->entry_query_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'key-events' => true ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'key-events' => true ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -121,7 +121,7 @@ final class EntriesCommandTest extends CliTestCase {
 		$post_id = self::factory()->post->create();
 		$command = new EntriesCommand( $this->container()->entry_query_service() );
 
-		$this->invoke_expecting_error( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_error( $command, array( (string) $post_id ) );
 
 		$this->assert_error_contains( 'not a liveblog' );
 	}
@@ -133,7 +133,7 @@ final class EntriesCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new EntriesCommand( $this->container()->entry_query_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assert_command_warning( 'No entries found' );
 	}
@@ -146,7 +146,7 @@ final class EntriesCommandTest extends CliTestCase {
 		$this->add_entry( $post_id, 'Test entry' );
 		$command = new EntriesCommand( $this->container()->entry_query_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -164,10 +164,10 @@ final class EntriesCommandTest extends CliTestCase {
 	 */
 	public function test_key_events_filter_excludes_key_event_column(): void {
 		$post_id = $this->create_liveblog();
-		$this->add_entry( $post_id, 'Key event', [ 'key_event' => true ] );
+		$this->add_entry( $post_id, 'Key event', array( 'key_event' => true ) );
 		$command = new EntriesCommand( $this->container()->entry_query_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'key-events' => true ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'key-events' => true ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -182,7 +182,7 @@ final class EntriesCommandTest extends CliTestCase {
 	public function test_entries_with_invalid_post_id(): void {
 		$command = new EntriesCommand( $this->container()->entry_query_service() );
 
-		$this->invoke_expecting_error( $command, [ '0' ] );
+		$this->invoke_expecting_error( $command, array( '0' ) );
 
 		$this->assert_error_contains( 'valid post ID' );
 	}
@@ -195,7 +195,7 @@ final class EntriesCommandTest extends CliTestCase {
 		$this->add_entry( $post_id, 'Regular entry' ); // Not a key event.
 		$command = new EntriesCommand( $this->container()->entry_query_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'key-events' => true ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'key-events' => true ) );
 
 		$this->assert_command_warning( 'No key events found' );
 	}
@@ -210,7 +210,7 @@ final class EntriesCommandTest extends CliTestCase {
 		}
 		$command = new EntriesCommand( $this->container()->entry_query_service() );
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'limit' => '0' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'limit' => '0' ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );

--- a/tests/Integration/Cli/FixArchiveCommandTest.php
+++ b/tests/Integration/Cli/FixArchiveCommandTest.php
@@ -28,7 +28,7 @@ final class FixArchiveCommandTest extends CliTestCase {
 		$service = new ArchiveRepairService();
 		$command = new FixArchiveCommand( $service );
 
-		$this->invoke_expecting_success( $command, [], [ 'dry-run' => true ] );
+		$this->invoke_expecting_success( $command, array(), array( 'dry-run' => true ) );
 
 		$this->assert_success_contains( 'Dry run completed' );
 		$this->assert_line_contains( 'dry-run mode' );
@@ -114,7 +114,7 @@ final class FixArchiveCommandTest extends CliTestCase {
 		$service = new ArchiveRepairService();
 		$command = new FixArchiveCommand( $service );
 
-		$this->invoke_expecting_success( $command, [], [ 'dry-run' => true ] );
+		$this->invoke_expecting_success( $command, array(), array( 'dry-run' => true ) );
 
 		$this->assert_success_contains( 'Re-run without --dry-run' );
 	}
@@ -155,7 +155,7 @@ final class FixArchiveCommandTest extends CliTestCase {
 	public function test_fix_archive_with_edited_entry(): void {
 		$post_id  = $this->create_liveblog();
 		$user     = $this->create_user();
-		$entry_id = $this->add_entry( $post_id, 'Original content', [ 'user' => $user ] );
+		$entry_id = $this->add_entry( $post_id, 'Original content', array( 'user' => $user ) );
 
 		// Simulate an edit by creating an update entry via the service.
 		$entry_service = $this->container()->entry_service();

--- a/tests/Integration/Cli/ListCommandTest.php
+++ b/tests/Integration/Cli/ListCommandTest.php
@@ -22,8 +22,8 @@ final class ListCommandTest extends CliTestCase {
 	 * Test listing all liveblogs.
 	 */
 	public function test_list_all_liveblogs(): void {
-		$this->create_liveblog( [ 'post_title' => 'Enabled Liveblog' ] );
-		$archived_id = $this->create_liveblog( [ 'post_title' => 'Archived Liveblog' ] );
+		$this->create_liveblog( array( 'post_title' => 'Enabled Liveblog' ) );
+		$archived_id = $this->create_liveblog( array( 'post_title' => 'Archived Liveblog' ) );
 		$this->archive_liveblog( $archived_id );
 		$command = new ListCommand();
 
@@ -38,12 +38,12 @@ final class ListCommandTest extends CliTestCase {
 	 * Test listing with --state=enabled.
 	 */
 	public function test_list_state_enabled(): void {
-		$this->create_liveblog( [ 'post_title' => 'Enabled Liveblog' ] );
-		$archived_id = $this->create_liveblog( [ 'post_title' => 'Archived Liveblog' ] );
+		$this->create_liveblog( array( 'post_title' => 'Enabled Liveblog' ) );
+		$archived_id = $this->create_liveblog( array( 'post_title' => 'Archived Liveblog' ) );
 		$this->archive_liveblog( $archived_id );
 		$command = new ListCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'state' => 'enabled' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'state' => 'enabled' ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -55,12 +55,12 @@ final class ListCommandTest extends CliTestCase {
 	 * Test listing with --state=archived.
 	 */
 	public function test_list_state_archived(): void {
-		$this->create_liveblog( [ 'post_title' => 'Enabled Liveblog' ] );
-		$archived_id = $this->create_liveblog( [ 'post_title' => 'Archived Liveblog' ] );
+		$this->create_liveblog( array( 'post_title' => 'Enabled Liveblog' ) );
+		$archived_id = $this->create_liveblog( array( 'post_title' => 'Archived Liveblog' ) );
 		$this->archive_liveblog( $archived_id );
 		$command = new ListCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'state' => 'archived' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'state' => 'archived' ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -75,7 +75,7 @@ final class ListCommandTest extends CliTestCase {
 		$this->create_liveblog();
 		$command = new ListCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'table' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'table' ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -89,7 +89,7 @@ final class ListCommandTest extends CliTestCase {
 		$this->create_liveblog();
 		$command = new ListCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'json' ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -103,7 +103,7 @@ final class ListCommandTest extends CliTestCase {
 		$this->create_liveblog();
 		$command = new ListCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'csv' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'csv' ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -117,7 +117,7 @@ final class ListCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new ListCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'ids' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'ids' ) );
 
 		$logs = $this->output->get_logs();
 		$this->assertNotEmpty( $logs );
@@ -175,7 +175,7 @@ final class ListCommandTest extends CliTestCase {
 	 * Test list item includes title.
 	 */
 	public function test_list_item_includes_title(): void {
-		$this->create_liveblog( [ 'post_title' => 'My Test Liveblog' ] );
+		$this->create_liveblog( array( 'post_title' => 'My Test Liveblog' ) );
 		$command = new ListCommand();
 
 		$this->invoke_expecting_success( $command );
@@ -193,7 +193,7 @@ final class ListCommandTest extends CliTestCase {
 		$post_id2 = $this->create_liveblog();
 		$command  = new ListCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'ids' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'ids' ) );
 
 		$logs = $this->output->get_logs();
 		$this->assertNotEmpty( $logs );

--- a/tests/Integration/Cli/StatsCommandTest.php
+++ b/tests/Integration/Cli/StatsCommandTest.php
@@ -39,7 +39,7 @@ final class StatsCommandTest extends CliTestCase {
 		$this->create_liveblog();
 		$command = new StatsCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$this->assertNotEmpty( $logs );
@@ -55,7 +55,7 @@ final class StatsCommandTest extends CliTestCase {
 		$this->create_liveblog();
 		$command = new StatsCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'yaml' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'yaml' ) );
 
 		$logs = $this->output->get_logs();
 		$this->assertNotEmpty( $logs );
@@ -71,7 +71,7 @@ final class StatsCommandTest extends CliTestCase {
 		$this->archive_liveblog( $archived_id );
 		$command = new StatsCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );
@@ -90,7 +90,7 @@ final class StatsCommandTest extends CliTestCase {
 		$this->add_entry( $post_id, 'Entry 3' );
 		$command = new StatsCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );
@@ -103,11 +103,11 @@ final class StatsCommandTest extends CliTestCase {
 	public function test_stats_shows_key_events(): void {
 		$post_id = $this->create_liveblog();
 		$this->add_entry( $post_id, 'Regular entry' );
-		$this->add_entry( $post_id, 'Key event 1', [ 'key_event' => true ] );
-		$this->add_entry( $post_id, 'Key event 2', [ 'key_event' => true ] );
+		$this->add_entry( $post_id, 'Key event 1', array( 'key_event' => true ) );
+		$this->add_entry( $post_id, 'Key event 2', array( 'key_event' => true ) );
 		$command = new StatsCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );
@@ -122,13 +122,13 @@ final class StatsCommandTest extends CliTestCase {
 		$user1   = $this->create_user();
 		$user2   = $this->create_user();
 		$user3   = $this->create_user();
-		$this->add_entry( $post_id, 'Entry 1', [ 'user' => $user1 ] );
-		$this->add_entry( $post_id, 'Entry 2', [ 'user' => $user2 ] );
-		$this->add_entry( $post_id, 'Entry 3', [ 'user' => $user3 ] );
-		$this->add_entry( $post_id, 'Entry 4', [ 'user' => $user1 ] );
+		$this->add_entry( $post_id, 'Entry 1', array( 'user' => $user1 ) );
+		$this->add_entry( $post_id, 'Entry 2', array( 'user' => $user2 ) );
+		$this->add_entry( $post_id, 'Entry 3', array( 'user' => $user3 ) );
+		$this->add_entry( $post_id, 'Entry 4', array( 'user' => $user1 ) );
 		$command = new StatsCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );
@@ -141,7 +141,7 @@ final class StatsCommandTest extends CliTestCase {
 	public function test_stats_empty_site(): void {
 		$command = new StatsCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );
@@ -153,15 +153,15 @@ final class StatsCommandTest extends CliTestCase {
 	 * Test stats shows most active liveblog.
 	 */
 	public function test_stats_shows_most_active_liveblog(): void {
-		$post_id1 = $this->create_liveblog( [ 'post_title' => 'Less Active' ] );
-		$post_id2 = $this->create_liveblog( [ 'post_title' => 'Most Active' ] );
+		$post_id1 = $this->create_liveblog( array( 'post_title' => 'Less Active' ) );
+		$post_id2 = $this->create_liveblog( array( 'post_title' => 'Most Active' ) );
 		$this->add_entry( $post_id1, 'Entry 1' );
 		$this->add_entry( $post_id2, 'Entry 1' );
 		$this->add_entry( $post_id2, 'Entry 2' );
 		$this->add_entry( $post_id2, 'Entry 3' );
 		$command = new StatsCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );
@@ -177,7 +177,7 @@ final class StatsCommandTest extends CliTestCase {
 		$this->add_entry( $post_id, 'Entry' );
 		$command = new StatsCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );
@@ -196,7 +196,7 @@ final class StatsCommandTest extends CliTestCase {
 		$this->add_entry( $post_id2, 'Entry 2' );
 		$command = new StatsCommand();
 
-		$this->invoke_expecting_success( $command, [], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array(), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );

--- a/tests/Integration/Cli/StatusCommandTest.php
+++ b/tests/Integration/Cli/StatusCommandTest.php
@@ -25,7 +25,7 @@ final class StatusCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new StatusCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$format_calls = $this->output->get_format_items_calls();
 		$this->assertNotEmpty( $format_calls );
@@ -39,7 +39,7 @@ final class StatusCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new StatusCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$this->assertNotEmpty( $logs );
@@ -56,7 +56,7 @@ final class StatusCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new StatusCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'format' => 'yaml' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'format' => 'yaml' ) );
 
 		$logs = $this->output->get_logs();
 		$this->assertNotEmpty( $logs );
@@ -70,7 +70,7 @@ final class StatusCommandTest extends CliTestCase {
 	public function test_status_with_invalid_id(): void {
 		$command = new StatusCommand();
 
-		$this->invoke_expecting_error( $command, [ '0' ] );
+		$this->invoke_expecting_error( $command, array( '0' ) );
 
 		$this->assert_error_contains( 'valid post ID' );
 	}
@@ -81,7 +81,7 @@ final class StatusCommandTest extends CliTestCase {
 	public function test_status_non_existent_post(): void {
 		$command = new StatusCommand();
 
-		$this->invoke_expecting_error( $command, [ '999999' ] );
+		$this->invoke_expecting_error( $command, array( '999999' ) );
 
 		$this->assert_error_contains( 'not found' );
 	}
@@ -93,7 +93,7 @@ final class StatusCommandTest extends CliTestCase {
 		$post_id = self::factory()->post->create();
 		$command = new StatusCommand();
 
-		$this->invoke_expecting_error( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_error( $command, array( (string) $post_id ) );
 
 		$this->assert_error_contains( 'not a liveblog' );
 	}
@@ -107,7 +107,7 @@ final class StatusCommandTest extends CliTestCase {
 		$this->add_entry( $post_id, 'Entry 2' );
 		$command = new StatusCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );
@@ -120,10 +120,10 @@ final class StatusCommandTest extends CliTestCase {
 	public function test_status_includes_key_events(): void {
 		$post_id = $this->create_liveblog();
 		$this->add_entry( $post_id, 'Regular entry' );
-		$this->add_entry( $post_id, 'Key event', [ 'key_event' => true ] );
+		$this->add_entry( $post_id, 'Key event', array( 'key_event' => true ) );
 		$command = new StatusCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );
@@ -137,7 +137,7 @@ final class StatusCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new StatusCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );
@@ -151,7 +151,7 @@ final class StatusCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new StatusCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );
@@ -166,7 +166,7 @@ final class StatusCommandTest extends CliTestCase {
 		$this->archive_liveblog( $post_id );
 		$command = new StatusCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );
@@ -177,10 +177,10 @@ final class StatusCommandTest extends CliTestCase {
 	 * Test status includes post title.
 	 */
 	public function test_status_includes_title(): void {
-		$post_id = $this->create_liveblog( [ 'post_title' => 'My Liveblog Title' ] );
+		$post_id = $this->create_liveblog( array( 'post_title' => 'My Liveblog Title' ) );
 		$command = new StatusCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );
@@ -194,12 +194,12 @@ final class StatusCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$user1   = $this->create_user();
 		$user2   = $this->create_user();
-		$this->add_entry( $post_id, 'Entry 1', [ 'user' => $user1 ] );
-		$this->add_entry( $post_id, 'Entry 2', [ 'user' => $user2 ] );
-		$this->add_entry( $post_id, 'Entry 3', [ 'user' => $user1 ] );
+		$this->add_entry( $post_id, 'Entry 1', array( 'user' => $user1 ) );
+		$this->add_entry( $post_id, 'Entry 2', array( 'user' => $user2 ) );
+		$this->add_entry( $post_id, 'Entry 3', array( 'user' => $user1 ) );
 		$command = new StatusCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ], [ 'format' => 'json' ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ), array( 'format' => 'json' ) );
 
 		$logs = $this->output->get_logs();
 		$json = json_decode( implode( '', $logs ), true );

--- a/tests/Integration/Cli/UnarchiveCommandTest.php
+++ b/tests/Integration/Cli/UnarchiveCommandTest.php
@@ -27,7 +27,7 @@ final class UnarchiveCommandTest extends CliTestCase {
 		$this->archive_liveblog( $post_id );
 		$command = new UnarchiveCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assert_command_success( 'unarchived and re-enabled' );
 
@@ -44,7 +44,7 @@ final class UnarchiveCommandTest extends CliTestCase {
 		$this->archive_liveblog( $post_id );
 		$command = new UnarchiveCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assertSame( 'enable', $this->get_liveblog_meta( $post_id ) );
 	}
@@ -55,7 +55,7 @@ final class UnarchiveCommandTest extends CliTestCase {
 	public function test_unarchive_with_invalid_id(): void {
 		$command = new UnarchiveCommand();
 
-		$this->invoke_expecting_error( $command, [ '0' ] );
+		$this->invoke_expecting_error( $command, array( '0' ) );
 
 		$this->assert_error_contains( 'valid post ID' );
 	}
@@ -66,7 +66,7 @@ final class UnarchiveCommandTest extends CliTestCase {
 	public function test_unarchive_non_existent_post(): void {
 		$command = new UnarchiveCommand();
 
-		$this->invoke_expecting_error( $command, [ '999999' ] );
+		$this->invoke_expecting_error( $command, array( '999999' ) );
 
 		$this->assert_error_contains( 'not found' );
 	}
@@ -78,7 +78,7 @@ final class UnarchiveCommandTest extends CliTestCase {
 		$post_id = $this->create_liveblog();
 		$command = new UnarchiveCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assert_command_warning( 'already enabled' );
 	}
@@ -90,7 +90,7 @@ final class UnarchiveCommandTest extends CliTestCase {
 		$post_id = self::factory()->post->create();
 		$command = new UnarchiveCommand();
 
-		$this->invoke_expecting_error( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_error( $command, array( (string) $post_id ) );
 
 		$this->assert_error_contains( 'not an archived liveblog' );
 	}
@@ -103,7 +103,7 @@ final class UnarchiveCommandTest extends CliTestCase {
 		$this->archive_liveblog( $post_id );
 		$command = new UnarchiveCommand();
 
-		$this->invoke_expecting_success( $command, [ (string) $post_id ] );
+		$this->invoke_expecting_success( $command, array( (string) $post_id ) );
 
 		$this->assert_success_contains( (string) $post_id );
 	}

--- a/tests/Integration/Cli/WpCliOutputCapture.php
+++ b/tests/Integration/Cli/WpCliOutputCapture.php
@@ -94,10 +94,10 @@ final class WpCliOutputCapture {
 	 * @return string All output joined by newlines.
 	 */
 	public function get_all_output(): string {
-		$output = [];
+		$output = array();
 
 		foreach ( WP_CLI::get_calls() as $call ) {
-			if ( in_array( $call['method'], [ 'success', 'error', 'warning', 'line', 'log' ], true ) ) {
+			if ( in_array( $call['method'], array( 'success', 'error', 'warning', 'line', 'log' ), true ) ) {
 				$output[] = sprintf( '[%s] %s', $call['method'], $call['args'][0] ?? '' );
 			}
 		}

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -78,7 +78,7 @@ final class RestApiTest extends IntegrationTestCase {
 		$hook_registered = false;
 		foreach ( $collection as $priority => $callbacks ) {
 			foreach ( $callbacks as $callback ) {
-				if ( is_array( $callback['function'] ) && $callback['function'][1] === 'register_routes' ) {
+				if ( is_array( $callback['function'] ) && 'register_routes' === $callback['function'][1] ) {
 					$hook_registered = true;
 					break 2;
 				}

--- a/tests/Integration/SchemaMetadataTest.php
+++ b/tests/Integration/SchemaMetadataTest.php
@@ -62,13 +62,6 @@ final class SchemaMetadataTest extends IntegrationTestCase {
 	}
 
 	/**
-	 * Tear down test fixtures.
-	 */
-	public function tear_down(): void {
-		parent::tear_down();
-	}
-
-	/**
 	 * Test that metadata includes required @context property.
 	 *
 	 * @covers ::generate

--- a/tests/Stubs/WpCliStubs.php
+++ b/tests/Stubs/WpCliStubs.php
@@ -12,6 +12,9 @@
 // phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedFunctionFound -- Stub for external namespace.
 // phpcs:disable Squiz.Classes.ClassFileName.NoMatch -- Stub file containing multiple classes.
 // phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses -- Stub file containing multiple classes.
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Stub file containing multiple classes.
+// phpcs:disable Universal.NamingConventions.NoReservedKeywordParameterNames -- Mirrors the real WP_CLI signature.
+// phpcs:disable WordPress.Security.EscapeOutput.ExceptionNotEscaped -- Exception message is stub-only and not rendered.
 
 if ( ! class_exists( 'WP_CLI' ) ) {
 	/**
@@ -25,7 +28,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 		 *
 		 * @var array
 		 */
-		private static $calls = [];
+		private static $calls = array();
 
 		/**
 		 * Flag to control confirm() behaviour.
@@ -40,7 +43,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 		 * @return void
 		 */
 		public static function reset() {
-			self::$calls           = [];
+			self::$calls           = array();
 			self::$confirm_returns = true;
 		}
 
@@ -52,10 +55,10 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 		 * @return void
 		 */
 		private static function record_call( $method, $args ) {
-			self::$calls[] = [
+			self::$calls[] = array(
 				'method' => $method,
 				'args'   => $args,
-			];
+			);
 		}
 
 		/**
@@ -122,7 +125,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 		 * @return void
 		 */
 		public static function success( $message ) {
-			self::record_call( 'success', [ $message ] );
+			self::record_call( 'success', array( $message ) );
 		}
 
 		/**
@@ -132,7 +135,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 		 * @throws WP_CLI_ExitException Always throws to simulate exit.
 		 */
 		public static function error( $message ) {
-			self::record_call( 'error', [ $message ] );
+			self::record_call( 'error', array( $message ) );
 			throw new WP_CLI_ExitException( $message, 1 );
 		}
 
@@ -143,7 +146,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 		 * @return void
 		 */
 		public static function warning( $message ) {
-			self::record_call( 'warning', [ $message ] );
+			self::record_call( 'warning', array( $message ) );
 		}
 
 		/**
@@ -153,7 +156,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 		 * @return void
 		 */
 		public static function line( $message = '' ) {
-			self::record_call( 'line', [ $message ] );
+			self::record_call( 'line', array( $message ) );
 		}
 
 		/**
@@ -163,7 +166,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 		 * @return void
 		 */
 		public static function log( $message ) {
-			self::record_call( 'log', [ $message ] );
+			self::record_call( 'log', array( $message ) );
 		}
 
 		/**
@@ -173,7 +176,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 		 * @return void
 		 */
 		public static function debug( $message ) {
-			self::record_call( 'debug', [ $message ] );
+			self::record_call( 'debug', array( $message ) );
 		}
 
 		/**
@@ -184,7 +187,7 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 		 * @throws WP_CLI_ExitException When confirm returns false.
 		 */
 		public static function confirm( $question ) {
-			self::record_call( 'confirm', [ $question ] );
+			self::record_call( 'confirm', array( $question ) );
 
 			if ( ! self::$confirm_returns ) {
 				throw new WP_CLI_ExitException( 'Cancelled by user.', 0 );
@@ -220,8 +223,8 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 		 * @param array  $args    Command arguments.
 		 * @return void
 		 */
-		public static function add_command( $name, $handler, $args = [] ) {
-			self::record_call( 'add_command', [ $name, $handler, $args ] );
+		public static function add_command( $name, $handler, $args = array() ) {
+			self::record_call( 'add_command', array( $name, $handler, $args ) );
 		}
 	}
 
@@ -262,5 +265,5 @@ if ( ! class_exists( 'WP_CLI' ) ) {
 
 // Initialize the global for format_items tracking.
 if ( ! isset( $GLOBALS['wp_cli_format_items_calls'] ) ) {
-	$GLOBALS['wp_cli_format_items_calls'] = [];
+	$GLOBALS['wp_cli_format_items_calls'] = array();
 }

--- a/tests/Stubs/WpCliUtilsStubs.php
+++ b/tests/Stubs/WpCliUtilsStubs.php
@@ -23,11 +23,11 @@ function format_items( $format, $items, $columns ) {
 	\WP_CLI::line( sprintf( '[format_items: %s, %d items, columns: %s]', $format, count( $items ), implode( ',', $columns ) ) );
 
 	// Store formatted output for assertions.
-	$GLOBALS['wp_cli_format_items_calls'][] = [
+	$GLOBALS['wp_cli_format_items_calls'][] = array(
 		'format'  => $format,
 		'items'   => $items,
 		'columns' => $columns,
-	];
+	);
 }
 
 /**
@@ -40,7 +40,7 @@ function format_items( $format, $items, $columns ) {
 function make_progress_bar( $message, $count ) {
 	\WP_CLI::line( sprintf( '[progress_bar: %s, %d items]', $message, $count ) );
 
-	return new class {
+	return new class() {
 		/**
 		 * Tick the progress bar.
 		 *
@@ -63,7 +63,7 @@ function make_progress_bar( $message, $count ) {
  * @return void
  */
 function reset_format_items_calls() {
-	$GLOBALS['wp_cli_format_items_calls'] = [];
+	$GLOBALS['wp_cli_format_items_calls'] = array();
 }
 
 /**
@@ -72,5 +72,5 @@ function reset_format_items_calls() {
  * @return array
  */
 function get_format_items_calls() {
-	return $GLOBALS['wp_cli_format_items_calls'] ?? [];
+	return $GLOBALS['wp_cli_format_items_calls'] ?? array();
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -88,7 +88,7 @@ if ( $is_integration ) {
 	require __DIR__ . '/Stubs/WpCliUtilsStubs.php';
 
 	if ( ! defined( 'WP_CLI' ) ) {
-		define( 'WP_CLI', true );
+		define( 'WP_CLI', true ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedConstantFound -- Stubs the WP_CLI runtime flag.
 	}
 
 	// Load the custom Spy REST Server for testing.


### PR DESCRIPTION
## Summary

The `PHP CS & Lint` workflow had been failing on 2.x since 27 January 2026. The backlog stood at 239 errors and 9 warnings spread across 27 files, which made every subsequent push look red and obscured any fresh regressions. This PR clears it.

The first commit is a mechanical `phpcbf` sweep — primarily converting the short array syntax in the CLI integration test suite (added during the DDD migration) back to long form, alongside an anonymous-class parentheses fix in `WpCliUtilsStubs` and a single quote swap in `EntryContent::truncate()`. There is no behavioural change; it is purely what the auto-fixer produces, isolated so it can be reviewed at a glance.

The second commit picks up the remaining violations that `phpcbf` cannot fix. Each file takes one targeted change, and the commit body names the rule being addressed in each case. The headline items are: `.phpcs.xml.dist` now recognises `Automattic\Liveblog` as a valid prefix (so the plugin's own namespace no longer trips `PrefixAllGlobals`); the `$container` boot variable in `liveblog.php` is inlined to remove the non-prefixed global; `$match` in `CommentEmbed::autoembed_callback()` is renamed to `$matches` to stop shadowing the PHP 8 reserved keyword; a short ternary in `ArchiveOldCommand` becomes a full ternary; a Yoda-order comparison lands in `RestApiTest`; a useless `tear_down()` override is dropped from `SchemaMetadataTest`; the three WP-CLI command `__invoke()` methods pick up narrowly scoped `phpcs:ignore` comments for the framework-mandated `$assoc_args` parameter they do not consume; and the multi-class `WpCliStubs` file extends its existing file-level disable list to cover the newer sniffs it triggers.

After both commits, `composer cs` exits 0 with no errors or warnings. The unit suite remains green at 190 tests and 446 assertions.

## Test plan

- [ ] CI: `PHP CS & Lint` passes on the PR
- [ ] CI: unit and integration suites remain green