### PR TITLE
Security hardening: cap checks, ID sanitisation, safer output

### DIFF
--- a/classes/class-wpcom-liveblog-amp.php
+++ b/classes/class-wpcom-liveblog-amp.php
@@ -185,12 +185,12 @@ class WPCOM_Liveblog_AMP {
 
 		echo '<meta property="og:title" content="' . esc_attr( $title ) . '">';
 		echo '<meta property="og:description" content="' . esc_attr( $description ) . '">';
-		echo '<meta property="og:url" content="' . esc_attr( $url ) . '">';
+		echo '<meta property="og:url" content="' . esc_url( $url ) . '">';
 		echo '<meta name="twitter:card" content="' . esc_attr( $description ) . '">';
 
 		// If we have an image, lets use it.
 		if ( $image ) {
-				echo '<meta property="og:image" content="' . esc_attr( $image ) . '">';
+				echo '<meta property="og:image" content="' . esc_url( $image ) . '">';
 		}
 	}
 

--- a/classes/class-wpcom-liveblog-entry-extend-feature-authors.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-authors.php
@@ -214,6 +214,13 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Authors extends WPCOM_Liveblog_Entry_E
 	 */
 	public function ajax_authors() {
 
+		// Only users who can edit a liveblog should be able to enumerate the
+		// author list. Without this any authenticated user (including
+		// subscribers) could scrape every user holding `edit_posts`.
+		if ( ! WPCOM_Liveblog::current_user_can_edit_liveblog() ) {
+			wp_send_json_error( null, 403 );
+		}
+
 		// Sanitize the input safely.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Public autocomplete endpoint.
 		if ( isset( $_GET['autocomplete'] ) ) {

--- a/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php
@@ -249,6 +249,12 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Hashtags extends WPCOM_Liveblog_Entry_
 	 */
 	public function ajax_terms() {
 
+		// Mirrors the REST hashtag endpoint's permission check. Without this any
+		// authenticated user could scrape the full hashtag taxonomy.
+		if ( ! WPCOM_Liveblog::current_user_can_edit_liveblog() ) {
+			wp_send_json_error( null, 403 );
+		}
+
 		// Sanitize the input safely.
 		if ( isset( $_GET['autocomplete'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public autocomplete endpoint.
 			$search_term = sanitize_text_field( wp_unslash( $_GET['autocomplete'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public autocomplete endpoint.

--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -643,6 +643,11 @@ class WPCOM_Liveblog_Entry {
 		}
 
 		if ( is_array( $contributors ) ) {
+			// The REST and legacy AJAX entry points do not guarantee this array
+			// contains integers. Coerce to positive integers here so arbitrary
+			// strings cannot be persisted to comment meta.
+			$contributors = array_values( array_filter( array_map( 'absint', $contributors ) ) );
+
 			if ( metadata_exists( 'comment', $comment_id, self::CONTRIBUTORS_META_KEY ) ) {
 				update_comment_meta( $comment_id, self::CONTRIBUTORS_META_KEY, $contributors );
 				return;

--- a/liveblog.php
+++ b/liveblog.php
@@ -2297,8 +2297,13 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 				return;
 			}
 
+			// Entry content is html_entity_decoded inside `get_liveblog_metadata()`, so a
+			// user-supplied `&lt;/script&gt;` in an entry becomes a literal `</script>` in the
+			// encoded payload. PHP's default slash escaping saves us from breakout today, but
+			// JSON_HEX_TAG explicitly escapes `<` and `>` so the JSON-LD block is safe by
+			// construction regardless of future json_encode default changes.
 			?>
-			<script type="application/ld+json"><?php echo wp_json_encode( $metadata ); ?></script>
+			<script type="application/ld+json"><?php echo wp_json_encode( $metadata, JSON_HEX_TAG ); ?></script>
 			<?php
 		}
 


### PR DESCRIPTION
## Summary

Four independent security hardening fixes uncovered by a manual review of REST, AJAX and template output. None of them is individually a live exploit, but each one closes off a class of unsafe behaviour and tightens the plugin's defaults.

The first commit brings the legacy `wp_ajax_liveblog_authors` and `wp_ajax_liveblog_terms` handlers into line with their REST counterparts, which already require the liveblog edit capability. Before the fix, any authenticated user, including a subscriber, could enumerate every user holding `edit_posts` and every term in the `hashtags` taxonomy. Both handlers now short-circuit with a 403 if the caller cannot edit a liveblog.

The second commit hardens `WPCOM_Liveblog_Entry::add_contributors`. The REST entry endpoint passes the `contributor_ids` JSON field through `html_entity_decode` without any integer or array coercion, and the legacy AJAX handler only applies `sanitize_text_field`. That meant non-integer strings could be persisted to comment meta. Normalising to a list of positive integers at the storage boundary makes the stored value well-formed regardless of caller.

The third commit switches the Open Graph `og:url` and `og:image` meta tags emitted by `WPCOM_Liveblog_AMP::social_meta_tags` from `esc_attr` to `esc_url`. `esc_attr` prevents HTML-level breakout but does not strip unsafe URL schemes such as `javascript:`; since both values derive from entry content or its first embedded image, `esc_url` is the correct escaper.

The final commit adds `JSON_HEX_TAG` to the `wp_json_encode` call in `print_liveblog_metadata`. Entry content is `html_entity_decode`'d immediately before being encoded, so a crafted entry containing `&lt;/script&gt;` resolves to a literal `</script>` inside the JSON-LD payload. PHP's default slash escaping currently mitigates the breakout, but that is implicit behaviour rather than enforced intent. `JSON_HEX_TAG` explicitly encodes `<` and `>` so the script block cannot be broken out of regardless of future `json_encode` default changes.

## Test plan

- [ ] PHPCS passes (`composer cs`) — verified locally, clean
- [ ] PHP lint passes (`composer lint`) — verified locally, 55 files clean
- [ ] Unit tests pass (`composer test:unit`) — verified locally, 3/3 pass
- [ ] Integration tests pass on CI
- [ ] Confirm subscriber-role user receives a 403 from `/wp-admin/admin-ajax.php?action=liveblog_authors` and `...=liveblog_terms`
- [ ] Confirm editor-role user still gets expected author and hashtag autocomplete results from both the legacy AJAX and REST endpoints
- [ ] Confirm entry creation with non-integer contributor_ids produces a clean integer array in `liveblog_contributors` comment meta
- [ ] Inspect an AMP single-entry page and confirm `og:url` and `og:image` render correctly
- [ ] View the page source of a liveblog post and confirm the `<script type="application/ld+json">` payload encodes `<` and `>` as `<` / `>`