### PR TITLE
Security hardening on 2.x: cap checks, safer output

### DIFF
--- a/src/php/Application/Filter/AuthorFilter.php
+++ b/src/php/Application/Filter/AuthorFilter.php
@@ -313,6 +313,13 @@ final class AuthorFilter implements ContentFilterInterface {
 	 * @return void
 	 */
 	public function ajax_authors(): void {
+		// Only users who can edit a liveblog should be able to enumerate the
+		// author list. Without this any authenticated user (including
+		// subscribers) could scrape every user holding `edit_posts`.
+		if ( ! RestApiController::current_user_can_edit_liveblog() ) {
+			wp_send_json_error( null, 403 );
+		}
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public autocomplete endpoint.
 		$term = isset( $_GET['autocomplete'] ) ? sanitize_text_field( wp_unslash( $_GET['autocomplete'] ) ) : '';
 

--- a/src/php/Application/Filter/HashtagFilter.php
+++ b/src/php/Application/Filter/HashtagFilter.php
@@ -341,6 +341,12 @@ final class HashtagFilter implements ContentFilterInterface {
 	 * @return void
 	 */
 	public function ajax_terms(): void {
+		// Mirrors the REST hashtag endpoint's permission check. Without this any
+		// authenticated user could scrape the full hashtag taxonomy.
+		if ( ! RestApiController::current_user_can_edit_liveblog() ) {
+			wp_send_json_error( null, 403 );
+		}
+
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public autocomplete endpoint.
 		$search_term = isset( $_GET['autocomplete'] ) ? sanitize_text_field( wp_unslash( $_GET['autocomplete'] ) ) : '';
 

--- a/src/php/Application/Presenter/MetadataPresenter.php
+++ b/src/php/Application/Presenter/MetadataPresenter.php
@@ -117,8 +117,13 @@ final class MetadataPresenter {
 			return;
 		}
 
+		// Entry content is html_entity_decoded when building `articleBody`, so a
+		// user-supplied `&lt;/script&gt;` in an entry becomes a literal `</script>` in the
+		// encoded payload. PHP's default slash escaping saves us from breakout today, but
+		// JSON_HEX_TAG explicitly escapes `<` and `>` so the JSON-LD block is safe by
+		// construction regardless of future json_encode default changes.
 		?>
-		<script type="application/ld+json"><?php echo wp_json_encode( $metadata ); ?></script>
+		<script type="application/ld+json"><?php echo wp_json_encode( $metadata, JSON_HEX_TAG ); ?></script>
 		<?php
 	}
 

--- a/src/php/Infrastructure/WordPress/AmpIntegration.php
+++ b/src/php/Infrastructure/WordPress/AmpIntegration.php
@@ -294,11 +294,11 @@ final class AmpIntegration {
 
 		echo '<meta property="og:title" content="' . esc_attr( $title ) . '">';
 		echo '<meta property="og:description" content="' . esc_attr( $description ) . '">';
-		echo '<meta property="og:url" content="' . esc_attr( $url ) . '">';
+		echo '<meta property="og:url" content="' . esc_url( $url ) . '">';
 		echo '<meta name="twitter:card" content="' . esc_attr( $description ) . '">';
 
 		if ( $image ) {
-			echo '<meta property="og:image" content="' . esc_attr( $image ) . '">';
+			echo '<meta property="og:image" content="' . esc_url( $image ) . '">';
 		}
 	}
 


### PR DESCRIPTION
## Summary

Ports three of the four hardening fixes from #867 onto the 2.x branch. The fourth fix from develop (contributor ID integer coercion in `WPCOM_Liveblog_Entry::add_contributors`) is not needed here because the 2.x refactor already calls `array_map( 'intval', $user_ids )` in `CommentEntryRepository::set_contributors` and enforces an `int[]` type hint on the parameter.

The first commit brings `AuthorFilter::ajax_authors` and `HashtagFilter::ajax_terms` into line with their REST counterparts, which already require the liveblog edit capability. Before the fix, any authenticated user could enumerate every user holding `edit_posts` and every term in the `hashtags` taxonomy simply by hitting the `wp_ajax_liveblog_authors` and `wp_ajax_liveblog_terms` actions. Both handlers now short-circuit with a 403 if the caller cannot edit a liveblog, reusing `RestApiController::current_user_can_edit_liveblog()` which is already imported in both files.

The second commit switches the Open Graph `og:url` and `og:image` meta tags emitted by `AmpIntegration::social_meta_tags` from `esc_attr` to `esc_url`. `esc_attr` prevents HTML-level breakout but does not strip unsafe URL schemes such as `javascript:`; since both values derive from entry content or its first embedded image, `esc_url` is the correct escaper.

The third commit adds `JSON_HEX_TAG` to the `wp_json_encode` call in `MetadataPresenter::print_json_ld`. Entry content is passed through `html_entity_decode` when building the `articleBody` field, so a crafted entry containing `&lt;/script&gt;` resolves to a literal `</script>` inside the JSON-LD payload. PHP's default slash escaping currently mitigates the breakout, but that is implicit behaviour rather than enforced intent. `JSON_HEX_TAG` explicitly encodes `<` and `>` so the script block cannot be broken out of regardless of future `json_encode` default changes.

Companion to #867 on develop.

## Test plan

- [ ] PHPCS passes (`composer cs`) — verified locally, clean
- [ ] PHP lint passes (`composer lint`) — verified locally, 130 files clean
- [ ] Unit tests pass (`composer test:unit`) — verified locally, 190/190 pass
- [ ] Integration tests pass on CI
- [ ] Confirm subscriber-role user receives a 403 from `/wp-admin/admin-ajax.php?action=liveblog_authors` and `...=liveblog_terms`
- [ ] Confirm editor-role user still gets expected author and hashtag autocomplete results from both the legacy AJAX and REST endpoints
- [ ] Inspect an AMP single-entry page and confirm `og:url` and `og:image` render correctly
- [ ] View the page source of a liveblog post and confirm the `<script type="application/ld+json">` payload encodes `<` and `>` as `<` / `>`