### PR TITLE
Scope liveblog write authorisation to the target post

### DIFF
--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -137,7 +137,7 @@ class WPCOM_Liveblog_Rest_Api {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( __CLASS__, 'crud_entry' ),
-				'permission_callback' => array( 'WPCOM_Liveblog', 'current_user_can_edit_liveblog' ),
+				'permission_callback' => array( __CLASS__, 'can_edit_liveblog_entries' ),
 				'args'                => array(
 					'crud_action' => array(
 						'required'          => true,
@@ -221,7 +221,7 @@ class WPCOM_Liveblog_Rest_Api {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( __CLASS__, 'format_preview_entry' ),
-				'permission_callback' => array( 'WPCOM_Liveblog', 'current_user_can_edit_liveblog' ),
+				'permission_callback' => array( __CLASS__, 'can_edit_liveblog_entries' ),
 				'args'                => array(
 					'entry_content' => array(
 						'required' => true,
@@ -292,7 +292,7 @@ class WPCOM_Liveblog_Rest_Api {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( __CLASS__, 'update_post_state' ),
-				'permission_callback' => array( 'WPCOM_Liveblog', 'current_user_can_edit_liveblog' ),
+				'permission_callback' => array( __CLASS__, 'can_edit_liveblog_entries' ),
 				'args'                => array(
 					'post_id'         => array(
 						'required' => true,
@@ -452,6 +452,41 @@ class WPCOM_Liveblog_Rest_Api {
 	}
 
 	/**
+	 * Permission callback for liveblog write routes scoped to a specific post.
+	 *
+	 * Enforces a post-scoped capability check so that users holding only a global
+	 * capability such as `publish_posts` cannot modify another user's liveblog.
+	 * The caller must have `edit_post` on the target post identified by the URL
+	 * path parameter (JSON body values are deliberately ignored here so the body
+	 * cannot override the route's target post).
+	 *
+	 * @since 1.12.0
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return true|WP_Error True when the request is permitted, otherwise a 403 error.
+	 */
+	public static function can_edit_liveblog_entries( WP_REST_Request $request ) {
+		$url_params = $request->get_url_params();
+		$post_id    = isset( $url_params['post_id'] ) ? (int) $url_params['post_id'] : 0;
+		$post       = $post_id > 0 ? get_post( $post_id ) : null;
+
+		$allowed = ( $post instanceof WP_Post && current_user_can( 'edit_post', $post_id ) );
+
+		/** This filter is documented in liveblog.php */
+		$allowed = (bool) apply_filters( 'liveblog_current_user_can_edit_liveblog', $allowed );
+
+		if ( $allowed ) {
+			return true;
+		}
+
+		return new WP_Error(
+			'rest_forbidden',
+			__( 'Sorry, you are not allowed to edit this liveblog.', 'liveblog' ),
+			array( 'status' => rest_authorization_required_code() )
+		);
+	}
+
+	/**
 	 * Get all entries for a post in between two timestamps.
 	 *
 	 * @param WP_REST_Request $request A REST request object.
@@ -490,8 +525,14 @@ class WPCOM_Liveblog_Rest_Api {
 		$crud_action = $request->get_param( 'crud_action' );
 		$json        = $request->get_json_params();
 
+		// The URL path post_id is authoritative for the target post; the permission
+		// callback uses the same source. JSON body `post_id` is ignored so a caller
+		// cannot target a different post than the one authorised by the route.
+		$url_params = $request->get_url_params();
+		$post_id    = isset( $url_params['post_id'] ) ? (int) $url_params['post_id'] : 0;
+
 		$args = array(
-			'post_id'         => self::get_json_param( 'post_id', $json ),
+			'post_id'         => $post_id,
 			'content'         => self::get_json_param( 'content', $json ),
 			'entry_id'        => self::get_json_param( 'entry_id', $json ),
 			'author_id'       => self::get_json_param( 'author_id', $json ),

--- a/liveblog.php
+++ b/liveblog.php
@@ -814,7 +814,12 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		 * Handle CRUD actions for liveblog entries.
 		 */
 		public static function ajax_crud_entry() {
-			self::ajax_current_user_can_edit_liveblog();
+			// The URL post (set by handle_request() from the permalink) is the
+			// authoritative target so a body parameter cannot redirect the action
+			// at a post the caller is not permitted to edit.
+			$post_id = (int) self::$post_id;
+
+			self::ajax_current_user_can_edit_liveblog_for_post( $post_id );
 			self::ajax_check_nonce();
 
 			$args = array();
@@ -829,7 +834,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			}
 
 			// phpcs:disable WordPress.Security.NonceVerification.Missing -- Nonce verified in ajax_check_nonce().
-			$args['post_id']         = isset( $_POST['post_id'] ) ? intval( $_POST['post_id'] ) : 0;
+			$args['post_id']         = $post_id;
 			$args['content']         = isset( $_POST['content'] ) ? sanitize_text_field( wp_unslash( $_POST['content'] ) ) : '';
 			$args['entry_id']        = isset( $_POST['entry_id'] ) ? intval( $_POST['entry_id'] ) : 0;
 			$args['author_id']       = isset( $_POST['author_id'] ) ? intval( $_POST['author_id'] ) : false;
@@ -1158,7 +1163,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		 * @return void
 		 */
 		public static function ajax_preview_entry() {
-			self::ajax_current_user_can_edit_liveblog();
+			self::ajax_current_user_can_edit_liveblog_for_post( (int) self::$post_id );
 
 			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Preview does not modify data.
 			$entry_content = isset( $_REQUEST['entry_content'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['entry_content'] ) ) : '';
@@ -1689,11 +1694,11 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		 */
 		public static function admin_ajax_set_liveblog_state_for_post() {
 			// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Nonce verified in ajax_check_nonce().
-			$post_id   = isset( $_REQUEST['post_id'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['post_id'] ) ) : 0;
+			$post_id   = isset( $_REQUEST['post_id'] ) ? (int) $_REQUEST['post_id'] : 0;
 			$new_state = isset( $_REQUEST['state'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['state'] ) ) : '';
 			// phpcs:enable
 
-			self::ajax_current_user_can_edit_liveblog();
+			self::ajax_current_user_can_edit_liveblog_for_post( $post_id );
 			self::ajax_check_nonce();
 
 			$meta_box = self::admin_set_liveblog_state_for_post( $post_id, $new_state, $_REQUEST ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified above.
@@ -1936,6 +1941,41 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		 */
 		public static function ajax_current_user_can_edit_liveblog() {
 			if ( ! self::current_user_can_edit_liveblog() ) {
+				self::send_forbidden_error( __( "Cheatin', uh?", 'liveblog' ) );
+			}
+		}
+
+		/**
+		 * Can the current user edit liveblog entries on a specific post.
+		 *
+		 * Post-scoped variant of `current_user_can_edit_liveblog()`. Checks the
+		 * `edit_post` meta capability on the supplied post so that holding only a
+		 * global capability such as `publish_posts` does not authorise mutation of
+		 * another user's liveblog.
+		 *
+		 * @param int $post_id The target post ID.
+		 * @return bool
+		 */
+		public static function current_user_can_edit_liveblog_for_post( $post_id ) {
+			$post_id = (int) $post_id;
+			$post    = $post_id > 0 ? get_post( $post_id ) : null;
+			$retval  = ( $post instanceof \WP_Post && current_user_can( 'edit_post', $post_id ) );
+
+			/** This filter is documented above in current_user_can_edit_liveblog(). */
+			return (bool) apply_filters( 'liveblog_current_user_can_edit_liveblog', $retval );
+		}
+
+		/**
+		 * Post-scoped ajax permission gate.
+		 *
+		 * Sends a 403 error response if the current user cannot edit liveblog
+		 * entries on the supplied post.
+		 *
+		 * @param int $post_id The target post ID.
+		 * @return void
+		 */
+		public static function ajax_current_user_can_edit_liveblog_for_post( $post_id ) {
+			if ( ! self::current_user_can_edit_liveblog_for_post( $post_id ) ) {
 				self::send_forbidden_error( __( "Cheatin', uh?", 'liveblog' ) );
 			}
 		}

--- a/tests/Integration/LiveblogTest.php
+++ b/tests/Integration/LiveblogTest.php
@@ -64,6 +64,40 @@ final class LiveblogTest extends TestCase {
 	}
 
 	/**
+	 * The check is capability-driven, not role-driven: a user without
+	 * `edit_others_posts` is denied write access to another user's liveblog,
+	 * even if they hold the Editor role by name.
+	 *
+	 * This protects against drift if a site customises the default role caps —
+	 * the fix follows whatever WordPress maps `edit_post` to in the current
+	 * environment, rather than hard-coding role names.
+	 */
+	public function test_current_user_can_edit_liveblog_for_post_follows_capability_not_role(): void {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_current_user( $editor_id );
+
+		// Baseline: a default Editor can edit another user's post.
+		$this->assertTrue( WPCOM_Liveblog::current_user_can_edit_liveblog_for_post( $post_id ) );
+
+		// Strip `edit_others_posts` from this user via the user_has_cap filter.
+		// This is per-request and does not mutate the shared role definition.
+		$strip_cap = static function ( $allcaps ) {
+			unset( $allcaps['edit_others_posts'] );
+			return $allcaps;
+		};
+		add_filter( 'user_has_cap', $strip_cap );
+
+		try {
+			$this->assertFalse( WPCOM_Liveblog::current_user_can_edit_liveblog_for_post( $post_id ) );
+		} finally {
+			remove_filter( 'user_has_cap', $strip_cap );
+		}
+	}
+
+	/**
 	 * Anonymous callers cannot edit liveblog content.
 	 */
 	public function test_current_user_can_edit_liveblog_for_post_denies_anonymous(): void {

--- a/tests/Integration/LiveblogTest.php
+++ b/tests/Integration/LiveblogTest.php
@@ -23,4 +23,82 @@ final class LiveblogTest extends TestCase {
 	public function test_protected_liveblog_meta_should_return_true(): void {
 		$this->assertTrue( is_protected_meta( WPCOM_Liveblog::KEY ) );
 	}
+
+	/**
+	 * An Author who owns the post is permitted to edit its liveblog.
+	 */
+	public function test_current_user_can_edit_liveblog_for_post_allows_post_owner(): void {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
+
+		wp_set_current_user( $author_id );
+
+		$this->assertTrue( WPCOM_Liveblog::current_user_can_edit_liveblog_for_post( $post_id ) );
+	}
+
+	/**
+	 * An Author who does not own the post cannot edit its liveblog, even when
+	 * they hold a global capability such as `publish_posts`.
+	 */
+	public function test_current_user_can_edit_liveblog_for_post_denies_non_owner_author(): void {
+		$owner_id  = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id   = self::factory()->post->create( array( 'post_author' => $owner_id ) );
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		wp_set_current_user( $author_id );
+
+		$this->assertFalse( WPCOM_Liveblog::current_user_can_edit_liveblog_for_post( $post_id ) );
+	}
+
+	/**
+	 * Editors hold `edit_others_posts` and may edit any post's liveblog.
+	 */
+	public function test_current_user_can_edit_liveblog_for_post_allows_editor_on_others_post(): void {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_current_user( $editor_id );
+
+		$this->assertTrue( WPCOM_Liveblog::current_user_can_edit_liveblog_for_post( $post_id ) );
+	}
+
+	/**
+	 * Anonymous callers cannot edit liveblog content.
+	 */
+	public function test_current_user_can_edit_liveblog_for_post_denies_anonymous(): void {
+		$post_id = self::factory()->post->create();
+
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( WPCOM_Liveblog::current_user_can_edit_liveblog_for_post( $post_id ) );
+	}
+
+	/**
+	 * A non-existent post cannot be edited regardless of capability.
+	 */
+	public function test_current_user_can_edit_liveblog_for_post_denies_missing_post(): void {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$this->assertFalse( WPCOM_Liveblog::current_user_can_edit_liveblog_for_post( 0 ) );
+		$this->assertFalse( WPCOM_Liveblog::current_user_can_edit_liveblog_for_post( 999999 ) );
+	}
+
+	/**
+	 * The `liveblog_current_user_can_edit_liveblog` filter can deny an otherwise
+	 * permitted caller, preserving the existing extension point.
+	 */
+	public function test_current_user_can_edit_liveblog_for_post_filter_can_deny(): void {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$post_id   = self::factory()->post->create();
+
+		wp_set_current_user( $editor_id );
+
+		add_filter( 'liveblog_current_user_can_edit_liveblog', '__return_false' );
+		$result = WPCOM_Liveblog::current_user_can_edit_liveblog_for_post( $post_id );
+		remove_filter( 'liveblog_current_user_can_edit_liveblog', '__return_false' );
+
+		$this->assertFalse( $result );
+	}
 }

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -422,16 +422,21 @@ final class RestApiTest extends TestCase {
 	 */
 	public function test_endpoint_crud_action(): void {
 		// Create an author and set as the current user.
-		$this->set_author_user();
+		$author_id = $this->set_author_user();
 
-		// Create a post.
-		self::factory()->post->create();
+		// Create a post owned by the author so the post-scoped permission check passes.
+		$post_id = self::factory()->post->create( array( 'post_author' => $author_id ) );
 
 		// The POST data to insert.
-		$post_vars = $this->build_entry_args( array( 'crud_action' => 'insert' ) );
+		$post_vars = $this->build_entry_args(
+			array(
+				'crud_action' => 'insert',
+				'post_id'     => $post_id,
+			)
+		);
 
 		// Try to access the endpoint and insert an entry.
-		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/1/crud' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/crud' );
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_body( wp_json_encode( $post_vars ) );
 		$response = $this->server->dispatch( $request );
@@ -494,13 +499,16 @@ final class RestApiTest extends TestCase {
 	 */
 	public function test_endpoint_entry_preview(): void {
 		// Create an author and set as the current user.
-		$this->set_author_user();
+		$author_id = $this->set_author_user();
+
+		// Create a post owned by the author so the post-scoped permission check passes.
+		$post_id = self::factory()->post->create( array( 'post_author' => $author_id ) );
 
 		// The POST data to preview.
 		$post_vars = array( 'entry_content' => 'Test Liveblog entry with /key' );
 
 		// Try to access the endpoint.
-		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/1/preview' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/preview' );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
 		$request->set_body_params( $post_vars );
 		$response = $this->server->dispatch( $request );
@@ -582,10 +590,10 @@ final class RestApiTest extends TestCase {
 	 */
 	public function test_endpoint_update_post_state(): void {
 		// Create an author and set as the current user.
-		$this->set_author_user();
+		$author_id = $this->set_author_user();
 
-		// Create a post.
-		$post = self::factory()->post->create_and_get();
+		// Create a post owned by the author so the post-scoped permission check passes.
+		$post = self::factory()->post->create_and_get( array( 'post_author' => $author_id ) );
 
 		// The POST data.
 		$post_vars = array(
@@ -677,8 +685,12 @@ final class RestApiTest extends TestCase {
 		// The "entry_content" POST data is required for the preview endpoint.
 		// Lets leave it out and expect a 400 bad request response.
 
-		// Create a liveblog post.
-		$post_id = $this->create_liveblog_post();
+		// Create an author and set as the current user so the post-scoped permission
+		// check passes and the request is evaluated against argument validation.
+		$author_id = $this->set_author_user();
+
+		// Create a liveblog post owned by the author.
+		$post_id = $this->create_liveblog_post( array( 'post_author' => $author_id ) );
 
 		// Try to access the endpoint.
 		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/preview' );
@@ -747,12 +759,16 @@ final class RestApiTest extends TestCase {
 	}
 
 	/**
-	 * Create and author and set it as the current user.
+	 * Create an author and set it as the current user.
+	 *
+	 * @return int The new author's user ID.
 	 */
-	private function set_author_user(): void {
+	private function set_author_user(): int {
 		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
 
 		wp_set_current_user( $author_id );
+
+		return $author_id;
 	}
 
 	/**
@@ -904,6 +920,164 @@ final class RestApiTest extends TestCase {
 		remove_filter( 'liveblog_rest_read_permission', '__return_true' );
 
 		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * An Author must not insert liveblog entries on a post owned by another user.
+	 *
+	 * Covers HackerOne report (CWE-285): the CRUD endpoint previously relied on the
+	 * global `publish_posts` capability, which allowed an Author to tamper with
+	 * another user's liveblog. The permission check is now scoped to `edit_post`
+	 * on the target post.
+	 */
+	public function test_endpoint_crud_insert_denied_for_non_owner_author(): void {
+		// Victim post owned by a different Author.
+		$victim_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post_id   = $this->create_liveblog_post( array( 'post_author' => $victim_author_id ) );
+
+		// Attacker: a different Author.
+		$this->set_author_user();
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $victim_post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				$this->build_entry_args(
+					array(
+						'crud_action' => 'insert',
+						'post_id'     => $victim_post_id,
+						'content'     => 'Unauthorised attacker entry.',
+					)
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * An Author must not delete a liveblog entry on a post owned by another user.
+	 */
+	public function test_endpoint_crud_delete_denied_for_non_owner_author(): void {
+		$victim_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post_id   = $this->create_liveblog_post( array( 'post_author' => $victim_author_id ) );
+		$victim_entry     = $this->insert_entries( 1, array( 'post_id' => $victim_post_id ) )[0];
+
+		$this->set_author_user();
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $victim_post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'crud_action' => 'delete',
+					'post_id'     => $victim_post_id,
+					'entry_id'    => $victim_entry->get_id(),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+
+		// Verify the entry is still present and not trashed.
+		$comment = get_comment( $victim_entry->get_id() );
+		$this->assertNotEquals( 'trash', $comment->comment_approved );
+	}
+
+	/**
+	 * An Editor (who has `edit_others_posts`) may write to any liveblog post.
+	 */
+	public function test_endpoint_crud_insert_allowed_for_editor_on_others_post(): void {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
+
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				$this->build_entry_args(
+					array(
+						'crud_action' => 'insert',
+						'post_id'     => $post_id,
+						'content'     => 'Editor intervention.',
+					)
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * A JSON body `post_id` must not override the URL post_id for the permission
+	 * check or the action target. An attacker cannot trick the endpoint into
+	 * writing against a post different from the one authorised by the route.
+	 */
+	public function test_endpoint_crud_json_body_post_id_cannot_override_url(): void {
+		// Victim post owned by another user.
+		$victim_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post_id   = $this->create_liveblog_post( array( 'post_author' => $victim_author_id ) );
+
+		// Attacker with their own liveblog post.
+		$attacker_id      = $this->set_author_user();
+		$attacker_post_id = $this->create_liveblog_post( array( 'post_author' => $attacker_id ) );
+
+		// URL path targets the attacker's own post (permission passes); JSON body tries
+		// to redirect the write at the victim post.
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $attacker_post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'crud_action' => 'insert',
+					'post_id'     => $victim_post_id,
+					'content'     => 'Body-override attacker entry.',
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$entries = $response->get_data()['entries'] ?? array();
+		$this->assertNotEmpty( $entries, 'Expected an inserted entry in the response.' );
+
+		$inserted = (array) $entries[0];
+
+		// The inserted entry must be attached to the URL post, not the JSON body post.
+		$comment = get_comment( $inserted['id'] );
+		$this->assertEquals( (int) $attacker_post_id, (int) $comment->comment_post_ID );
+		$this->assertNotEquals( (int) $victim_post_id, (int) $comment->comment_post_ID );
+	}
+
+	/**
+	 * The update_post_state route must be denied for an Author who does not own the post.
+	 */
+	public function test_endpoint_update_post_state_denied_for_non_owner_author(): void {
+		$victim_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post_id   = self::factory()->post->create( array( 'post_author' => $victim_author_id ) );
+
+		$this->set_author_user();
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $victim_post_id . '/post_state' );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$request->set_body_params(
+			array(
+				'state'           => 'enable',
+				'template_name'   => 'list',
+				'template_format' => 'full',
+				'limit'           => '5',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The liveblog write surfaces — both the REST routes (`/crud`, `/preview`, `/post_state`) and the legacy AJAX handlers reachable via `<permalink>/liveblog/crud`, `<permalink>/liveblog/preview`, and `admin-ajax.php?action=set_liveblog_state_for_post` — gated callers on the global `publish_posts` capability rather than on the right to edit the specific target post. Any authenticated user holding `publish_posts` (every default Author and above) could therefore mutate liveblog state or entries on a post they had no business editing. The CRUD path was worse still: it took the target `post_id` from the JSON body, so even a route bound to one post could be redirected at another.

The fix replaces the global capability check with a post-scoped helper that maps to the `edit_post` meta capability against the URL's `post_id`. For the REST routes that live under `/posts/(?P<post_id>\d+)/...`, the URL `post_id` is treated as authoritative everywhere — both in the permission callback and inside `crud_entry`, so the body cannot override the authorised target. For the legacy `<permalink>/liveblog/*` handlers the URL permalink post (already resolved into `WPCOM_Liveblog::$post_id`) is the gated target. The admin-ajax state handler continues to use `$_REQUEST['post_id']` since it has no URL post, but the check now runs against that exact ID.

Because the helper delegates to `edit_post` rather than naming roles, it follows whatever WordPress maps that meta cap to in the current environment. Sites that customise role caps (for instance, removing `edit_others_posts` from Editors) get the right behaviour automatically. A regression test in `LiveblogTest` documents this property by stripping the cap via `user_has_cap` and asserting the helper denies access.

The existing `liveblog_current_user_can_edit_liveblog` filter is preserved as a final extension point so downstream code that further restricts editing keeps working.

## Test plan

- [ ] `composer test:integration` — covers the new REST and legacy-AJAX permission paths, including the body-override bypass case
- [ ] Manual: as an Author who does not own a post, attempt to POST to `/wp-json/liveblog/v1/posts/<other-post>/crud` and confirm a 403
- [ ] Manual: as the post owner, confirm the editor still loads and entries still publish