### PR TITLE
Scope liveblog write authorisation to the target post (2.x)

### DIFF
--- a/src/php/Infrastructure/WordPress/AdminController.php
+++ b/src/php/Infrastructure/WordPress/AdminController.php
@@ -312,11 +312,35 @@ final class AdminController {
 	/**
 	 * Check if the current user can edit liveblog.
 	 *
+	 * Gates on the configured global editor capability with no post context.
+	 * Use {@see self::current_user_can_edit_for_post()} when a target post is
+	 * known, so authorisation is scoped to that post.
+	 *
 	 * @return bool True if user can edit.
 	 */
 	public static function current_user_can_edit(): bool {
 		$cap    = LiveblogConfiguration::get_edit_capability();
 		$retval = current_user_can( $cap );
+
+		return (bool) apply_filters( 'liveblog_current_user_can_edit_liveblog', $retval );
+	}
+
+	/**
+	 * Check if the current user can edit liveblog state for a specific post.
+	 *
+	 * Mirrors {@see RestApiController::current_user_can_edit_liveblog_for_request()}
+	 * for non-REST entry points (e.g. the admin-ajax state handler), which have
+	 * no `WP_REST_Request` to inspect. Delegates to the `edit_post` meta
+	 * capability so the check follows whatever WordPress maps that to in the
+	 * current environment.
+	 *
+	 * @param int $post_id The target post ID.
+	 * @return bool True if user can edit liveblog state on the post.
+	 */
+	public static function current_user_can_edit_for_post( int $post_id ): bool {
+		$retval = ( $post_id > 0 )
+			&& ( get_post( $post_id ) instanceof \WP_Post )
+			&& current_user_can( 'edit_post', $post_id );
 
 		return (bool) apply_filters( 'liveblog_current_user_can_edit_liveblog', $retval );
 	}

--- a/src/php/Infrastructure/WordPress/PluginBootstrapper.php
+++ b/src/php/Infrastructure/WordPress/PluginBootstrapper.php
@@ -570,7 +570,7 @@ final class PluginBootstrapper {
 				$post_id   = isset( $_REQUEST['post_id'] ) ? (int) $_REQUEST['post_id'] : 0;
 				$new_state = isset( $_REQUEST['state'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['state'] ) ) : '';
 
-				if ( ! $post_id || ! AdminController::current_user_can_edit() ) {
+				if ( ! AdminController::current_user_can_edit_for_post( $post_id ) ) {
 					wp_send_json_error( 'Unauthorized' );
 				}
 

--- a/src/php/Infrastructure/WordPress/RestApiController.php
+++ b/src/php/Infrastructure/WordPress/RestApiController.php
@@ -125,13 +125,42 @@ final class RestApiController {
 	/**
 	 * Check if the current user can edit the liveblog.
 	 *
-	 * Static method for REST API permission callbacks.
+	 * Static method for REST API permission callbacks that have no post in the URL
+	 * (e.g. authors and hashtags autocomplete). Gates on the configured global
+	 * editor capability without any post context.
 	 *
 	 * @return bool True if the current user can edit.
 	 */
 	public static function current_user_can_edit_liveblog(): bool {
 		$cap    = LiveblogConfiguration::get_edit_capability();
 		$retval = current_user_can( $cap );
+
+		return (bool) apply_filters( 'liveblog_current_user_can_edit_liveblog', $retval );
+	}
+
+	/**
+	 * Permission callback for REST write routes that target a specific post.
+	 *
+	 * The CRUD, preview and post_state routes all live under
+	 * `/posts/(?P<post_id>\d+)/...`. Authorisation must be scoped to the post in
+	 * the URL rather than to a global capability, otherwise any user holding
+	 * `publish_posts` (every default Author and above) could mutate liveblog
+	 * state on a post they have no right to edit.
+	 *
+	 * The check delegates to the `edit_post` meta capability, which WordPress
+	 * maps to whatever primitive caps the current site honours. This keeps the
+	 * check correct under role customisation rather than naming roles directly.
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return bool True when the current user can edit the URL post.
+	 */
+	public static function current_user_can_edit_liveblog_for_request( WP_REST_Request $request ): bool {
+		$url_params = $request->get_url_params();
+		$post_id    = isset( $url_params['post_id'] ) ? (int) $url_params['post_id'] : 0;
+
+		$retval = ( $post_id > 0 )
+			&& ( get_post( $post_id ) instanceof \WP_Post )
+			&& current_user_can( 'edit_post', $post_id );
 
 		return (bool) apply_filters( 'liveblog_current_user_can_edit_liveblog', $retval );
 	}
@@ -277,7 +306,7 @@ final class RestApiController {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'crud_entry' ),
-				'permission_callback' => array( self::class, 'current_user_can_edit_liveblog' ),
+				'permission_callback' => array( self::class, 'current_user_can_edit_liveblog_for_request' ),
 				'args'                => array(
 					'crud_action' => array(
 						'required'          => true,
@@ -334,7 +363,7 @@ final class RestApiController {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'format_preview_entry' ),
-				'permission_callback' => array( self::class, 'current_user_can_edit_liveblog' ),
+				'permission_callback' => array( self::class, 'current_user_can_edit_liveblog_for_request' ),
 				'args'                => array(
 					'entry_content' => array( 'required' => true ),
 				),
@@ -376,7 +405,7 @@ final class RestApiController {
 			array(
 				'methods'             => WP_REST_Server::CREATABLE,
 				'callback'            => array( $this, 'update_post_state' ),
-				'permission_callback' => array( self::class, 'current_user_can_edit_liveblog' ),
+				'permission_callback' => array( self::class, 'current_user_can_edit_liveblog_for_request' ),
 				'args'                => array(
 					'post_id'         => array( 'required' => true ),
 					'state'           => array( 'required' => true ),
@@ -473,15 +502,21 @@ final class RestApiController {
 		$crud_action = $request->get_param( 'crud_action' );
 		$json        = $request->get_json_params();
 
+		// Use the URL post_id as the authoritative target. The permission
+		// callback authorises against the URL post_id, so the JSON body must
+		// not be allowed to redirect the action at a different post.
+		$url_params = $request->get_url_params();
+		$post_id    = isset( $url_params['post_id'] ) ? (int) $url_params['post_id'] : 0;
+
 		$args = array(
-			'post_id'         => $this->get_json_param( 'post_id', $json ),
+			'post_id'         => $post_id,
 			'content'         => $this->get_json_param( 'content', $json ),
 			'entry_id'        => $this->get_json_param( 'entry_id', $json ),
 			'author_id'       => $this->get_json_param( 'author_id', $json ),
 			'contributor_ids' => $this->get_json_param( 'contributor_ids', $json ),
 		);
 
-		$this->set_liveblog_vars( (int) $args['post_id'] );
+		$this->set_liveblog_vars( $post_id );
 
 		$user = wp_get_current_user();
 		if ( ! $user || ! $user->exists() ) {

--- a/tests/Integration/AdminControllerTest.php
+++ b/tests/Integration/AdminControllerTest.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Integration tests for AdminController.
+ *
+ * @package Automattic\Liveblog\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Tests\Integration;
+
+use Automattic\Liveblog\Infrastructure\WordPress\AdminController;
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+
+/**
+ * AdminController integration test case.
+ *
+ * Focused on the post-scoped permission helper used by the
+ * `set_liveblog_state_for_post` admin-ajax handler.
+ */
+final class AdminControllerTest extends TestCase {
+
+	/**
+	 * The post owner can edit liveblog state on their own post.
+	 */
+	public function test_current_user_can_edit_for_post_allows_owner(): void {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
+
+		wp_set_current_user( $author_id );
+
+		$this->assertTrue( AdminController::current_user_can_edit_for_post( $post_id ) );
+	}
+
+	/**
+	 * An author who does not own the post is denied even when they hold
+	 * `publish_posts` globally.
+	 */
+	public function test_current_user_can_edit_for_post_denies_non_owner_author(): void {
+		$owner_id    = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id     = self::factory()->post->create( array( 'post_author' => $owner_id ) );
+		$attacker_id = self::factory()->user->create( array( 'role' => 'author' ) );
+
+		wp_set_current_user( $attacker_id );
+
+		$this->assertFalse( AdminController::current_user_can_edit_for_post( $post_id ) );
+	}
+
+	/**
+	 * Editors hold `edit_others_posts` and may edit any post's liveblog.
+	 */
+	public function test_current_user_can_edit_for_post_allows_editor_on_others_post(): void {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_current_user( $editor_id );
+
+		$this->assertTrue( AdminController::current_user_can_edit_for_post( $post_id ) );
+	}
+
+	/**
+	 * Anonymous callers cannot edit liveblog state.
+	 */
+	public function test_current_user_can_edit_for_post_denies_anonymous(): void {
+		$post_id = self::factory()->post->create();
+
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( AdminController::current_user_can_edit_for_post( $post_id ) );
+	}
+
+	/**
+	 * A non-existent post cannot be edited regardless of capability.
+	 */
+	public function test_current_user_can_edit_for_post_denies_missing_post(): void {
+		$admin_id = self::factory()->user->create( array( 'role' => 'administrator' ) );
+		wp_set_current_user( $admin_id );
+
+		$this->assertFalse( AdminController::current_user_can_edit_for_post( 0 ) );
+		$this->assertFalse( AdminController::current_user_can_edit_for_post( 999999 ) );
+	}
+
+	/**
+	 * The check is capability-driven, not role-driven: stripping
+	 * `edit_others_posts` from an Editor denies write access, even though
+	 * the role still nominally exists.
+	 */
+	public function test_current_user_can_edit_for_post_follows_capability_not_role(): void {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+
+		wp_set_current_user( $editor_id );
+
+		// Baseline: a default Editor can edit another user's post.
+		$this->assertTrue( AdminController::current_user_can_edit_for_post( $post_id ) );
+
+		$strip_cap = static function ( $allcaps ) {
+			unset( $allcaps['edit_others_posts'] );
+			return $allcaps;
+		};
+		add_filter( 'user_has_cap', $strip_cap );
+
+		try {
+			$this->assertFalse( AdminController::current_user_can_edit_for_post( $post_id ) );
+		} finally {
+			remove_filter( 'user_has_cap', $strip_cap );
+		}
+	}
+
+	/**
+	 * The `liveblog_current_user_can_edit_liveblog` filter still applies and
+	 * can deny an otherwise permitted caller.
+	 */
+	public function test_current_user_can_edit_for_post_filter_can_deny(): void {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
+
+		wp_set_current_user( $author_id );
+
+		add_filter( 'liveblog_current_user_can_edit_liveblog', '__return_false' );
+		$result = AdminController::current_user_can_edit_for_post( $post_id );
+		remove_filter( 'liveblog_current_user_can_edit_liveblog', '__return_false' );
+
+		$this->assertFalse( $result );
+	}
+}

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -440,17 +440,21 @@ final class RestApiTest extends IntegrationTestCase {
 	 * Integration test - Test accessing the crud endpoint with an insert action.
 	 */
 	public function test_endpoint_crud_action(): void {
-		// Create an author and set as the current user.
-		$this->set_author_user();
-
-		// Create a post.
-		self::factory()->post->create();
+		// Create an author who also owns the target post — the permission
+		// callback now requires `edit_post` on the URL post_id.
+		$author_id = $this->set_author_user();
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
 
 		// The POST data to insert.
-		$post_vars = $this->build_entry_args( array( 'crud_action' => 'insert' ) );
+		$post_vars = $this->build_entry_args(
+			array(
+				'crud_action' => 'insert',
+				'post_id'     => $post_id,
+			)
+		);
 
 		// Try to access the endpoint and insert an entry.
-		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/1/crud' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/crud' );
 		$request->add_header( 'content-type', 'application/json' );
 		$request->set_body( wp_json_encode( $post_vars ) );
 		$response = $this->server->dispatch( $request );
@@ -512,14 +516,16 @@ final class RestApiTest extends IntegrationTestCase {
 	 * Integration test - Test accessing the entry preview endpoint.
 	 */
 	public function test_endpoint_entry_preview(): void {
-		// Create an author and set as the current user.
-		$this->set_author_user();
+		// Create an author who also owns the target post — the preview route
+		// is now scoped to `edit_post` on the URL post_id.
+		$author_id = $this->set_author_user();
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
 
 		// The POST data to preview.
 		$post_vars = array( 'entry_content' => 'Test Liveblog entry with /key' );
 
 		// Try to access the endpoint.
-		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/1/preview' );
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/preview' );
 		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
 		$request->set_body_params( $post_vars );
 		$response = $this->server->dispatch( $request );
@@ -600,11 +606,10 @@ final class RestApiTest extends IntegrationTestCase {
 	 * Integration test - Test accessing the update post state endpoint.
 	 */
 	public function test_endpoint_update_post_state(): void {
-		// Create an author and set as the current user.
-		$this->set_author_user();
-
-		// Create a post.
-		$post = self::factory()->post->create_and_get();
+		// Create an author who also owns the target post — the post_state
+		// route is now scoped to `edit_post` on the URL post_id.
+		$author_id = $this->set_author_user();
+		$post      = self::factory()->post->create_and_get( array( 'post_author' => $author_id ) );
 
 		// The POST data.
 		$post_vars = array(
@@ -675,6 +680,171 @@ final class RestApiTest extends IntegrationTestCase {
 
 		// Assert forbidden response.
 		$this->assertTrue( $response->get_status() === 403 || $response->get_status() === 401 );
+	}
+
+	/**
+	 * An author who does not own the target post must not be able to insert
+	 * an entry into another user's liveblog (CWE-285).
+	 */
+	public function test_endpoint_crud_insert_denies_non_owner_author(): void {
+		// Post belongs to a different author.
+		$owner_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id  = self::factory()->post->create( array( 'post_author' => $owner_id ) );
+
+		// Current user is a different author with `publish_posts` but no
+		// `edit_post` on the target.
+		$attacker_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $attacker_id );
+
+		$post_vars = $this->build_entry_args(
+			array(
+				'crud_action' => 'insert',
+				'post_id'     => $post_id,
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $post_vars ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * An editor (default cap `edit_others_posts`) can edit any post's liveblog.
+	 */
+	public function test_endpoint_crud_insert_allows_editor_on_others_post(): void {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$post_vars = $this->build_entry_args(
+			array(
+				'crud_action' => 'insert',
+				'post_id'     => $post_id,
+			)
+		);
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $post_vars ) );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * The CRUD endpoint must use the URL post_id, not the JSON body. Otherwise
+	 * a caller who passes the permission check for one post could redirect
+	 * the action at another post they have no right to edit.
+	 */
+	public function test_endpoint_crud_json_body_post_id_cannot_override_url(): void {
+		// Author owns post A.
+		$author_id    = $this->set_author_user();
+		$owned_post   = self::factory()->post->create( array( 'post_author' => $author_id ) );
+		$victim_owner = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post  = self::factory()->post->create( array( 'post_author' => $victim_owner ) );
+
+		// Capture the post_id the entry was actually inserted against, so the
+		// test does not depend on for_json() exposing post_id (it does not).
+		$inserted_post_ids = array();
+		$capture           = static function ( $entry_id, $post_id ) use ( &$inserted_post_ids ) {
+			$inserted_post_ids[] = (int) $post_id;
+		};
+		add_action( 'liveblog_insert_entry', $capture, 10, 2 );
+
+		$post_vars = $this->build_entry_args(
+			array(
+				'crud_action' => 'insert',
+				'post_id'     => $victim_post, // Body claims a post the caller cannot edit.
+				'content'     => 'attacker entry',
+			)
+		);
+
+		// URL targets the owned post (so permission_callback passes).
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $owned_post . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $post_vars ) );
+		$response = $this->server->dispatch( $request );
+
+		remove_action( 'liveblog_insert_entry', $capture, 10 );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		// Entry must have been attached to the URL post, not the body post.
+		$this->assertSame( array( (int) $owned_post ), $inserted_post_ids );
+	}
+
+	/**
+	 * The post-scoped permission helper follows whatever WordPress maps
+	 * `edit_post` to in the current environment, rather than naming roles. If
+	 * a site customises role caps (for instance, removes `edit_others_posts`
+	 * from Editors), the check correctly denies write access to other users'
+	 * liveblogs.
+	 */
+	public function test_endpoint_crud_follows_capability_not_role(): void {
+		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+
+		$post_vars = $this->build_entry_args(
+			array(
+				'crud_action' => 'insert',
+				'post_id'     => $post_id,
+			)
+		);
+
+		// Strip `edit_others_posts` from this user via the user_has_cap filter.
+		// Per-request only; does not mutate the shared role definition.
+		$strip_cap = static function ( $allcaps ) {
+			unset( $allcaps['edit_others_posts'] );
+			return $allcaps;
+		};
+		add_filter( 'user_has_cap', $strip_cap );
+
+		try {
+			$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/crud' );
+			$request->add_header( 'content-type', 'application/json' );
+			$request->set_body( wp_json_encode( $post_vars ) );
+			$response = $this->server->dispatch( $request );
+
+			$this->assertEquals( 403, $response->get_status() );
+		} finally {
+			remove_filter( 'user_has_cap', $strip_cap );
+		}
+	}
+
+	/**
+	 * The `liveblog_current_user_can_edit_liveblog` filter still applies to
+	 * the post-scoped permission callback, preserving the existing extension
+	 * point for downstream code that further restricts editing.
+	 */
+	public function test_endpoint_crud_filter_can_deny(): void {
+		$author_id = $this->set_author_user();
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
+
+		add_filter( 'liveblog_current_user_can_edit_liveblog', '__return_false' );
+
+		try {
+			$post_vars = $this->build_entry_args(
+				array(
+					'crud_action' => 'insert',
+					'post_id'     => $post_id,
+				)
+			);
+
+			$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/crud' );
+			$request->add_header( 'content-type', 'application/json' );
+			$request->set_body( wp_json_encode( $post_vars ) );
+			$response = $this->server->dispatch( $request );
+
+			$this->assertEquals( 403, $response->get_status() );
+		} finally {
+			remove_filter( 'liveblog_current_user_can_edit_liveblog', '__return_false' );
+		}
 	}
 
 	/**
@@ -766,12 +936,16 @@ final class RestApiTest extends IntegrationTestCase {
 	}
 
 	/**
-	 * Create and author and set it as the current user.
+	 * Create an author and set it as the current user.
+	 *
+	 * @return int The new author's user ID.
 	 */
-	private function set_author_user(): void {
+	private function set_author_user(): int {
 		$author_id = self::factory()->user->create( array( 'role' => 'author' ) );
 
 		wp_set_current_user( $author_id );
+
+		return $author_id;
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Backports the authorisation fix from #870 to the `2.x` branch.

The same flaw exists on 2.x, though in a slightly narrower form: the legacy `<permalink>/liveblog/*` AJAX handlers were dropped here, so the only write surfaces left are the REST routes and the `set_liveblog_state_for_post` admin-ajax handler. Both gated callers on a global editor capability rather than on the right to edit the specific target post, so any user holding `publish_posts` could mutate liveblog state on a post they had no business touching. The CRUD route was worse still, taking the target `post_id` from the JSON body — so even a route bound to one post could be redirected at another.

The fix follows the same pattern as #870. A new post-scoped permission callback on `RestApiController` maps to the `edit_post` meta capability against the URL `post_id`, and the `/crud`, `/preview` and `/post_state` routes all use it. Inside `crud_entry` the URL `post_id` is now treated as authoritative, so the body cannot redirect the action. For the admin-ajax handler, a parallel `AdminController::current_user_can_edit_for_post()` helper provides the same post-scoped check; the closure in `PluginBootstrapper` calls it after reading the request's `post_id`. The autocomplete routes (`/authors`, `/hashtags`) keep the existing global check because they have no post context.

Because the helpers delegate to `edit_post` rather than naming roles, they follow whatever WordPress maps that meta cap to in the current environment. Sites that customise role caps (for instance, removing `edit_others_posts` from Editors) get the right behaviour automatically. New regression tests in `RestApiTest` and `AdminControllerTest` document this property by stripping the cap via `user_has_cap` and asserting the helper denies access.

The existing `liveblog_current_user_can_edit_liveblog` filter is preserved as a final extension point so downstream code that further restricts editing keeps working.

## Test plan

- [ ] `composer test:integration` — covers the new REST and admin-ajax permission paths, including the body-override bypass case
- [ ] Manual: as an Author who does not own a post, attempt to POST to `/wp-json/liveblog/v1/<other-post>/crud` and confirm a 403
- [ ] Manual: as the post owner, confirm the editor still loads and entries still publish