### PR TITLE
Security hardening: preview CSRF, autocomplete post-scoping, attribute escaping, author validation

### DIFF
--- a/classes/class-wpcom-liveblog-entry-extend-feature-authors.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-authors.php
@@ -79,10 +79,15 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Authors extends WPCOM_Liveblog_Entry_E
 	 */
 	public function get_config( $config ) {
 
-		$endpoint_url = admin_url( 'admin-ajax.php' ) . '?action=liveblog_authors';
+		// The endpoint is built at plugin-load time, before the current post
+		// is known. Use the `%POST_ID%` placeholder here and have
+		// `WPCOM_Liveblog_Entry_Extend::get_autocomplete()` substitute the
+		// actual post id at render time so the autocomplete URL targets
+		// the post-scoped route.
+		$endpoint_url = admin_url( 'admin-ajax.php' ) . '?action=liveblog_authors&post_id=%POST_ID%';
 
 		if ( WPCOM_Liveblog::use_rest_api() ) {
-			$endpoint_url = trailingslashit( trailingslashit( WPCOM_Liveblog_Rest_Api::build_endpoint_base() ) . 'authors' );
+			$endpoint_url = trailingslashit( trailingslashit( WPCOM_Liveblog_Rest_Api::build_endpoint_base() ) . '%POST_ID%/authors' );
 		}
 
 		// Add config to frontend autocomplete after allowing modifications.
@@ -91,7 +96,7 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Authors extends WPCOM_Liveblog_Entry_E
 			array(
 				'type'        => 'ajax',
 				'cache'       => 1000 * 60 * 30,
-				'url'         => esc_url( $endpoint_url ),
+				'url'         => $endpoint_url,
 				'displayKey'  => 'key',
 				'search'      => 'key',
 				'regex'       => '@([\w\-]*)$',
@@ -218,10 +223,13 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Authors extends WPCOM_Liveblog_Entry_E
 	 */
 	public function ajax_authors() {
 
-		// Only users who can edit a liveblog should be able to enumerate the
-		// author list. Without this any authenticated user (including
-		// subscribers) could scrape every user holding `edit_posts`.
-		if ( ! WPCOM_Liveblog::current_user_can_edit_liveblog() ) {
+		// Post-scoped permission check. Mirrors the REST authors endpoint:
+		// callers must hold `edit_post` on the target post, not just a
+		// global cap, otherwise any contributor could enumerate every user
+		// holding `edit_posts` across the whole site.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public autocomplete endpoint; CSRF is irrelevant for a read.
+		$post_id = isset( $_GET['post_id'] ) ? (int) $_GET['post_id'] : 0;
+		if ( ! WPCOM_Liveblog::current_user_can_edit_liveblog_for_post( $post_id ) ) {
 			wp_send_json_error( null, 403 );
 		}
 

--- a/classes/class-wpcom-liveblog-entry-extend-feature-authors.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-authors.php
@@ -164,10 +164,14 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Authors extends WPCOM_Liveblog_Entry_E
 		$user         = get_user_by( 'slug', $author );
 		$display_name = $user ? $user->display_name : $author;
 
-		// Replace @author with a link to the author's post listing page.
+		// Replace @author with a link to the author's post listing page. The
+		// `liveblog_author_class` and `liveblog_author` filters allow third
+		// parties to influence both the class prefix and the matched author
+		// slug, so escape every interpolated value at the point of attribute
+		// construction.
 		return str_replace(
 			$regex_match[1],
-			'<a href="' . get_author_posts_url( -1, $author ) . '" class="liveblog-author ' . $this->class_prefix . $author . '">' . esc_html( $display_name ) . '</a>',
+			'<a href="' . esc_url( get_author_posts_url( -1, $author ) ) . '" class="liveblog-author ' . esc_attr( $this->class_prefix . $author ) . '">' . esc_html( $display_name ) . '</a>',
 			$regex_match[0]
 		);
 	}

--- a/classes/class-wpcom-liveblog-entry-extend-feature-emojis.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-emojis.php
@@ -1065,10 +1065,13 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Emojis extends WPCOM_Liveblog_Entry_Ex
 		$image = $this->map_emoji( $this->emojis[ $emoji ], $emoji );
 		$image = $image['image'];
 
-		// Replace the emoji with a img tag of the emoji.
+		// Replace the emoji with a img tag of the emoji. `liveblog_cdn_emojis`,
+		// `liveblog_emoji_class` and `liveblog_active_emojis` are all
+		// publicly-documented filters, so escape every interpolated value at
+		// the point of attribute construction.
 		return str_replace(
 			$regex_match[1],
-			'<img src="' . $this->emoji_cdn . $image . '.png" class="liveblog-emoji ' . $this->class_prefix . $emoji . '" data-emoji="' . $emoji . '">',
+			'<img src="' . esc_url( $this->emoji_cdn . $image . '.png' ) . '" class="liveblog-emoji ' . esc_attr( $this->class_prefix . $emoji ) . '" data-emoji="' . esc_attr( $emoji ) . '">',
 			$regex_match[0]
 		);
 	}

--- a/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php
@@ -190,11 +190,16 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Hashtags extends WPCOM_Liveblog_Entry_
 		// Get the term link for the hashtag.
 		$term_link = $term ? get_term_link( $term, self::$taxonomy ) : '';
 
-		// Replace the #hashtag content with a link to the hashtag archive.
+		// Replace the #hashtag content with a link to the hashtag archive. The
+		// `liveblog_hashtag_class` filter lets third parties replace `class_prefix`
+		// with arbitrary content, so escape every interpolated value at the point
+		// of attribute construction rather than relying solely on upstream
+		// sanitisation.
+		$class_attr = esc_attr( $this->class_prefix . $hashtag );
 		if ( $term_link && ! is_wp_error( $term_link ) ) {
 			return str_replace(
 				$regex_match[1],
-				'<a href="' . esc_url( $term_link ) . '" class="liveblog-hash ' . $this->class_prefix . $hashtag . '">' . esc_html( $hashtag ) . '</a>',
+				'<a href="' . esc_url( $term_link ) . '" class="liveblog-hash ' . $class_attr . '">' . esc_html( $hashtag ) . '</a>',
 				$regex_match[0]
 			);
 		}
@@ -202,7 +207,7 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Hashtags extends WPCOM_Liveblog_Entry_
 		// Fallback to span if term link fails.
 		return str_replace(
 			$regex_match[1],
-			'<span class="liveblog-hash ' . $this->class_prefix . $hashtag . '">' . esc_html( $hashtag ) . '</span>',
+			'<span class="liveblog-hash ' . $class_attr . '">' . esc_html( $hashtag ) . '</span>',
 			$regex_match[0]
 		);
 	}

--- a/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-hashtags.php
@@ -104,10 +104,15 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Hashtags extends WPCOM_Liveblog_Entry_
 	 */
 	public function get_config( $config ) {
 
-		$endpoint_url = admin_url( 'admin-ajax.php' ) . '?action=liveblog_terms';
+		// The endpoint is built at plugin-load time, before the current post
+		// is known. Use the `%POST_ID%` placeholder here and have
+		// `WPCOM_Liveblog_Entry_Extend::get_autocomplete()` substitute the
+		// actual post id at render time so the autocomplete URL targets
+		// the post-scoped route.
+		$endpoint_url = admin_url( 'admin-ajax.php' ) . '?action=liveblog_terms&post_id=%POST_ID%';
 
 		if ( WPCOM_Liveblog::use_rest_api() ) {
-			$endpoint_url = trailingslashit( trailingslashit( WPCOM_Liveblog_Rest_Api::build_endpoint_base() ) . 'hashtags' );
+			$endpoint_url = trailingslashit( trailingslashit( WPCOM_Liveblog_Rest_Api::build_endpoint_base() ) . '%POST_ID%/hashtags' );
 		}
 
 		// Add config to frontend autocomplete after allowing modifications.
@@ -123,7 +128,7 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Hashtags extends WPCOM_Liveblog_Entry_
 				'name'        => 'Hashtag',
 				'template'    => '${slug}',
 				'replaceText' => '#$',
-				'url'         => esc_url( $endpoint_url ),
+				'url'         => $endpoint_url,
 			)
 		);
 
@@ -254,9 +259,13 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Hashtags extends WPCOM_Liveblog_Entry_
 	 */
 	public function ajax_terms() {
 
-		// Mirrors the REST hashtag endpoint's permission check. Without this any
-		// authenticated user could scrape the full hashtag taxonomy.
-		if ( ! WPCOM_Liveblog::current_user_can_edit_liveblog() ) {
+		// Post-scoped permission check. Mirrors the REST hashtag endpoint:
+		// callers must hold `edit_post` on the target post, not just a
+		// global cap, otherwise any contributor could scrape the full
+		// hashtag taxonomy across the whole site.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public autocomplete endpoint; CSRF is irrelevant for a read.
+		$post_id = isset( $_GET['post_id'] ) ? (int) $_GET['post_id'] : 0;
+		if ( ! WPCOM_Liveblog::current_user_can_edit_liveblog_for_post( $post_id ) ) {
 			wp_send_json_error( null, 403 );
 		}
 

--- a/classes/class-wpcom-liveblog-entry-extend.php
+++ b/classes/class-wpcom-liveblog-entry-extend.php
@@ -102,10 +102,34 @@ class WPCOM_Liveblog_Entry_Extend {
 	 * Returns the settings for autocomplete that are used by
 	 * the frontend javascript for autocomplete matching.
 	 *
+	 * Feature configs (authors, hashtags) emit URLs that contain a
+	 * `%POST_ID%` placeholder because the configs are computed at plugin
+	 * load time, before the current post is known. This method substitutes
+	 * the placeholder with the supplied post id so the URLs target the
+	 * post-scoped REST/AJAX routes added in 1.12.0.
+	 *
+	 * @param int|null $post_id The post id to inject into autocomplete URLs.
+	 *                          Falls back to `get_the_ID()` for callers that
+	 *                          don't pass one explicitly.
 	 * @return array
 	 */
-	public static function get_autocomplete() {
-		return self::$autocomplete;
+	public static function get_autocomplete( $post_id = null ) {
+		$autocomplete = self::$autocomplete;
+
+		$post_id = $post_id ? (int) $post_id : (int) get_the_ID();
+
+		if ( $post_id <= 0 ) {
+			return $autocomplete;
+		}
+
+		$placeholder = '%POST_ID%';
+		foreach ( $autocomplete as $key => $entry ) {
+			if ( isset( $entry['url'] ) && false !== strpos( $entry['url'], $placeholder ) ) {
+				$autocomplete[ $key ]['url'] = esc_url( str_replace( $placeholder, (string) $post_id, $entry['url'] ) );
+			}
+		}
+
+		return $autocomplete;
 	}
 
 	/**

--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -602,7 +602,7 @@ class WPCOM_Liveblog_Entry {
 	 * @return WP_User The user object.
 	 */
 	private static function handle_author_select( $args, $entry_id ) {
-		if ( isset( $args['author_id'] ) && $args['author_id'] ) {
+		if ( isset( $args['author_id'] ) && $args['author_id'] && self::is_user_assignable_as_author( (int) $args['author_id'] ) ) {
 			$user_object = self::get_userdata_with_filter( $args['author_id'] );
 			if ( $user_object ) {
 				$args['user'] = $user_object;
@@ -631,6 +631,29 @@ class WPCOM_Liveblog_Entry {
 	}
 
 	/**
+	 * Whether a supplied user id may be set as an entry's author or contributor.
+	 *
+	 * The author/contributor pickers in the editor only suggest users who hold
+	 * the `edit_posts` capability — that is the data set returned by the
+	 * autocomplete endpoint. The back end did not previously enforce that
+	 * boundary, so a malicious editor could pass any user id (including a
+	 * subscriber's) and have the resulting comment attributed to them, leaking
+	 * `comment_author_email` for that user and breaking the audit trail.
+	 *
+	 * @param int $user_id Candidate user id.
+	 * @return bool True when the candidate is a real user with `edit_posts`.
+	 */
+	private static function is_user_assignable_as_author( $user_id ) {
+		if ( $user_id <= 0 ) {
+			return false;
+		}
+
+		// `user_can()` handles a non-existent user id by returning false; no
+		// additional `get_userdata()` round trip is needed.
+		return user_can( $user_id, 'edit_posts' );
+	}
+
+	/**
 	 * Store the contributors as comment meta.
 	 *
 	 * @param int   $comment_id   The comment ID for the meta we should update.
@@ -647,6 +670,19 @@ class WPCOM_Liveblog_Entry {
 			// contains integers. Coerce to positive integers here so arbitrary
 			// strings cannot be persisted to comment meta.
 			$contributors = array_values( array_filter( array_map( 'absint', $contributors ) ) );
+
+			// Keep only users who could legitimately appear in the contributor
+			// picker (those with `edit_posts`). Without this filter a malicious
+			// editor could attribute an entry to any user id, including
+			// subscribers, leaking the assigned user's display name and avatar
+			// onto the post.
+			$assignable = array();
+			foreach ( $contributors as $contributor_id ) {
+				if ( self::is_user_assignable_as_author( $contributor_id ) ) {
+					$assignable[] = $contributor_id;
+				}
+			}
+			$contributors = $assignable;
 
 			if ( metadata_exists( 'comment', $comment_id, self::CONTRIBUTORS_META_KEY ) ) {
 				update_comment_meta( $comment_id, self::CONTRIBUTORS_META_KEY, $contributors );

--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -804,17 +804,20 @@ class WPCOM_Liveblog_Rest_Api {
 	/**
 	 * Get parameter from JSON.
 	 *
+	 * Returns the value as supplied by the client. Per-field sanitisation is
+	 * applied downstream (`wp_filter_post_kses` for content, `absint` for the
+	 * contributor IDs), and that is the right place for it. Decoding HTML
+	 * entities here would silently undo any encoding the client applied,
+	 * weaken defence in depth, and trigger PHP 8.1+ deprecation warnings when
+	 * the value is non-string (e.g. integer contributor IDs).
+	 *
 	 * @param string $param The parameter name.
 	 * @param array  $json  The JSON data.
 	 * @return mixed The parameter value or false if not found.
 	 */
 	public static function get_json_param( $param, $json ) {
 		if ( isset( $json[ $param ] ) ) {
-			// Handle arrays (e.g., contributor_ids from multi-select).
-			if ( is_array( $json[ $param ] ) ) {
-				return array_map( 'html_entity_decode', $json[ $param ] );
-			}
-			return html_entity_decode( $json[ $param ] );
+			return $json[ $param ];
 		}
 		return false;
 	}

--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -232,23 +232,28 @@ class WPCOM_Liveblog_Rest_Api {
 
 		/*
 		 * Get a list of authors matching a search term.
-		 * Used to autocomplete @ mentions
+		 * Used to autocomplete @ mentions.
 		 *
-		 * /authors/<term>
+		 * The route is post-scoped so the permission check can require
+		 * `edit_post` on the target post rather than relying on a global
+		 * capability such as `publish_posts`. Pre-1.12.0 callers using the
+		 * legacy `/authors/<term>` shape are no longer accepted; the post
+		 * id is now mandatory.
 		 *
-		 * TODO: The regex pattern will allow no slash between 'authors' and the search term.
-		 *       Look into requiring the slash
-		 *
+		 * /<post_id>/authors/<term>
 		 */
 		register_rest_route(
 			self::$api_namespace,
-			'/authors([/]*)(?P<term>.*)',
+			'/(?P<post_id>\d+)/authors([/]*)(?P<term>.*)',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( __CLASS__, 'get_authors' ),
-				'permission_callback' => array( 'WPCOM_Liveblog', 'current_user_can_edit_liveblog' ),
+				'permission_callback' => array( __CLASS__, 'can_edit_liveblog_entries' ),
 				'args'                => array(
-					'term' => array(
+					'post_id' => array(
+						'required' => true,
+					),
+					'term'    => array(
 						'required' => false,
 					),
 				),
@@ -257,23 +262,24 @@ class WPCOM_Liveblog_Rest_Api {
 
 		/*
 		 * Get a list of hashtags matching a search term.
-		 * Used to autocomplete previously used #hashtags
+		 * Used to autocomplete previously used #hashtags.
 		 *
-		 * /hashtags/<term>
+		 * Post-scoped for the same reason as the authors route.
 		 *
-		 * TODO: The regex pattern will allow no slash between 'hashtags' and the search term.
-		 *       Look into requiring the slash
-		 *
+		 * /<post_id>/hashtags/<term>
 		 */
 		register_rest_route(
 			self::$api_namespace,
-			'/hashtags([/]*)(?P<term>.*)',
+			'/(?P<post_id>\d+)/hashtags([/]*)(?P<term>.*)',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( __CLASS__, 'get_hashtag_terms' ),
-				'permission_callback' => array( 'WPCOM_Liveblog', 'current_user_can_edit_liveblog' ),
+				'permission_callback' => array( __CLASS__, 'can_edit_liveblog_entries' ),
 				'args'                => array(
-					'term' => array(
+					'post_id' => array(
+						'required' => true,
+					),
+					'term'    => array(
 						'required' => false,
 					),
 				),

--- a/docs/entry-hooks.md
+++ b/docs/entry-hooks.md
@@ -27,7 +27,7 @@ public static function filter( $entry ) {
 This is where `:emoji:` is converted back to `<img>`:
 
 ```php
-add_filter( 'liveblog_preview_update_entry', array( __CLASS__, 'filter' ), 10 );
+add_filter( 'liveblog_before_preview_entry', array( __CLASS__, 'filter' ), 10 );
 
 public static function filter( $entry ) {
 	return $entry;

--- a/liveblog.php
+++ b/liveblog.php
@@ -1357,7 +1357,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 						'cross_domain'                 => false,
 
 						'features'                     => WPCOM_Liveblog_Entry_Extend::get_enabled_features(),
-						'autocomplete'                 => WPCOM_Liveblog_Entry_Extend::get_autocomplete(),
+						'autocomplete'                 => WPCOM_Liveblog_Entry_Extend::get_autocomplete( get_the_ID() ),
 						'command_class'                => apply_filters( 'liveblog_command_class', WPCOM_Liveblog_Entry_Extend_Feature_Commands::$class_prefix ),
 
 						// Internationalization strings.

--- a/liveblog.php
+++ b/liveblog.php
@@ -1165,7 +1165,13 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		public static function ajax_preview_entry() {
 			self::ajax_current_user_can_edit_liveblog_for_post( (int) self::$post_id );
 
-			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Preview does not modify data.
+			// Preview runs the same `liveblog_before_preview_entry` filter chain as the
+			// editor. Feature filters (notably hashtags) call wp_insert_term() on any
+			// new tag in the content, so an unauthenticated POST can pollute the
+			// hashtag taxonomy. Require the standard liveblog nonce here.
+			self::ajax_check_nonce();
+
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified in ajax_check_nonce().
 			$entry_content = isset( $_REQUEST['entry_content'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['entry_content'] ) ) : '';
 			$entry_content = self::format_preview_entry( $entry_content );
 

--- a/tests/Integration/EntryTest.php
+++ b/tests/Integration/EntryTest.php
@@ -220,6 +220,90 @@ final class EntryTest extends TestCase {
 	}
 
 	/**
+	 * `author_id` for a user with `edit_posts` is accepted and the resulting
+	 * comment is attributed to that user. This is the legitimate co-author
+	 * flow and must keep working.
+	 */
+	public function test_insert_with_author_id_for_editable_user_attributes_entry_to_them(): void {
+		$inserter_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$author_id   = self::factory()->user->create(
+			array(
+				'role'         => 'author',
+				'display_name' => 'Picked Author',
+			)
+		);
+
+		$entry = WPCOM_Liveblog_Entry::insert(
+			$this->build_entry_args(
+				array(
+					'user'      => get_userdata( $inserter_id ),
+					'author_id' => $author_id,
+				)
+			)
+		);
+
+		$comment = get_comment( $entry->get_id() );
+		$this->assertEquals( $author_id, (int) $comment->user_id );
+		$this->assertEquals( 'Picked Author', $comment->comment_author );
+	}
+
+	/**
+	 * `author_id` pointing at a user without `edit_posts` (e.g. a
+	 * subscriber) must be rejected silently and the entry must remain
+	 * attributed to the inserting user. Otherwise an editor could spoof
+	 * arbitrary site users — including subscribers, leaking their email —
+	 * through a pure server-side input the autocomplete UI would never have
+	 * suggested.
+	 */
+	public function test_insert_with_author_id_for_subscriber_keeps_inserter_as_author(): void {
+		$inserter_id   = self::factory()->user->create(
+			array(
+				'role'         => 'editor',
+				'display_name' => 'Real Editor',
+			)
+		);
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		$entry = WPCOM_Liveblog_Entry::insert(
+			$this->build_entry_args(
+				array(
+					'user'      => get_userdata( $inserter_id ),
+					'author_id' => $subscriber_id,
+				)
+			)
+		);
+
+		$comment = get_comment( $entry->get_id() );
+		$this->assertEquals( $inserter_id, (int) $comment->user_id );
+		$this->assertEquals( 'Real Editor', $comment->comment_author );
+	}
+
+	/**
+	 * `contributor_ids` containing users without `edit_posts` are dropped
+	 * before they are persisted to comment meta. The contributor picker
+	 * surfaces only `edit_posts` users; the back end must not accept ids
+	 * outside that set.
+	 */
+	public function test_insert_with_contributor_ids_filters_out_subscribers(): void {
+		$inserter_id     = self::factory()->user->create( array( 'role' => 'editor' ) );
+		$valid_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$subscriber_id   = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+
+		$entry = WPCOM_Liveblog_Entry::insert(
+			$this->build_entry_args(
+				array(
+					'user'            => get_userdata( $inserter_id ),
+					'contributor_ids' => array( $valid_author_id, $subscriber_id ),
+				)
+			)
+		);
+
+		$stored = get_comment_meta( $entry->get_id(), 'liveblog_contributors', true );
+
+		$this->assertEquals( array( $valid_author_id ), $stored );
+	}
+
+	/**
 	 * Set liveblog hook fired global.
 	 */
 	public static function set_liveblog_hook_fired(): void {

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -525,7 +525,10 @@ final class RestApiTest extends TestCase {
 	 */
 	public function test_endpoint_get_authors(): void {
 		// Create an author and set as the current user.
-		$this->set_author_user();
+		$author_id = $this->set_author_user();
+
+		// Create a post owned by the author so the post-scoped permission check passes.
+		$post_id = self::factory()->post->create( array( 'post_author' => $author_id ) );
 
 		// Create 2 authors.
 		self::factory()->user->create(
@@ -542,7 +545,7 @@ final class RestApiTest extends TestCase {
 			)
 		);
 
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/authors/jo' );
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/authors/jo' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert successful response.
@@ -553,11 +556,35 @@ final class RestApiTest extends TestCase {
 	}
 
 	/**
+	 * Integration test - The authors endpoint must require edit_post on the
+	 * supplied post. A user without that capability is denied even if they
+	 * hold a global capability such as `publish_posts`.
+	 */
+	public function test_endpoint_get_authors_denies_user_without_edit_post(): void {
+		// Author A owns the post.
+		$post_owner_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id       = self::factory()->post->create( array( 'post_author' => $post_owner_id ) );
+
+		// Author B is logged in and has `publish_posts` but no `edit_post` on
+		// the post owned by Author A.
+		$other_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $other_author_id );
+
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/authors/jo' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
 	 * Integration test - Test accessing the get hashtags endpoint.
 	 */
 	public function test_endpoint_get_hashtags(): void {
 		// Create an author and set as the current user.
-		$this->set_author_user();
+		$author_id = $this->set_author_user();
+
+		// Create a post owned by the author so the post-scoped permission check passes.
+		$post_id = self::factory()->post->create( array( 'post_author' => $author_id ) );
 
 		// Create 2 hashtags.
 		self::factory()->term->create(
@@ -575,7 +602,7 @@ final class RestApiTest extends TestCase {
 			)
 		);
 
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/hashtags/cool' );
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/hashtags/cool' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert successful response.
@@ -583,6 +610,27 @@ final class RestApiTest extends TestCase {
 
 		// The array should contain 2 authors.
 		$this->assertCount( 2, $response->get_data() );
+	}
+
+	/**
+	 * Integration test - The hashtags endpoint must require edit_post on the
+	 * supplied post. A user without that capability is denied even if they
+	 * hold a global capability such as `publish_posts`.
+	 */
+	public function test_endpoint_get_hashtags_denies_user_without_edit_post(): void {
+		// Author A owns the post.
+		$post_owner_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id       = self::factory()->post->create( array( 'post_author' => $post_owner_id ) );
+
+		// Author B is logged in and has `publish_posts` but no `edit_post` on
+		// the post owned by Author A.
+		$other_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $other_author_id );
+
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/hashtags/cool' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 403, $response->get_status() );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

A second pass of the security audit started in #867 and #870. Each commit addresses a separate finding; together they close the remaining gaps in the editor permission boundary and tighten defence-in-depth on the content rendering paths.

**Legacy preview endpoint was CSRF-open.** `ajax_preview_entry()` skipped `ajax_check_nonce()` on the assumption that preview was read-only, but the `liveblog_before_preview_entry` filter chain runs the hashtag feature filter, which calls `wp_insert_term()` for any new `#tag` it finds. A CSRF against a logged-in editor could therefore pollute the hashtags taxonomy with arbitrary slugs. The first commit requires the standard liveblog nonce on this endpoint. The REST equivalent is unaffected because cookie-authenticated REST already requires `X-WP-Nonce`.

**Authors and hashtags autocompletes were not post-scoped.** Both the REST routes (`/authors/<term>`, `/hashtags/<term>`) and the legacy `wp_ajax_liveblog_authors`/`wp_ajax_liveblog_terms` handlers gated on the global `current_user_can_edit_liveblog()` (default cap `publish_posts`). Any user holding that cap could enumerate every `edit_posts` user and the entire hashtags taxonomy, regardless of which post — if any — they were editing. Mirroring the boundary that #870 established for the write endpoints, the routes are now post-scoped: `/<post_id>/authors/<term>` and `/<post_id>/hashtags/<term>`, both gated on `edit_post` for the supplied post. The legacy AJAX handlers read `post_id` from the query string and use the same post-scoped check. The autocomplete URL is built at plugin-load time, before the current post is known, so the URL builder emits a `%POST_ID%` placeholder that `WPCOM_Liveblog_Entry_Extend::get_autocomplete()` substitutes when the config is shipped to the front end. Tests cover the happy path and a denial for a user without `edit_post` on the specific post. Note: the pre-1.12.0 `/authors/<term>` and `/hashtags/<term>` URL shapes are no longer accepted; consumers must include the post id.

**Author and contributor ids were not validated.** The editor's author/contributor pickers only suggest users with `edit_posts`, but the back end accepted any user id sent in `author_id` or `contributor_ids`. An editor on post A could therefore attribute (or retroactively re-attribute, on update) an entry to any user on the site — a subscriber, a different editor, even an admin — overwriting `comment_author`, `comment_author_email` and `comment_author_url` with the impersonated user's data. That is both an impersonation primitive on a public liveblog and an email-disclosure vector via standard comment APIs. Author and contributor ids that don't pass `user_can( \$user_id, 'edit_posts' )` are now rejected silently, mirroring the data set the autocomplete returns.

**Defence-in-depth tidy-up.** Two smaller items:

- The hashtag, author and emoji `preg_replace_callback` renderers built `<a>`/`<img>`/`<span>` tags by string concatenation and interpolated filter-controlled values (`liveblog_hashtag_class`, `liveblog_author`, `liveblog_cdn_emojis`, `liveblog_emoji_class`, `liveblog_active_emojis`) straight into `class`, `href`, `src` and `data-emoji` without `esc_attr()` or `esc_url()`. With the shipped defaults the output is safe today, but a third-party hook returning a quote could break out. `wp_filter_post_kses` strips the resulting event handler when content is stored, but that is a single point of failure rather than a guarantee.
- `WPCOM_Liveblog_Rest_Api::get_json_param()` was running every JSON value through `html_entity_decode()`. JSON does not encode HTML entities, so the call served no purpose, silently undid any encoding the client applied (a defence-in-depth loss before `wp_filter_post_kses`), and triggered PHP 8.1+ deprecation warnings when the value was non-string (e.g. integer contributor ids).

## Test plan

- [ ] `composer test:unit` passes locally.
- [ ] `composer test:integration` passes locally — note in particular the new `RestApiTest::test_endpoint_get_authors_denies_user_without_edit_post`, `RestApiTest::test_endpoint_get_hashtags_denies_user_without_edit_post`, and the three new `EntryTest::test_insert_with_*` cases.
- [ ] Manual: enable a liveblog, edit an entry, type `#newtag` into the editor, click Preview without submitting. Confirm `newtag` is _not_ created in the `hashtags` taxonomy (admin → Posts → Hashtags) without first publishing the entry — and that submitting the entry _does_ create it.
- [ ] Manual: confirm `@` and `#` autocomplete still surface suggestions on the post editor.
- [ ] Manual: as a user with `edit_post` on post A but not on post B, confirm `GET /wp-json/liveblog/v1/<B>/authors/jo` and `/<B>/hashtags/cool` return `403`.
- [ ] Manual: confirm posting an entry with `author_id` set to a subscriber's user id leaves the entry attributed to the actual poster rather than the subscriber.