### PR TITLE
Tighten DDD layering: pure Domain, injected renderers, trimmed EntryOperations

### DIFF
--- a/src/php/Application/Aggregate/LiveblogPost.php
+++ b/src/php/Application/Aggregate/LiveblogPost.php
@@ -1,23 +1,26 @@
 <?php
 /**
- * LiveblogPost entity representing a post with liveblog functionality.
+ * LiveblogPost aggregate representing a post with liveblog functionality.
  *
- * @package Automattic\Liveblog\Domain\Entity
+ * @package Automattic\Liveblog\Application\Aggregate
  */
 
 declare( strict_types=1 );
 
-namespace Automattic\Liveblog\Domain\Entity;
+namespace Automattic\Liveblog\Application\Aggregate;
 
 use Automattic\Liveblog\Application\Config\LiveblogConfiguration;
 use DateTimeImmutable;
 use WP_Post;
 
 /**
- * Domain entity wrapping WP_Post with liveblog-specific behaviour.
+ * Aggregate wrapping WP_Post with liveblog-specific state and behaviour.
  *
- * Encapsulates the liveblog state and operations for a WordPress post,
- * providing a clean domain interface for working with liveblog posts.
+ * Encapsulates the liveblog state and operations for a WordPress post.
+ * Lives in the Application layer because state and capability checks are
+ * read and written through WordPress functions (post meta, post type
+ * support, capability checks). Pure persistence-agnostic types belong in
+ * the Domain layer; this aggregate is intentionally WordPress-aware.
  */
 final class LiveblogPost {
 

--- a/src/php/Application/Config/LazyloadConfiguration.php
+++ b/src/php/Application/Config/LazyloadConfiguration.php
@@ -9,8 +9,8 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Application\Config;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
-use Automattic\Liveblog\Infrastructure\DI\Container;
+use Automattic\Liveblog\Application\Renderer\TemplateRendererInterface;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 
 /**
  * Configuration for lazy loading liveblog entries.
@@ -61,6 +61,22 @@ final class LazyloadConfiguration {
 	 * @var int|null
 	 */
 	private ?int $entries_per_page = null;
+
+	/**
+	 * Template renderer for admin notices.
+	 *
+	 * @var TemplateRendererInterface
+	 */
+	private TemplateRendererInterface $template_renderer;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param TemplateRendererInterface $template_renderer Renderer used for the deprecated plugin admin notice.
+	 */
+	public function __construct( TemplateRendererInterface $template_renderer ) {
+		$this->template_renderer = $template_renderer;
+	}
 
 	/**
 	 * Check if lazy loading is enabled.
@@ -186,7 +202,7 @@ final class LazyloadConfiguration {
 	 */
 	public function render_deprecated_plugin_notice(): void {
 		echo wp_kses_post(
-			Container::instance()->template_renderer()->render(
+			$this->template_renderer->render(
 				'lazyload-notice.php',
 				array(
 					'plugin' => 'Lazyload Liveblog Entries',

--- a/src/php/Application/Config/LazyloadConfiguration.php
+++ b/src/php/Application/Config/LazyloadConfiguration.php
@@ -9,7 +9,6 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Application\Config;
 
-use Automattic\Liveblog\Application\Renderer\TemplateRendererInterface;
 use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 
 /**
@@ -61,22 +60,6 @@ final class LazyloadConfiguration {
 	 * @var int|null
 	 */
 	private ?int $entries_per_page = null;
-
-	/**
-	 * Template renderer for admin notices.
-	 *
-	 * @var TemplateRendererInterface
-	 */
-	private TemplateRendererInterface $template_renderer;
-
-	/**
-	 * Constructor.
-	 *
-	 * @param TemplateRendererInterface $template_renderer Renderer used for the deprecated plugin admin notice.
-	 */
-	public function __construct( TemplateRendererInterface $template_renderer ) {
-		$this->template_renderer = $template_renderer;
-	}
 
 	/**
 	 * Check if lazy loading is enabled.
@@ -156,8 +139,6 @@ final class LazyloadConfiguration {
 	 * @return void
 	 */
 	public function initialize(): void {
-		$this->check_deprecated_plugin();
-
 		if ( ! $this->is_enabled() ) {
 			return;
 		}
@@ -175,40 +156,6 @@ final class LazyloadConfiguration {
 		$args['number'] = $this->get_initial_entries();
 
 		return $args;
-	}
-
-	/**
-	 * Check for and disable the deprecated Lazyload Liveblog Entries plugin.
-	 *
-	 * @return void
-	 */
-	private function check_deprecated_plugin(): void {
-		if ( ! has_action( 'init', 'Lazyload_Liveblog_Entries' ) ) {
-			return;
-		}
-
-		if ( is_admin() && current_user_can( 'activate_plugins' ) ) {
-			add_action( 'admin_notices', array( $this, 'render_deprecated_plugin_notice' ) );
-		}
-
-		// Disable the deprecated plugin.
-		remove_action( 'init', 'Lazyload_Liveblog_Entries' );
-	}
-
-	/**
-	 * Render the admin notice for deprecated plugin.
-	 *
-	 * @return void
-	 */
-	public function render_deprecated_plugin_notice(): void {
-		echo wp_kses_post(
-			$this->template_renderer->render(
-				'lazyload-notice.php',
-				array(
-					'plugin' => 'Lazyload Liveblog Entries',
-				)
-			)
-		);
 	}
 
 	/**

--- a/src/php/Application/Presenter/EntryPresenter.php
+++ b/src/php/Application/Presenter/EntryPresenter.php
@@ -13,8 +13,7 @@ use Automattic\Liveblog\Application\Config\AllowedTagsConfiguration;
 use Automattic\Liveblog\Application\Renderer\ContentRendererInterface;
 use Automattic\Liveblog\Application\Service\KeyEventService;
 use Automattic\Liveblog\Domain\Entity\Entry;
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
-use Automattic\Liveblog\Infrastructure\DI\Container;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_Comment;
 
 /**
@@ -68,38 +67,44 @@ final class EntryPresenter {
 	/**
 	 * Constructor.
 	 *
-	 * @param Entry                         $entry             The entry to present.
-	 * @param KeyEventService               $key_event_service Service for key event operations.
-	 * @param WP_Comment|null               $comment           Optional comment for additional WordPress data.
-	 * @param ContentRendererInterface|null $renderer          Optional content renderer (defaults to container renderer).
+	 * @param Entry                    $entry             The entry to present.
+	 * @param KeyEventService          $key_event_service Service for key event operations.
+	 * @param ContentRendererInterface $renderer          Content renderer for transforming raw content to HTML.
+	 * @param WP_Comment|null          $comment           Optional comment for additional WordPress data.
 	 */
 	public function __construct(
 		Entry $entry,
 		KeyEventService $key_event_service,
-		?WP_Comment $comment = null,
-		?ContentRendererInterface $renderer = null
+		ContentRendererInterface $renderer,
+		?WP_Comment $comment = null
 	) {
 		$this->entry             = $entry;
 		$this->key_event_service = $key_event_service;
+		$this->renderer          = $renderer;
 		$this->comment           = $comment;
-		$this->renderer          = $renderer ?? Container::instance()->content_renderer();
 	}
 
 	/**
 	 * Create a presenter from an Entry.
 	 *
-	 * Fetches the comment automatically and uses the default WordPress renderer.
+	 * Fetches the comment automatically.
 	 *
-	 * @param Entry           $entry             The entry to present.
-	 * @param KeyEventService $key_event_service Service for key event operations.
+	 * @param Entry                    $entry             The entry to present.
+	 * @param KeyEventService          $key_event_service Service for key event operations.
+	 * @param ContentRendererInterface $renderer          Content renderer for transforming raw content to HTML.
 	 * @return self
 	 */
-	public static function from_entry( Entry $entry, KeyEventService $key_event_service ): self {
+	public static function from_entry(
+		Entry $entry,
+		KeyEventService $key_event_service,
+		ContentRendererInterface $renderer
+	): self {
 		$comment = get_comment( $entry->id()->to_int() );
 
 		return new self(
 			$entry,
 			$key_event_service,
+			$renderer,
 			$comment instanceof WP_Comment ? $comment : null
 		);
 	}
@@ -171,15 +176,6 @@ final class EntryPresenter {
 			'is_liveblog_editable'   => self::is_liveblog_editable( $this->entry->post_id() ),
 			'allowed_tags_for_entry' => AllowedTagsConfiguration::get(),
 		);
-	}
-
-	/**
-	 * Render the entry to HTML using the template.
-	 *
-	 * @return string
-	 */
-	public function render(): string {
-		return Container::instance()->template_renderer()->render( 'liveblog-single-entry.php', $this->for_render() );
 	}
 
 	/**

--- a/src/php/Application/Presenter/MetadataPresenter.php
+++ b/src/php/Application/Presenter/MetadataPresenter.php
@@ -10,9 +10,10 @@ declare( strict_types=1 );
 namespace Automattic\Liveblog\Application\Presenter;
 
 use Automattic\Liveblog\Application\Config\LazyloadConfiguration;
+use Automattic\Liveblog\Application\Renderer\ContentRendererInterface;
 use Automattic\Liveblog\Application\Service\EntryQueryService;
 use Automattic\Liveblog\Application\Service\KeyEventService;
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_Post;
 
 /**
@@ -39,17 +40,37 @@ final class MetadataPresenter {
 	private KeyEventService $key_event_service;
 
 	/**
+	 * Content renderer.
+	 *
+	 * @var ContentRendererInterface
+	 */
+	private ContentRendererInterface $content_renderer;
+
+	/**
+	 * Lazyload configuration.
+	 *
+	 * @var LazyloadConfiguration
+	 */
+	private LazyloadConfiguration $lazyload_configuration;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param EntryQueryService $entry_query_service Entry query service.
-	 * @param KeyEventService   $key_event_service   Key event service.
+	 * @param EntryQueryService        $entry_query_service    Entry query service.
+	 * @param KeyEventService          $key_event_service      Key event service.
+	 * @param ContentRendererInterface $content_renderer       Content renderer used by the entry presenter.
+	 * @param LazyloadConfiguration    $lazyload_configuration Lazyload configuration.
 	 */
 	public function __construct(
 		EntryQueryService $entry_query_service,
-		KeyEventService $key_event_service
+		KeyEventService $key_event_service,
+		ContentRendererInterface $content_renderer,
+		LazyloadConfiguration $lazyload_configuration
 	) {
-		$this->entry_query_service = $entry_query_service;
-		$this->key_event_service   = $key_event_service;
+		$this->entry_query_service    = $entry_query_service;
+		$this->key_event_service      = $key_event_service;
+		$this->content_renderer       = $content_renderer;
+		$this->lazyload_configuration = $lazyload_configuration;
 	}
 
 	/**
@@ -135,8 +156,7 @@ final class MetadataPresenter {
 	 */
 	private function get_paginated_entries( int $post_id ): array {
 		$request_data = $this->get_request_data();
-		$lazyload     = new LazyloadConfiguration();
-		$per_page     = $lazyload->get_entries_per_page();
+		$per_page     = $this->lazyload_configuration->get_entries_per_page();
 
 		$result = $this->entry_query_service->get_entries_paged(
 			$post_id,
@@ -149,7 +169,7 @@ final class MetadataPresenter {
 		$entries_for_json = array();
 
 		foreach ( $result['entries'] as $entry ) {
-			$presenter          = EntryPresenter::from_entry( $entry, $this->key_event_service );
+			$presenter          = EntryPresenter::from_entry( $entry, $this->key_event_service, $this->content_renderer );
 			$entries_for_json[] = $presenter->for_json();
 		}
 

--- a/src/php/Application/Renderer/TemplateRendererInterface.php
+++ b/src/php/Application/Renderer/TemplateRendererInterface.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Template renderer interface.
+ *
+ * @package Automattic\Liveblog\Application\Renderer
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Application\Renderer;
+
+/**
+ * Renders a template with a set of variables.
+ *
+ * Application code depends on this interface so it never reaches into the
+ * infrastructure layer for template rendering.
+ */
+interface TemplateRendererInterface {
+
+	/**
+	 * Render a template.
+	 *
+	 * @param string               $template_name Template file name (relative to the templates directory).
+	 * @param array<string, mixed> $variables     Variables to expose to the template.
+	 * @return string The rendered output.
+	 */
+	public function render( string $template_name, array $variables = array() ): string;
+}

--- a/src/php/Application/Service/AutoArchiveService.php
+++ b/src/php/Application/Service/AutoArchiveService.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Application\Service;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 
 /**
  * Handles automatic archiving of liveblogs based on expiry dates.

--- a/src/php/Application/Service/EntryOperations.php
+++ b/src/php/Application/Service/EntryOperations.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace Automattic\Liveblog\Application\Service;
 
 use Automattic\Liveblog\Application\Presenter\EntryPresenter;
+use Automattic\Liveblog\Application\Renderer\ContentRendererInterface;
 use Automattic\Liveblog\Domain\Repository\EntryRepositoryInterface;
 use Automattic\Liveblog\Domain\ValueObject\EntryId;
 use Automattic\Liveblog\Infrastructure\Repository\CommentEntryRepository;
@@ -61,23 +62,33 @@ final class EntryOperations {
 	private ContentProcessor $content_processor;
 
 	/**
+	 * Content renderer used when presenting entries for JSON.
+	 *
+	 * @var ContentRendererInterface
+	 */
+	private ContentRendererInterface $content_renderer;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param EntryService             $entry_service     The entry service.
 	 * @param KeyEventService          $key_event_service The key event service.
 	 * @param EntryRepositoryInterface $repository        The entry repository.
 	 * @param ContentProcessor         $content_processor The content processor.
+	 * @param ContentRendererInterface $content_renderer  Content renderer used by the entry presenter.
 	 */
 	public function __construct(
 		EntryService $entry_service,
 		KeyEventService $key_event_service,
 		EntryRepositoryInterface $repository,
-		ContentProcessor $content_processor
+		ContentProcessor $content_processor,
+		ContentRendererInterface $content_renderer
 	) {
 		$this->entry_service     = $entry_service;
 		$this->key_event_service = $key_event_service;
 		$this->repository        = $repository;
 		$this->content_processor = $content_processor;
+		$this->content_renderer  = $content_renderer;
 	}
 
 	/**
@@ -200,7 +211,7 @@ final class EntryOperations {
 
 			// Get the entry and present it for JSON.
 			$entry     = $this->repository->get_entry( $entry_id );
-			$presenter = EntryPresenter::from_entry( $entry, $this->key_event_service );
+			$presenter = EntryPresenter::from_entry( $entry, $this->key_event_service, $this->content_renderer );
 
 			return array(
 				'entries'          => array( $presenter->for_json() ),
@@ -329,6 +340,10 @@ final class EntryOperations {
 	/**
 	 * Execute delete_key action.
 	 *
+	 * Strips the /key command from the entry content via KeyEventService,
+	 * then updates the entry through EntryService. Coordinating these here
+	 * keeps EntryService and KeyEventService independent of each other.
+	 *
 	 * @param array $args    Arguments.
 	 * @param int   $post_id Post ID.
 	 * @return EntryId The entry ID.
@@ -338,10 +353,16 @@ final class EntryOperations {
 		$original_comment = get_comment( $args['entry_id'] );
 		$user             = get_userdata( $original_comment->user_id );
 
-		return $this->entry_service->delete_key(
-			$post_id,
-			EntryId::from_int( (int) $args['entry_id'] ),
+		$entry_id        = EntryId::from_int( (int) $args['entry_id'] );
+		$updated_content = $this->key_event_service->remove_key_action(
 			$args['content'] ?? '',
+			$entry_id->to_int()
+		);
+
+		return $this->entry_service->update(
+			$post_id,
+			$entry_id,
+			$updated_content,
 			$user
 		);
 	}

--- a/src/php/Application/Service/EntryOperations.php
+++ b/src/php/Application/Service/EntryOperations.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Entry operations service - facade for CRUD operations.
+ * Dispatcher for HTTP entry mutations (REST and admin-ajax).
  *
  * @package Automattic\Liveblog\Application\Service
  */
@@ -18,11 +18,14 @@ use WP_Error;
 use WP_User;
 
 /**
- * Entry operations service - provides CRUD operations for liveblog entries.
+ * Dispatcher for HTTP entry mutations.
  *
- * This facade coordinates between the EntryService (for database operations)
- * and KeyEventService (for key event handling) to provide a unified interface
- * for legacy code that previously used Container::instance() directly.
+ * Bridges REST and admin-ajax callers to the underlying entry services.
+ * It dispatches CRUD action strings to the appropriate flow, applies the
+ * `liveblog_before_*_entry` filters and `liveblog_*_entry` actions around
+ * each mutation, and prepares the JSON payload that callers return to the
+ * client. Coordinating these concerns here keeps EntryService, KeyEventService
+ * and the HTTP controllers independent of each other.
  */
 final class EntryOperations {
 
@@ -89,102 +92,6 @@ final class EntryOperations {
 		$this->repository        = $repository;
 		$this->content_processor = $content_processor;
 		$this->content_renderer  = $content_renderer;
-	}
-
-	/**
-	 * Insert a new entry.
-	 *
-	 * @param int        $post_id         The post ID.
-	 * @param string     $content         The entry content.
-	 * @param WP_User    $user            The author user object.
-	 * @param bool       $hide_author     Whether to hide the author.
-	 * @param int[]|null $contributor_ids Optional contributor IDs.
-	 * @return EntryId The new entry ID.
-	 * @throws \InvalidArgumentException If arguments are invalid.
-	 * @throws \RuntimeException If entry creation fails.
-	 */
-	public function insert(
-		int $post_id,
-		string $content,
-		WP_User $user,
-		bool $hide_author = false,
-		?array $contributor_ids = null
-	): EntryId {
-		return $this->entry_service->create(
-			$post_id,
-			$content,
-			$user,
-			$hide_author,
-			$contributor_ids
-		);
-	}
-
-	/**
-	 * Update an existing entry.
-	 *
-	 * @param int     $post_id  The post ID.
-	 * @param EntryId $entry_id The entry ID to update.
-	 * @param string  $content  The new content.
-	 * @param WP_User $user     The user making the update.
-	 * @return EntryId The new entry ID (update creates a new comment).
-	 * @throws \InvalidArgumentException If arguments are invalid.
-	 * @throws \RuntimeException If entry update fails.
-	 */
-	public function update( int $post_id, EntryId $entry_id, string $content, WP_User $user ): EntryId {
-		return $this->entry_service->update( $post_id, $entry_id, $content, $user );
-	}
-
-	/**
-	 * Delete an entry.
-	 *
-	 * @param int     $post_id  The post ID.
-	 * @param EntryId $entry_id The entry ID to delete.
-	 * @param WP_User $user     The user making the deletion.
-	 * @return EntryId The delete marker entry ID.
-	 * @throws \InvalidArgumentException If arguments are invalid.
-	 * @throws \RuntimeException If entry deletion fails.
-	 */
-	public function delete( int $post_id, EntryId $entry_id, WP_User $user ): EntryId {
-		return $this->entry_service->delete( $post_id, $entry_id, $user );
-	}
-
-	/**
-	 * Check if an entry is a key event.
-	 *
-	 * @param int $entry_id The entry ID.
-	 * @return bool True if the entry is a key event.
-	 */
-	public function is_key_event( int $entry_id ): bool {
-		return $this->key_event_service->is_key_event( $entry_id );
-	}
-
-	/**
-	 * Remove key action from entry content.
-	 *
-	 * @param string $content  The entry content.
-	 * @param int    $entry_id The entry ID.
-	 * @return string Modified content with /key removed.
-	 */
-	public function remove_key_action( string $content, int $entry_id ): string {
-		return $this->key_event_service->remove_key_action( $content, $entry_id );
-	}
-
-	/**
-	 * Get the entry service.
-	 *
-	 * @return EntryService
-	 */
-	public function entry_service(): EntryService {
-		return $this->entry_service;
-	}
-
-	/**
-	 * Get the key event service.
-	 *
-	 * @return KeyEventService
-	 */
-	public function key_event_service(): KeyEventService {
-		return $this->key_event_service;
 	}
 
 	/**

--- a/src/php/Application/Service/EntryService.php
+++ b/src/php/Application/Service/EntryService.php
@@ -34,39 +34,12 @@ final class EntryService {
 	private EntryRepositoryInterface $repository;
 
 	/**
-	 * Key event service.
-	 *
-	 * @var KeyEventService|null
-	 */
-	private ?KeyEventService $key_event_service = null;
-
-	/**
 	 * Constructor.
 	 *
-	 * @param EntryRepositoryInterface $repository        Entry repository.
-	 * @param KeyEventService|null     $key_event_service Optional key event service.
+	 * @param EntryRepositoryInterface $repository Entry repository.
 	 */
-	public function __construct( EntryRepositoryInterface $repository, ?KeyEventService $key_event_service = null ) {
-		$this->repository        = $repository;
-		$this->key_event_service = $key_event_service;
-	}
-
-	/**
-	 * Get the key event service.
-	 *
-	 * Uses lazy loading to avoid circular dependencies.
-	 *
-	 * @return KeyEventService
-	 */
-	private function get_key_event_service(): KeyEventService {
-		if ( null === $this->key_event_service ) {
-			$this->key_event_service = new KeyEventService(
-				$this->repository,
-				new EntryQueryService( $this->repository )
-			);
-		}
-
-		return $this->key_event_service;
+	public function __construct( EntryRepositoryInterface $repository ) {
+		$this->repository = $repository;
 	}
 
 	/**
@@ -299,32 +272,6 @@ final class EntryService {
 	 */
 	public function is_authors_hidden( EntryId $entry_id ): bool {
 		return $this->repository->is_authors_hidden( $entry_id );
-	}
-
-	/**
-	 * Delete a key event from an entry.
-	 *
-	 * Removes the key event meta and strips the /key command from content,
-	 * then updates the entry.
-	 *
-	 * @param int     $post_id  Post ID for the liveblog.
-	 * @param EntryId $entry_id ID of the entry.
-	 * @param string  $content  Current content (with /key to be stripped).
-	 * @param WP_User $author   Author of the update.
-	 * @return EntryId The updated entry's ID.
-	 * @throws InvalidArgumentException If entry not found or post ID is invalid.
-	 */
-	public function delete_key(
-		int $post_id,
-		EntryId $entry_id,
-		string $content,
-		WP_User $author
-	): EntryId {
-		// Remove the key event meta and strip /key from content.
-		$updated_content = $this->get_key_event_service()->remove_key_action( $content, $entry_id->to_int() );
-
-		// Update the entry with the new content.
-		return $this->update( $post_id, $entry_id, $updated_content, $author );
 	}
 
 	/**

--- a/src/php/Application/Service/KeyEventShortcodeHandler.php
+++ b/src/php/Application/Service/KeyEventShortcodeHandler.php
@@ -10,8 +10,8 @@ declare( strict_types=1 );
 namespace Automattic\Liveblog\Application\Service;
 
 use Automattic\Liveblog\Application\Config\KeyEventConfiguration;
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
-use Automattic\Liveblog\Infrastructure\DI\Container;
+use Automattic\Liveblog\Application\Renderer\TemplateRendererInterface;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 
 /**
  * Handles the [liveblog_key_events] shortcode.
@@ -35,17 +35,27 @@ final class KeyEventShortcodeHandler {
 	private KeyEventConfiguration $configuration;
 
 	/**
+	 * Template renderer.
+	 *
+	 * @var TemplateRendererInterface
+	 */
+	private TemplateRendererInterface $template_renderer;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param KeyEventService       $key_event_service The key event service.
-	 * @param KeyEventConfiguration $configuration     The configuration.
+	 * @param KeyEventService           $key_event_service The key event service.
+	 * @param KeyEventConfiguration     $configuration     The configuration.
+	 * @param TemplateRendererInterface $template_renderer The template renderer.
 	 */
 	public function __construct(
 		KeyEventService $key_event_service,
-		KeyEventConfiguration $configuration
+		KeyEventConfiguration $configuration,
+		TemplateRendererInterface $template_renderer
 	) {
 		$this->key_event_service = $key_event_service;
 		$this->configuration     = $configuration;
+		$this->template_renderer = $template_renderer;
 	}
 
 	/**
@@ -90,7 +100,7 @@ final class KeyEventShortcodeHandler {
 
 		// Render using the existing template system.
 		// Note: The template renders a container div; key events are loaded via JS.
-		return Container::instance()->template_renderer()->render(
+		return $this->template_renderer->render(
 			'liveblog-key-events.php',
 			array(
 				'title'    => $atts['title'],
@@ -108,7 +118,7 @@ final class KeyEventShortcodeHandler {
 	 * @return string The admin options HTML.
 	 */
 	public function get_admin_options( int $post_id ): string {
-		return Container::instance()->template_renderer()->render(
+		return $this->template_renderer->render(
 			'liveblog-key-admin.php',
 			array(
 				'current_key_template' => get_post_meta( $post_id, KeyEventConfiguration::META_KEY_TEMPLATE, true ),

--- a/src/php/Infrastructure/CLI/AddCommand.php
+++ b/src/php/Infrastructure/CLI/AddCommand.php
@@ -10,7 +10,7 @@ declare( strict_types=1 );
 namespace Automattic\Liveblog\Infrastructure\CLI;
 
 use Automattic\Liveblog\Application\Service\EntryService;
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_CLI;
 use WP_User;
 

--- a/src/php/Infrastructure/CLI/ArchiveCommand.php
+++ b/src/php/Infrastructure/CLI/ArchiveCommand.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Infrastructure\CLI;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_CLI;
 
 /**

--- a/src/php/Infrastructure/CLI/ArchiveOldCommand.php
+++ b/src/php/Infrastructure/CLI/ArchiveOldCommand.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Infrastructure\CLI;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_CLI;
 use WP_CLI\Utils;
 use WP_Query;

--- a/src/php/Infrastructure/CLI/DisableCommand.php
+++ b/src/php/Infrastructure/CLI/DisableCommand.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Infrastructure\CLI;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_CLI;
 
 /**

--- a/src/php/Infrastructure/CLI/EnableCommand.php
+++ b/src/php/Infrastructure/CLI/EnableCommand.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Infrastructure\CLI;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_CLI;
 
 /**

--- a/src/php/Infrastructure/CLI/EntriesCommand.php
+++ b/src/php/Infrastructure/CLI/EntriesCommand.php
@@ -10,7 +10,7 @@ declare( strict_types=1 );
 namespace Automattic\Liveblog\Infrastructure\CLI;
 
 use Automattic\Liveblog\Application\Service\EntryQueryService;
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_CLI;
 use WP_CLI\Utils;
 

--- a/src/php/Infrastructure/CLI/ListCommand.php
+++ b/src/php/Infrastructure/CLI/ListCommand.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Infrastructure\CLI;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_CLI;
 use WP_CLI\Utils;
 use WP_Query;

--- a/src/php/Infrastructure/CLI/StatusCommand.php
+++ b/src/php/Infrastructure/CLI/StatusCommand.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Infrastructure\CLI;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_CLI;
 use WP_CLI\Utils;
 

--- a/src/php/Infrastructure/CLI/UnarchiveCommand.php
+++ b/src/php/Infrastructure/CLI/UnarchiveCommand.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Infrastructure\CLI;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_CLI;
 
 /**

--- a/src/php/Infrastructure/DI/Container.php
+++ b/src/php/Infrastructure/DI/Container.php
@@ -461,9 +461,7 @@ final class Container {
 		}
 
 		if ( null === $this->lazyload_configuration ) {
-			$this->lazyload_configuration = new LazyloadConfiguration(
-				$this->template_renderer()
-			);
+			$this->lazyload_configuration = new LazyloadConfiguration();
 		}
 
 		return $this->lazyload_configuration;

--- a/src/php/Infrastructure/DI/Container.php
+++ b/src/php/Infrastructure/DI/Container.php
@@ -10,6 +10,7 @@ declare( strict_types=1 );
 namespace Automattic\Liveblog\Infrastructure\DI;
 
 use Automattic\Liveblog\Application\Config\KeyEventConfiguration;
+use Automattic\Liveblog\Application\Config\LazyloadConfiguration;
 use Automattic\Liveblog\Application\Config\LiveblogConfiguration;
 use Automattic\Liveblog\Application\Filter\ContentFilterRegistry;
 use Automattic\Liveblog\Application\Presenter\MetadataPresenter;
@@ -209,6 +210,13 @@ final class Container {
 	 * @var SocketioManager|null
 	 */
 	private ?SocketioManager $socketio_manager = null;
+
+	/**
+	 * Cached lazyload configuration instance.
+	 *
+	 * @var LazyloadConfiguration|null
+	 */
+	private ?LazyloadConfiguration $lazyload_configuration = null;
 
 	/**
 	 * Private constructor to enforce singleton.
@@ -434,11 +442,31 @@ final class Container {
 		if ( null === $this->key_event_shortcode_handler ) {
 			$this->key_event_shortcode_handler = new KeyEventShortcodeHandler(
 				$this->key_event_service(),
-				new KeyEventConfiguration()
+				new KeyEventConfiguration(),
+				$this->template_renderer()
 			);
 		}
 
 		return $this->key_event_shortcode_handler;
+	}
+
+	/**
+	 * Get the lazyload configuration.
+	 *
+	 * @return LazyloadConfiguration
+	 */
+	public function lazyload_configuration(): LazyloadConfiguration {
+		if ( isset( $this->overrides['lazyload_configuration'] ) ) {
+			return ( $this->overrides['lazyload_configuration'] )();
+		}
+
+		if ( null === $this->lazyload_configuration ) {
+			$this->lazyload_configuration = new LazyloadConfiguration(
+				$this->template_renderer()
+			);
+		}
+
+		return $this->lazyload_configuration;
 	}
 
 	/**
@@ -493,7 +521,8 @@ final class Container {
 				$this->entry_service(),
 				$this->key_event_service(),
 				$this->entry_repository(),
-				$this->content_processor()
+				$this->content_processor(),
+				$this->content_renderer()
 			);
 		}
 
@@ -516,7 +545,8 @@ final class Container {
 				$this->entry_operations(),
 				$this->key_event_service(),
 				$this->request_router(),
-				$this->admin_controller()
+				$this->admin_controller(),
+				$this->content_renderer()
 			);
 		}
 
@@ -596,7 +626,9 @@ final class Container {
 		if ( null === $this->metadata_presenter ) {
 			$this->metadata_presenter = new MetadataPresenter(
 				$this->entry_query_service(),
-				$this->key_event_service()
+				$this->key_event_service(),
+				$this->content_renderer(),
+				$this->lazyload_configuration()
 			);
 		}
 
@@ -617,7 +649,8 @@ final class Container {
 			$this->request_router = new RequestRouter(
 				$this->entry_query_service(),
 				$this->entry_operations(),
-				$this->key_event_service()
+				$this->key_event_service(),
+				$this->content_renderer()
 			);
 		}
 

--- a/src/php/Infrastructure/SocketIO/SocketioManager.php
+++ b/src/php/Infrastructure/SocketIO/SocketioManager.php
@@ -10,7 +10,7 @@ declare( strict_types=1 );
 namespace Automattic\Liveblog\Infrastructure\SocketIO;
 
 use Automattic\Liveblog\Application\Config\LiveblogConfiguration;
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use Automattic\Liveblog\Infrastructure\WordPress\TemplateRenderer;
 use Exception;
 use Predis\Client as RedisClient;

--- a/src/php/Infrastructure/WordPress/AdminController.php
+++ b/src/php/Infrastructure/WordPress/AdminController.php
@@ -10,7 +10,7 @@ declare( strict_types=1 );
 namespace Automattic\Liveblog\Infrastructure\WordPress;
 
 use Automattic\Liveblog\Application\Config\LiveblogConfiguration;
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_Post;
 use WP_Query;
 

--- a/src/php/Infrastructure/WordPress/AmpIntegration.php
+++ b/src/php/Infrastructure/WordPress/AmpIntegration.php
@@ -13,7 +13,7 @@ use Automattic\Liveblog\Application\Config\LazyloadConfiguration;
 use Automattic\Liveblog\Application\Config\LiveblogConfiguration;
 use Automattic\Liveblog\Application\Presenter\EntryPresenter;
 use Automattic\Liveblog\Application\Presenter\MetadataPresenter;
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_Post;
 
 /**

--- a/src/php/Infrastructure/WordPress/AssetManager.php
+++ b/src/php/Infrastructure/WordPress/AssetManager.php
@@ -15,7 +15,7 @@ use Automattic\Liveblog\Application\Filter\CommandFilter;
 use Automattic\Liveblog\Application\Filter\ContentFilterRegistry;
 use Automattic\Liveblog\Application\Presenter\EntryPresenter;
 use Automattic\Liveblog\Application\Service\EntryQueryService;
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use Automattic\Liveblog\Infrastructure\SocketIO\SocketioManager;
 use WP_Post;
 

--- a/src/php/Infrastructure/WordPress/PluginBootstrapper.php
+++ b/src/php/Infrastructure/WordPress/PluginBootstrapper.php
@@ -425,8 +425,44 @@ final class PluginBootstrapper {
 	 * @return void
 	 */
 	private function init_lazyload(): void {
-		// Initialize on template_redirect when liveblog state is available.
-		add_action( 'template_redirect', array( $this->container->lazyload_configuration(), 'initialize' ) );
+		add_action(
+			'template_redirect',
+			function () {
+				$this->handle_deprecated_lazyload_plugin();
+				$this->container->lazyload_configuration()->initialize();
+			}
+		);
+	}
+
+	/**
+	 * Disable the deprecated Lazyload Liveblog Entries plugin and surface a notice.
+	 *
+	 * The standalone plugin is now superseded by built-in lazyload support, so we
+	 * unhook its `init` callback and prompt admins to remove it.
+	 *
+	 * @return void
+	 */
+	private function handle_deprecated_lazyload_plugin(): void {
+		if ( ! has_action( 'init', 'Lazyload_Liveblog_Entries' ) ) {
+			return;
+		}
+
+		if ( is_admin() && current_user_can( 'activate_plugins' ) ) {
+			$template_renderer = $this->container->template_renderer();
+			add_action(
+				'admin_notices',
+				static function () use ( $template_renderer ) {
+					echo wp_kses_post(
+						$template_renderer->render(
+							'lazyload-notice.php',
+							array( 'plugin' => 'Lazyload Liveblog Entries' )
+						)
+					);
+				}
+			);
+		}
+
+		remove_action( 'init', 'Lazyload_Liveblog_Entries' );
 	}
 
 	/**

--- a/src/php/Infrastructure/WordPress/PluginBootstrapper.php
+++ b/src/php/Infrastructure/WordPress/PluginBootstrapper.php
@@ -19,7 +19,7 @@ use Automattic\Liveblog\Application\Filter\HashtagFilter;
 use Automattic\Liveblog\Application\Service\ArchiveRepairService;
 use Automattic\Liveblog\Application\Service\ShortcodeFilter;
 use Automattic\Liveblog\Domain\Entity\Entry;
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use Automattic\Liveblog\Infrastructure\CLI\AddCommand;
 use Automattic\Liveblog\Infrastructure\CLI\ArchiveCommand;
 use Automattic\Liveblog\Infrastructure\CLI\ArchiveOldCommand;
@@ -425,11 +425,8 @@ final class PluginBootstrapper {
 	 * @return void
 	 */
 	private function init_lazyload(): void {
-		// Create configuration directly - it just reads options, no dependencies.
-		$configuration = new LazyloadConfiguration();
-
 		// Initialize on template_redirect when liveblog state is available.
-		add_action( 'template_redirect', array( $configuration, 'initialize' ) );
+		add_action( 'template_redirect', array( $this->container->lazyload_configuration(), 'initialize' ) );
 	}
 
 	/**

--- a/src/php/Infrastructure/WordPress/RequestRouter.php
+++ b/src/php/Infrastructure/WordPress/RequestRouter.php
@@ -12,6 +12,7 @@ namespace Automattic\Liveblog\Infrastructure\WordPress;
 use Automattic\Liveblog\Application\Config\LazyloadConfiguration;
 use Automattic\Liveblog\Application\Config\LiveblogConfiguration;
 use Automattic\Liveblog\Application\Presenter\EntryPresenter;
+use Automattic\Liveblog\Application\Renderer\ContentRendererInterface;
 use Automattic\Liveblog\Application\Service\EntryOperations;
 use Automattic\Liveblog\Application\Service\EntryQueryService;
 use Automattic\Liveblog\Application\Service\KeyEventService;
@@ -45,20 +46,30 @@ final class RequestRouter {
 	private KeyEventService $key_event_service;
 
 	/**
+	 * Content renderer used by the entry presenter.
+	 *
+	 * @var ContentRendererInterface
+	 */
+	private ContentRendererInterface $content_renderer;
+
+	/**
 	 * Constructor.
 	 *
-	 * @param EntryQueryService $entry_query_service The entry query service.
-	 * @param EntryOperations   $entry_operations    The entry operations service.
-	 * @param KeyEventService   $key_event_service   The key event service.
+	 * @param EntryQueryService        $entry_query_service The entry query service.
+	 * @param EntryOperations          $entry_operations    The entry operations service.
+	 * @param KeyEventService          $key_event_service   The key event service.
+	 * @param ContentRendererInterface $content_renderer    Content renderer used by the entry presenter.
 	 */
 	public function __construct(
 		EntryQueryService $entry_query_service,
 		EntryOperations $entry_operations,
-		KeyEventService $key_event_service
+		KeyEventService $key_event_service,
+		ContentRendererInterface $content_renderer
 	) {
 		$this->entry_query_service = $entry_query_service;
 		$this->entry_operations    = $entry_operations;
 		$this->key_event_service   = $key_event_service;
+		$this->content_renderer    = $content_renderer;
 	}
 
 	/**
@@ -348,7 +359,7 @@ final class RequestRouter {
 		$result = array();
 
 		foreach ( $entries as $entry ) {
-			$presenter = EntryPresenter::from_entry( $entry, $this->key_event_service );
+			$presenter = EntryPresenter::from_entry( $entry, $this->key_event_service, $this->content_renderer );
 			$result[]  = $presenter->for_json();
 		}
 

--- a/src/php/Infrastructure/WordPress/RestApiController.php
+++ b/src/php/Infrastructure/WordPress/RestApiController.php
@@ -13,11 +13,12 @@ use Automattic\Liveblog\Application\Config\LiveblogConfiguration;
 use Automattic\Liveblog\Application\Filter\AuthorFilter;
 use Automattic\Liveblog\Application\Filter\HashtagFilter;
 use Automattic\Liveblog\Application\Presenter\EntryPresenter;
+use Automattic\Liveblog\Application\Renderer\ContentRendererInterface;
 use Automattic\Liveblog\Application\Service\EntryOperations;
 use Automattic\Liveblog\Application\Service\EntryQueryService;
 use Automattic\Liveblog\Application\Service\KeyEventService;
 use Automattic\Liveblog\Domain\Entity\Entry;
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use WP_Error;
 use WP_REST_Request;
 use WP_REST_Server;
@@ -92,6 +93,13 @@ final class RestApiController {
 	private AdminController $admin_controller;
 
 	/**
+	 * Content renderer used by the entry presenter.
+	 *
+	 * @var ContentRendererInterface
+	 */
+	private ContentRendererInterface $content_renderer;
+
+	/**
 	 * Current post ID for the request.
 	 *
 	 * @var int
@@ -101,24 +109,27 @@ final class RestApiController {
 	/**
 	 * Constructor.
 	 *
-	 * @param EntryQueryService $query_service     Entry query service.
-	 * @param EntryOperations   $entry_operations  Entry operations service.
-	 * @param KeyEventService   $key_event_service Key event service.
-	 * @param RequestRouter     $request_router    Request router.
-	 * @param AdminController   $admin_controller  Admin controller.
+	 * @param EntryQueryService        $query_service     Entry query service.
+	 * @param EntryOperations          $entry_operations  Entry operations service.
+	 * @param KeyEventService          $key_event_service Key event service.
+	 * @param RequestRouter            $request_router    Request router.
+	 * @param AdminController          $admin_controller  Admin controller.
+	 * @param ContentRendererInterface $content_renderer  Content renderer used by the entry presenter.
 	 */
 	public function __construct(
 		EntryQueryService $query_service,
 		EntryOperations $entry_operations,
 		KeyEventService $key_event_service,
 		RequestRouter $request_router,
-		AdminController $admin_controller
+		AdminController $admin_controller,
+		ContentRendererInterface $content_renderer
 	) {
 		$this->query_service     = $query_service;
 		$this->entry_operations  = $entry_operations;
 		$this->key_event_service = $key_event_service;
 		$this->request_router    = $request_router;
 		$this->admin_controller  = $admin_controller;
+		$this->content_renderer  = $content_renderer;
 		$this->api_namespace     = 'liveblog/v' . self::API_VERSION;
 	}
 
@@ -730,7 +741,7 @@ final class RestApiController {
 
 		foreach ( $entries as $entry ) {
 			if ( $entry instanceof Entry ) {
-				$presenter          = EntryPresenter::from_entry( $entry, $this->key_event_service );
+				$presenter          = EntryPresenter::from_entry( $entry, $this->key_event_service, $this->content_renderer );
 				$entries_for_json[] = $presenter->for_json();
 			}
 		}

--- a/src/php/Infrastructure/WordPress/TemplateRenderer.php
+++ b/src/php/Infrastructure/WordPress/TemplateRenderer.php
@@ -9,7 +9,8 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Infrastructure\WordPress;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Renderer\TemplateRendererInterface;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use Automattic\Liveblog\Infrastructure\DI\Container;
 
 /**
@@ -17,7 +18,7 @@ use Automattic\Liveblog\Infrastructure\DI\Container;
  *
  * Supports theme overrides in child-theme/liveblog/ and theme/liveblog/ directories.
  */
-final class TemplateRenderer {
+final class TemplateRenderer implements TemplateRendererInterface {
 
 	/**
 	 * Plugin templates directory path.

--- a/tests/Integration/Cli/ArchiveCommandTest.php
+++ b/tests/Integration/Cli/ArchiveCommandTest.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Tests\Integration\Cli;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use Automattic\Liveblog\Infrastructure\CLI\ArchiveCommand;
 
 /**

--- a/tests/Integration/Cli/ArchiveOldCommandTest.php
+++ b/tests/Integration/Cli/ArchiveOldCommandTest.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Tests\Integration\Cli;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use Automattic\Liveblog\Infrastructure\CLI\ArchiveOldCommand;
 
 /**

--- a/tests/Integration/Cli/CliTestCase.php
+++ b/tests/Integration/Cli/CliTestCase.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Tests\Integration\Cli;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use Automattic\Liveblog\Tests\Integration\IntegrationTestCase;
 use WP_CLI;
 use WP_CLI_ExitException;

--- a/tests/Integration/Cli/DisableCommandTest.php
+++ b/tests/Integration/Cli/DisableCommandTest.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Tests\Integration\Cli;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use Automattic\Liveblog\Infrastructure\CLI\DisableCommand;
 use WP_CLI;
 

--- a/tests/Integration/Cli/EnableCommandTest.php
+++ b/tests/Integration/Cli/EnableCommandTest.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Tests\Integration\Cli;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use Automattic\Liveblog\Infrastructure\CLI\EnableCommand;
 
 /**

--- a/tests/Integration/Cli/UnarchiveCommandTest.php
+++ b/tests/Integration/Cli/UnarchiveCommandTest.php
@@ -9,7 +9,7 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Tests\Integration\Cli;
 
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use Automattic\Liveblog\Infrastructure\CLI\UnarchiveCommand;
 
 /**

--- a/tests/Integration/FilterSupportedPostTypesTest.php
+++ b/tests/Integration/FilterSupportedPostTypesTest.php
@@ -10,15 +10,15 @@ declare( strict_types=1 );
 namespace Automattic\Liveblog\Tests\Integration;
 
 use Automattic\Liveblog\Application\Config\LiveblogConfiguration;
-use Automattic\Liveblog\Domain\Entity\LiveblogPost;
+use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /**
  * Tests for the liveblog_supported_post_types filter.
  *
  * @covers \Automattic\Liveblog\Application\Config\LiveblogConfiguration
- * @covers \Automattic\Liveblog\Domain\Entity\LiveblogPost::is_viewing_liveblog_post
- * @covers \Automattic\Liveblog\Domain\Entity\LiveblogPost::state
+ * @covers \Automattic\Liveblog\Application\Aggregate\LiveblogPost::is_viewing_liveblog_post
+ * @covers \Automattic\Liveblog\Application\Aggregate\LiveblogPost::state
  */
 final class FilterSupportedPostTypesTest extends TestCase {
 

--- a/tests/Unit/Application/Config/LazyloadConfigurationTest.php
+++ b/tests/Unit/Application/Config/LazyloadConfigurationTest.php
@@ -10,7 +10,9 @@ declare( strict_types=1 );
 namespace Automattic\Liveblog\Tests\Unit\Application\Config;
 
 use Automattic\Liveblog\Application\Config\LazyloadConfiguration;
+use Automattic\Liveblog\Application\Renderer\TemplateRendererInterface;
 use Brain\Monkey\Functions;
+use Mockery;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
 /**
@@ -33,7 +35,7 @@ final class LazyloadConfigurationTest extends TestCase {
 	protected function set_up(): void {
 		parent::set_up();
 
-		$this->config = new LazyloadConfiguration();
+		$this->config = new LazyloadConfiguration( Mockery::mock( TemplateRendererInterface::class ) );
 	}
 
 	/**

--- a/tests/Unit/Application/Config/LazyloadConfigurationTest.php
+++ b/tests/Unit/Application/Config/LazyloadConfigurationTest.php
@@ -10,9 +10,7 @@ declare( strict_types=1 );
 namespace Automattic\Liveblog\Tests\Unit\Application\Config;
 
 use Automattic\Liveblog\Application\Config\LazyloadConfiguration;
-use Automattic\Liveblog\Application\Renderer\TemplateRendererInterface;
 use Brain\Monkey\Functions;
-use Mockery;
 use Yoast\WPTestUtils\BrainMonkey\TestCase;
 
 /**
@@ -35,7 +33,7 @@ final class LazyloadConfigurationTest extends TestCase {
 	protected function set_up(): void {
 		parent::set_up();
 
-		$this->config = new LazyloadConfiguration( Mockery::mock( TemplateRendererInterface::class ) );
+		$this->config = new LazyloadConfiguration();
 	}
 
 	/**

--- a/tests/Unit/Application/Presenter/EntryPresenterTest.php
+++ b/tests/Unit/Application/Presenter/EntryPresenterTest.php
@@ -42,7 +42,7 @@ final class EntryPresenterTest extends TestCase {
 		$key_event_service = $this->create_mock_key_event_service();
 		$comment           = $this->create_mock_comment();
 		$renderer          = $this->create_mock_renderer( '<p>Rendered content</p>' );
-		$presenter         = new EntryPresenter( $entry, $key_event_service, $comment, $renderer );
+		$presenter         = new EntryPresenter( $entry, $key_event_service, $renderer, $comment );
 
 		$json = $presenter->for_json();
 
@@ -76,7 +76,7 @@ final class EntryPresenterTest extends TestCase {
 		$key_event_service = $this->create_mock_key_event_service();
 		$comment           = $this->create_mock_comment();
 		$renderer          = $this->create_mock_renderer( '<p>Updated</p>' );
-		$presenter         = new EntryPresenter( $entry, $key_event_service, $comment, $renderer );
+		$presenter         = new EntryPresenter( $entry, $key_event_service, $renderer, $comment );
 
 		$json = $presenter->for_json();
 
@@ -100,7 +100,7 @@ final class EntryPresenterTest extends TestCase {
 			->with( 'Test content', $comment )
 			->andReturn( '<p>Rendered</p>' );
 
-		$presenter = new EntryPresenter( $entry, $key_event_service, $comment, $renderer );
+		$presenter = new EntryPresenter( $entry, $key_event_service, $renderer, $comment );
 		$presenter->for_json();
 
 		// Mockery verifies the expectation automatically.
@@ -137,7 +137,7 @@ final class EntryPresenterTest extends TestCase {
 		$key_event_service = $this->create_mock_key_event_service();
 		$comment           = $this->create_mock_comment();
 		$renderer          = $this->create_mock_renderer( '<p>Test</p>' );
-		$presenter         = new EntryPresenter( $entry, $key_event_service, $comment, $renderer );
+		$presenter         = new EntryPresenter( $entry, $key_event_service, $renderer, $comment );
 
 		$json = $presenter->for_json();
 
@@ -155,7 +155,7 @@ final class EntryPresenterTest extends TestCase {
 
 		// New entry.
 		$new_entry  = $this->create_entry();
-		$presenter1 = new EntryPresenter( $new_entry, $key_event_service, $this->create_mock_comment(), $this->create_mock_renderer() );
+		$presenter1 = new EntryPresenter( $new_entry, $key_event_service, $this->create_mock_renderer(), $this->create_mock_comment() );
 		$this->assertSame( 'new', $presenter1->for_json()->type );
 
 		// Update entry.
@@ -168,7 +168,7 @@ final class EntryPresenterTest extends TestCase {
 			EntryId::from_int( 100 ),
 			new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) )
 		);
-		$presenter2   = new EntryPresenter( $update_entry, $key_event_service, $this->create_mock_comment(), $this->create_mock_renderer() );
+		$presenter2   = new EntryPresenter( $update_entry, $key_event_service, $this->create_mock_renderer(), $this->create_mock_comment() );
 		$this->assertSame( 'update', $presenter2->for_json()->type );
 
 		// Delete entry.
@@ -181,7 +181,7 @@ final class EntryPresenterTest extends TestCase {
 			EntryId::from_int( 100 ),
 			new DateTimeImmutable( 'now', new DateTimeZone( 'UTC' ) )
 		);
-		$presenter3   = new EntryPresenter( $delete_entry, $key_event_service, $this->create_mock_comment(), $this->create_mock_renderer() );
+		$presenter3   = new EntryPresenter( $delete_entry, $key_event_service, $this->create_mock_renderer(), $this->create_mock_comment() );
 		$this->assertSame( 'delete', $presenter3->for_json()->type );
 	}
 


### PR DESCRIPTION
## Summary

Architectural follow-up against `2.x` after reviewing the DDD refactor. Three concerns surfaced from the review and are addressed here in three commits, each independently green.

`LiveblogPost` lived under `Domain/Entity/` but called `update_post_meta`, `delete_post_meta`, `post_type_supports`, `current_user_can`, `do_action` and `apply_filters` directly. That made it a WordPress-aware aggregate, not a persistence-agnostic domain entity. Moving it to `Application/Aggregate/` matches what the class actually is, and leaves the `Domain` layer holding only `Entry`, the value objects and `EntryRepositoryInterface` — all of which are genuinely free of WordPress dependencies. No behaviour change; only the namespace and 28 imports move with it.

Three Application-layer classes (`EntryPresenter`, `KeyEventShortcodeHandler`, `LazyloadConfiguration`) reached back into `Container::instance()` at runtime to fetch a renderer. That inverts the dependency direction and hides the dependency from the constructor. Each one now declares the renderer it needs as a constructor parameter, with the wiring done once in `Container` or `PluginBootstrapper`. A new `Application\Renderer\TemplateRendererInterface` mirrors the existing `ContentRendererInterface`, so Application code never imports the concrete `TemplateRenderer` from `Infrastructure`. `EntryPresenter` loses an unreachable `render()` method in passing.

The same commit also untangles a circular dependency: `EntryService` accepted an optional `KeyEventService` constructor argument with a lazy fallback that constructed a fresh `KeyEventService` and `EntryQueryService` on demand. The lazy create silently bypassed any test double a caller had wired up. The only path that needed it — `delete_key` — is called exclusively from `EntryOperations::execute_delete_key`, which already has both services injected. Moving the two-step orchestration up to that caller lets `EntryService` collapse to a single repository-only constructor, and the cycle is gone.

Finally, `EntryOperations` had seven public pass-through methods (`insert`, `update`, `delete`, `is_key_event`, `remove_key_action` plus `entry_service()` and `key_event_service()` accessors) that call-site mapping showed have no external callers. They were leftover scaffolding from an earlier refactor, documented as a facade for legacy container access that no longer exists. Removing them, together with rewriting the class docblock to describe what the class actually does — dispatch CRUD action strings, apply the `liveblog_*_entry` filters and actions around each mutation, and prepare the JSON payload for REST and admin-ajax callers — leaves a clear public surface of `do_crud`, `format_preview` and `is_valid_action`.

What this PR does **not** do: replace the hand-rolled service-locator container, collapse the single-implementation `ContentRendererInterface` and `EmbedHandlerInterface`, or extract a `LiveblogPostRepository`. Those were considered and judged either out of scope or actively unhelpful at the current size of the codebase.

## Test plan

- [ ] `composer install && vendor/bin/phpunit --testsuite unit` — 190 tests, all green at HEAD and at each intermediate commit.
- [ ] `vendor/bin/phpcs src/php --standard=.phpcs.xml.dist` — clean.
- [ ] Smoke test in wp-env: create a liveblog, post an entry, edit an entry, mark an entry as key event then unmark it, archive the post. The CRUD path exercises both REST and admin-ajax routes that depend on the new constructor wiring.