### PR TITLE
Bind liveblog entry CRUD operations to the authorised post

### DIFF
--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -403,6 +403,11 @@ class WPCOM_Liveblog_Entry {
 			return new WP_Error( 'entry-delete', __( 'Missing entry ID', 'liveblog' ) );
 		}
 
+		$entry_post_check = self::validate_entry_belongs_to_post( $args );
+		if ( is_wp_error( $entry_post_check ) ) {
+			return $entry_post_check;
+		}
+
 		// Always use the original author for the update entry, otherwise until refresh
 		// users will see the user who edited the entry as the author.
 		$args['user'] = self::user_object_from_comment_id( $args['entry_id'] );
@@ -447,6 +452,12 @@ class WPCOM_Liveblog_Entry {
 		if ( ! $args['entry_id'] ) {
 			return new WP_Error( 'entry-delete', __( 'Missing entry ID', 'liveblog' ) );
 		}
+
+		$entry_post_check = self::validate_entry_belongs_to_post( $args );
+		if ( is_wp_error( $entry_post_check ) ) {
+			return $entry_post_check;
+		}
+
 		$args['content'] = '';
 		$comment         = self::insert_comment( $args );
 		if ( is_wp_error( $comment ) ) {
@@ -485,10 +496,52 @@ class WPCOM_Liveblog_Entry {
 			return new WP_Error( 'entry-delete', __( 'Missing entry ID', 'liveblog' ) );
 		}
 
+		// Guard before remove_key_action() runs: it deletes comment meta on the
+		// referenced entry, so the post-binding check must happen first.
+		$entry_post_check = self::validate_entry_belongs_to_post( $args );
+		if ( is_wp_error( $entry_post_check ) ) {
+			return $entry_post_check;
+		}
+
 		$args['content'] = WPCOM_Liveblog_Entry_Key_Events::remove_key_action( $args['content'], $args['entry_id'] );
 
 		$entry = self::update( $args );
 		return $entry;
+	}
+
+	/**
+	 * Verify that the entry being mutated belongs to the authorised post.
+	 *
+	 * The CRUD entry points authorise the caller against the post id taken from
+	 * the route URL (REST) or the permalink (admin-ajax), but the entry id
+	 * arrives separately in the request body and is not re-validated against
+	 * that post. Without binding the two together, a caller authorised to edit
+	 * their own liveblog can pass the entry id of an entry belonging to another
+	 * user's post and have the update/delete sink mutate it (CWE-639 IDOR,
+	 * HackerOne #3742849, an incomplete-fix follow-up to the 1.12.0 post-scoped
+	 * authorisation work).
+	 *
+	 * The entry must exist, be a liveblog entry (so the endpoint cannot be used
+	 * to trash arbitrary non-liveblog comments), and be attached to the
+	 * authorised post. The error message is deliberately generic so the endpoint
+	 * cannot be used to probe for entries on other posts.
+	 *
+	 * @param array $args The entry properties. Requires `entry_id` and `post_id`.
+	 * @return true|WP_Error True when the entry belongs to the post, otherwise an error.
+	 */
+	private static function validate_entry_belongs_to_post( $args ) {
+		$post_id = isset( $args['post_id'] ) ? (int) $args['post_id'] : 0;
+		$comment = get_comment( $args['entry_id'] );
+
+		if (
+			$comment instanceof WP_Comment
+			&& 'liveblog' === $comment->comment_type
+			&& (int) $comment->comment_post_ID === $post_id
+		) {
+			return true;
+		}
+
+		return new WP_Error( 'entry-not-found', __( 'Entry not found in this liveblog.', 'liveblog' ) );
 	}
 
 	/**

--- a/tests/Integration/EntryTest.php
+++ b/tests/Integration/EntryTest.php
@@ -11,6 +11,7 @@ namespace Automattic\Liveblog\Tests\Integration;
 
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 use WPCOM_Liveblog_Entry;
+use WPCOM_Liveblog_Entry_Key_Events;
 use WPCOM_Liveblog_Entry_Query;
 use ReflectionProperty;
 
@@ -157,6 +158,103 @@ final class EntryTest extends TestCase {
 		WPCOM_Liveblog_Entry::delete( $this->build_entry_args( array( 'entry_id' => $entry->get_id() ) ) );
 		$query = new WPCOM_Liveblog_Entry_Query( $entry->get_post_id(), 'liveblog' );
 		$this->assertNull( $query->get_by_id( $entry->get_id() ) );
+	}
+
+	/**
+	 * The update() method must reject an entry that belongs to a different post.
+	 *
+	 * Defence-in-depth at the mutation sink for HackerOne #3742849 (CWE-639
+	 * IDOR): the CRUD permission check authorises a post id, but the entry id is
+	 * supplied separately and must be bound to that post before wp_update_comment()
+	 * runs.
+	 */
+	public function test_update_rejects_entry_belonging_to_another_post(): void {
+		$entry            = WPCOM_Liveblog_Entry::insert( $this->build_entry_args( array( 'post_id' => 100 ) ) );
+		$entry_id         = (int) $entry->get_id();
+		$original_content = get_comment( $entry_id )->comment_content;
+
+		$result = WPCOM_Liveblog_Entry::update(
+			$this->build_entry_args(
+				array(
+					'post_id'  => 200,
+					'entry_id' => $entry_id,
+					'content'  => 'tampered',
+				)
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( $original_content, get_comment( $entry_id )->comment_content );
+	}
+
+	/**
+	 * The delete() method must reject an entry that belongs to a different post.
+	 */
+	public function test_delete_rejects_entry_belonging_to_another_post(): void {
+		$entry    = WPCOM_Liveblog_Entry::insert( $this->build_entry_args( array( 'post_id' => 100 ) ) );
+		$entry_id = (int) $entry->get_id();
+
+		$result = WPCOM_Liveblog_Entry::delete(
+			$this->build_entry_args(
+				array(
+					'post_id'  => 200,
+					'entry_id' => $entry_id,
+				)
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertNotEquals( 'trash', get_comment( $entry_id )->comment_approved );
+	}
+
+	/**
+	 * The delete_key() method must reject an entry that belongs to a different
+	 * post before it strips the key-event comment meta. remove_key_action()
+	 * mutates the referenced entry, so the post-binding guard has to run first.
+	 */
+	public function test_delete_key_rejects_entry_belonging_to_another_post(): void {
+		$entry    = WPCOM_Liveblog_Entry::insert( $this->build_entry_args( array( 'post_id' => 100 ) ) );
+		$entry_id = (int) $entry->get_id();
+		add_comment_meta( $entry_id, WPCOM_Liveblog_Entry_Key_Events::META_KEY, WPCOM_Liveblog_Entry_Key_Events::META_VALUE );
+
+		$result = WPCOM_Liveblog_Entry::delete_key(
+			$this->build_entry_args(
+				array(
+					'post_id'  => 200,
+					'entry_id' => $entry_id,
+					'content'  => 'tampered',
+				)
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		// The key-event meta on the foreign entry must be untouched.
+		$this->assertEquals(
+			WPCOM_Liveblog_Entry_Key_Events::META_VALUE,
+			get_comment_meta( $entry_id, WPCOM_Liveblog_Entry_Key_Events::META_KEY, true )
+		);
+	}
+
+	/**
+	 * A legitimate update on an entry that belongs to the supplied post is
+	 * still allowed. Guards against the post-binding check over-reaching.
+	 */
+	public function test_update_allows_entry_belonging_to_the_same_post(): void {
+		$entry    = WPCOM_Liveblog_Entry::insert( $this->build_entry_args( array( 'post_id' => 100 ) ) );
+		$entry_id = (int) $entry->get_id();
+
+		$result = WPCOM_Liveblog_Entry::update(
+			$this->build_entry_args(
+				array(
+					'post_id'  => 100,
+					'entry_id' => $entry_id,
+					'content'  => 'legitimately updated',
+				)
+			)
+		);
+
+		$this->assertInstanceOf( WPCOM_Liveblog_Entry::class, $result );
+		$this->assertEquals( 'legitimately updated', get_comment( $entry_id )->comment_content );
 	}
 
 	/**

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -1105,6 +1105,87 @@ final class RestApiTest extends TestCase {
 	}
 
 	/**
+	 * An Author authorised on their own liveblog must not update an entry that
+	 * belongs to another user's post by supplying that entry's id in the body.
+	 *
+	 * Covers HackerOne report #3742849 (CWE-639 IDOR): an incomplete-fix
+	 * follow-up to the 1.12.0 post-scoped authorisation. The permission check
+	 * passes against the attacker-owned URL post, but the entry id must still be
+	 * bound to that post before the update sink runs.
+	 */
+	public function test_endpoint_crud_update_denied_for_entry_on_another_post(): void {
+		// Victim post (owned by another author) with a seeded entry.
+		$victim_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post_id   = $this->create_liveblog_post( array( 'post_author' => $victim_author_id ) );
+		$victim_entry     = $this->insert_entries( 1, array( 'post_id' => $victim_post_id ) )[0];
+		$victim_entry_id  = (int) $victim_entry->get_id();
+		$original_content = get_comment( $victim_entry_id )->comment_content;
+
+		// Attacker authorises against their own liveblog post.
+		$attacker_id      = $this->set_author_user();
+		$attacker_post_id = $this->create_liveblog_post( array( 'post_author' => $attacker_id ) );
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $attacker_post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'crud_action' => 'update',
+					'entry_id'    => $victim_entry_id,
+					'content'     => 'Tampered by attacker.',
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		// The request must not succeed in mutating the victim entry.
+		$this->assertNotEquals( 200, $response->get_status() );
+
+		// The victim entry content is unchanged and it has not been replaced.
+		$this->assertEquals( $original_content, get_comment( $victim_entry_id )->comment_content );
+		$replacements = get_comments(
+			array(
+				'meta_key'   => WPCOM_Liveblog_Entry::REPLACES_META_KEY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => $victim_entry_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
+		$this->assertEmpty( $replacements, 'No replacement entry should have been created for the victim entry.' );
+	}
+
+	/**
+	 * An Author authorised on their own liveblog must not delete an entry that
+	 * belongs to another user's post by supplying that entry's id in the body.
+	 *
+	 * Covers HackerOne report #3742849 (CWE-639 IDOR).
+	 */
+	public function test_endpoint_crud_delete_denied_for_entry_on_another_post(): void {
+		$victim_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post_id   = $this->create_liveblog_post( array( 'post_author' => $victim_author_id ) );
+		$victim_entry     = $this->insert_entries( 1, array( 'post_id' => $victim_post_id ) )[0];
+		$victim_entry_id  = (int) $victim_entry->get_id();
+
+		$attacker_id      = $this->set_author_user();
+		$attacker_post_id = $this->create_liveblog_post( array( 'post_author' => $attacker_id ) );
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $attacker_post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'crud_action' => 'delete',
+					'entry_id'    => $victim_entry_id,
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotEquals( 200, $response->get_status() );
+
+		// The victim entry must still be present and not trashed.
+		$this->assertNotEquals( 'trash', get_comment( $victim_entry_id )->comment_approved );
+	}
+
+	/**
 	 * The update_post_state route must be denied for an Author who does not own the post.
 	 */
 	public function test_endpoint_update_post_state_denied_for_non_owner_author(): void {


### PR DESCRIPTION
## Summary

The 1.12.0 release scoped liveblog write authorisation to the post id in the route URL, so a low-privileged Author can no longer act against a liveblog they do not own. That fix was incomplete. The `update` and `delete` CRUD operations authorise against the URL post id but then act on the `entry_id` supplied separately in the request body, without checking that the entry actually belongs to the authorised post.

This leaves an authorisation bypass (CWE-639, HackerOne #3742849). An Author authorises against a liveblog they own, then sends a victim entry id from another user's liveblog in the body. The permission callback passes on the attacker-owned post, but the mutation lands on the victim entry: `wp_update_comment()` rewrites it, or `wp_delete_comment()` trashes it. Direct requests to the victim post URL are still correctly blocked, which is precisely why the body-supplied entry id is the way in.

The fix binds the entry to the authorised post at the mutation sink rather than at the entry point. Putting the check in `WPCOM_Liveblog_Entry::update()`, `delete()` and `delete_key()` — the methods that immediately precede the comment mutations — means both the REST and legacy admin-ajax paths are covered by a single guard, and any future caller inherits it. An entry is only mutated if the referenced comment exists, is a liveblog entry, and is attached to the authorised post; otherwise a generic error is returned so the endpoint cannot be used to probe for entries elsewhere.

`delete_key()` needs its own guard rather than relying on the shared `update()` path: it calls `remove_key_action()` first, which strips the referenced entry's key-event meta before `update()` would run. Requiring the `liveblog` comment type, as well as the post match, additionally prevents the endpoint from being repurposed to edit or trash arbitrary non-liveblog comments.

While reviewing the entry point, an earlier draft also cast the body `entry_id` in the REST handler, on the assumption the route's `sanitize_numeric` callback was not firing. Testing against the live REST stack showed that assumption was wrong — WordPress sanitises declared body parameters in place before the callback runs — so that change was dropped as redundant.

## Test plan

New integration tests reproduce the bypass and assert the victim entry is left intact:

- `RestApiTest`: end-to-end update and delete against an attacker-owned post carrying a victim entry id in the body, asserting the victim entry is neither rewritten (nor replaced) nor trashed.
- `EntryTest`: sink-level rejection for `update()`, `delete()` and `delete_key()` across posts, including that `delete_key()` leaves the foreign entry's key-event meta untouched, plus a positive same-post update so the guard does not over-reach.

Run with `composer test:integration` (full suite green: 145 integration tests, 3 unit tests; phpcs clean).