### PR TITLE
Bind the post_state write route to the authorised URL post

### DIFF
--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -472,9 +472,8 @@ class WPCOM_Liveblog_Rest_Api {
 	 * @return true|WP_Error True when the request is permitted, otherwise a 403 error.
 	 */
 	public static function can_edit_liveblog_entries( WP_REST_Request $request ) {
-		$url_params = $request->get_url_params();
-		$post_id    = isset( $url_params['post_id'] ) ? (int) $url_params['post_id'] : 0;
-		$post       = $post_id > 0 ? get_post( $post_id ) : null;
+		$post_id = self::get_authorised_post_id( $request );
+		$post    = $post_id > 0 ? get_post( $post_id ) : null;
 
 		$allowed = ( $post instanceof WP_Post && current_user_can( 'edit_post', $post_id ) );
 
@@ -490,6 +489,25 @@ class WPCOM_Liveblog_Rest_Api {
 			__( 'Sorry, you are not allowed to edit this liveblog.', 'liveblog' ),
 			array( 'status' => rest_authorization_required_code() )
 		);
+	}
+
+	/**
+	 * Get the authorised target post ID for a write request from the URL path.
+	 *
+	 * Write routes are scoped to the post in the route URL, and the write
+	 * permission callback ({@see can_edit_liveblog_entries()}) authorises against
+	 * that same value. Handlers must therefore read the post ID from the URL path
+	 * parameters and never from get_param(): WP_REST_Request::get_param() resolves
+	 * JSON body, POST body, and query-string parameters ahead of URL path
+	 * parameters, so a body or query `post_id` could otherwise re-target the action
+	 * at a post the caller is not authorised to edit (CWE-639).
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return int The post ID from the URL path, or 0 when absent.
+	 */
+	private static function get_authorised_post_id( WP_REST_Request $request ) {
+		$url_params = $request->get_url_params();
+		return isset( $url_params['post_id'] ) ? (int) $url_params['post_id'] : 0;
 	}
 
 	/**
@@ -534,8 +552,7 @@ class WPCOM_Liveblog_Rest_Api {
 		// The URL path post_id is authoritative for the target post; the permission
 		// callback uses the same source. JSON body `post_id` is ignored so a caller
 		// cannot target a different post than the one authorised by the route.
-		$url_params = $request->get_url_params();
-		$post_id    = isset( $url_params['post_id'] ) ? (int) $url_params['post_id'] : 0;
+		$post_id = self::get_authorised_post_id( $request );
 
 		$args = array(
 			'post_id'         => $post_id,
@@ -614,8 +631,9 @@ class WPCOM_Liveblog_Rest_Api {
 	 */
 	public static function format_preview_entry( WP_REST_Request $request ) {
 
-		// Get required parameters from the request.
-		$post_id       = $request->get_param( 'post_id' );
+		// The URL path post_id is authoritative; read it from the same source as the
+		// permission callback so a body/query value cannot change the post context.
+		$post_id       = self::get_authorised_post_id( $request );
 		$json          = $request->get_json_params();
 		$entry_content = self::get_json_param( 'entry_content', $json );
 
@@ -677,8 +695,11 @@ class WPCOM_Liveblog_Rest_Api {
 	 */
 	public static function update_post_state( WP_REST_Request $request ) {
 
-		// Get required parameters from the request.
-		$post_id = $request->get_param( 'post_id' );
+		// The URL path post_id is authoritative for the target post; the permission
+		// callback authorises against the same source. Reading it from get_param()
+		// would let a JSON body or query `post_id` re-target the state change at a
+		// post the caller is not authorised to edit (CWE-639).
+		$post_id = self::get_authorised_post_id( $request );
 		$state   = $request->get_param( 'state' );
 
 		// Additional request variables used in the liveblog_admin_settings_update action.

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -1210,6 +1210,50 @@ final class RestApiTest extends TestCase {
 	}
 
 	/**
+	 * A request body `post_id` must not override the URL post_id for the
+	 * post_state route.
+	 *
+	 * The permission callback authorises against the URL post, so the state change
+	 * must land on that post — never on a victim post supplied in the request body
+	 * or query string. Covers a cross-post IDOR (CWE-639) analogous to HackerOne
+	 * #3742849: an Author authorised on their own liveblog could otherwise enable,
+	 * archive, or disable the liveblog on any post by passing its id in the body.
+	 */
+	public function test_endpoint_update_post_state_body_post_id_cannot_override_url(): void {
+		// Victim post owned by another author, with an enabled liveblog.
+		$victim_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post_id   = $this->create_liveblog_post( array( 'post_author' => $victim_author_id ) );
+
+		// Attacker authorises against their own enabled liveblog post.
+		$attacker_id      = $this->set_author_user();
+		$attacker_post_id = $this->create_liveblog_post( array( 'post_author' => $attacker_id ) );
+
+		// URL path targets the attacker's own post (permission passes); the body
+		// tries to redirect the state change at the victim post.
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $attacker_post_id . '/post_state' );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$request->set_body_params(
+			array(
+				'post_id'         => $victim_post_id,
+				'state'           => 'archive',
+				'template_name'   => 'list',
+				'template_format' => 'full',
+				'limit'           => '5',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		// The request is authorised against the attacker's own post, so it succeeds.
+		$this->assertEquals( 200, $response->get_status() );
+
+		// The victim's liveblog state is untouched (still 'enable', not 'archive').
+		$this->assertEquals( 'enable', get_post_meta( $victim_post_id, WPCOM_Liveblog::KEY, true ) );
+
+		// The state change landed on the URL post (the attacker's own post).
+		$this->assertEquals( 'archive', get_post_meta( $attacker_post_id, WPCOM_Liveblog::KEY, true ) );
+	}
+
+	/**
 	 * Build the list of public read endpoint URLs that accept a post_id for testing.
 	 *
 	 * @param int $post_id  Post ID to embed.


### PR DESCRIPTION
## Summary

The 1.12.0 release scoped liveblog write authorisation to the post id in the route URL, and #895 went on to bind entry mutations to that authorised post at the sink. Both fixes targeted the same underlying mistake — authorising against one post while acting on another — but neither covered the `post_state` route.

`POST /liveblog/v1/<post_id>/post_state` is gated by `can_edit_liveblog_entries()`, which deliberately reads the target post from `$request->get_url_params()` and checks `edit_post` against it. The handler `update_post_state()`, however, took the post id from `$request->get_param( 'post_id' )`. `WP_REST_Request::get_param()` resolves parameters in the order JSON body, POST body, query string, then URL path, so a `post_id` supplied in the request body or query string overrides the URL value. The resolved id then flowed unchecked into `admin_set_liveblog_state_for_post()` → `set_liveblog_state()`, which writes and deletes the `liveblog` state meta, the auto-archive meta, and (via the `liveblog_admin_settings_update` action) the key-event template meta, with no further capability check.

The result was a cross-post authorisation bypass (CWE-639). An author authorised on their own liveblog could target the route at a post they own, pass another author's post id in the body, and enable, archive, or disable the liveblog on that post — for example taking a live event offline mid-broadcast. `crud_entry()` was already hardened against exactly this body-overrides-URL pattern in 1.12.0; `update_post_state()` was simply never brought into line.

The fix introduces a single `get_authorised_post_id()` helper that always reads the URL path, and routes the permission callback, `crud_entry()`, `update_post_state()`, and `format_preview_entry()` through it. Sourcing authorisation and action from the same place removes the whole class of mismatch rather than patching one route. `format_preview_entry()` had the same `get_param()` split with no current impact (preview persists nothing post-scoped), but is included so a future change to the preview path cannot silently inherit the wrong post context.

## Test plan

A new integration test, `test_endpoint_update_post_state_body_post_id_cannot_override_url`, authorises against an attacker-owned post and supplies a victim post id in the body, asserting the victim's liveblog state is untouched and the change lands on the URL post. Verified to fail against the pre-fix code (the victim post was archived) and pass with the fix.

- `composer test:integration` — full suite green (146 tests), `phpcs` clean.

> Note for the maintainer: I have left the new private helper without an `@since` tag, matching the style of `validate_entry_belongs_to_post()` from #895. Worth confirming whether this ships as 1.12.1 or 1.13.0 when the changelog is cut.