### PR TITLE
Stop the author autocomplete leaking editor email addresses

### DIFF
--- a/classes/class-wpcom-liveblog-entry-extend-feature-authors.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-authors.php
@@ -267,6 +267,14 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Authors extends WPCOM_Liveblog_Entry_E
 		// If there is a search term, append '*' to match chars after the term.
 		if ( strlen( trim( $term ) ) > 0 ) {
 			$args['search'] = $term . '*';
+
+			// Restrict the search to non-PII columns. Without an explicit
+			// search_columns, WP_User_Query matches the term against user_email
+			// (exclusively when the term contains an '@'), which turns this
+			// autocomplete into a blind email-existence oracle for users holding
+			// `edit_posts` (CWE-203). The picker only ever needs to match on
+			// login, nicename, and display name.
+			$args['search_columns'] = array( 'user_login', 'user_nicename', 'display_name' );
 		}
 
 		// Map the authors into the expected format.

--- a/tests/Integration/ExtendFeatureAuthorsTest.php
+++ b/tests/Integration/ExtendFeatureAuthorsTest.php
@@ -47,4 +47,37 @@ final class ExtendFeatureAuthorsTest extends TestCase {
 		}
 		return $example;
 	}
+
+	/**
+	 * The author autocomplete must not match the search term against user_email.
+	 *
+	 * Without an explicit search_columns, WP_User_Query searches user_email when
+	 * the term contains an '@', turning the picker into a blind email-existence
+	 * oracle for users holding `edit_posts` (CWE-203). An email-prefix search must
+	 * therefore return nothing, while a nicename / display-name search must still
+	 * resolve the user.
+	 *
+	 * @covers WPCOM_Liveblog_Entry_Extend_Feature_Authors::get_authors()
+	 */
+	public function test_get_authors_does_not_match_on_email(): void {
+		$user_id = self::factory()->user->create(
+			array(
+				'role'          => 'author',
+				'user_login'    => 'liveblogeditor',
+				'user_email'    => 'secret.address@example.com',
+				'display_name'  => 'Liveblog Editor',
+				'user_nicename' => 'liveblog-editor',
+			)
+		);
+
+		$feature = new WPCOM_Liveblog_Entry_Extend_Feature_Authors();
+
+		// An email-prefix search must not reveal the user.
+		$by_email = array_map( 'intval', wp_list_pluck( $feature->get_authors( 'secret.address@example' ), 'id' ) );
+		$this->assertNotContains( (int) $user_id, $by_email, 'Author autocomplete must not match on user_email.' );
+
+		// A legitimate nicename / display-name search must still find the user.
+		$by_name = array_map( 'intval', wp_list_pluck( $feature->get_authors( 'liveblog' ), 'id' ) );
+		$this->assertContains( (int) $user_id, $by_name, 'Author autocomplete should still match on nicename and display name.' );
+	}
 }


### PR DESCRIPTION
## Summary

The author autocomplete that powers @-mentions runs a `get_users()` query with `search => $term . '*'` but never sets `search_columns`. When `search_columns` is left unset, `WP_User_Query` chooses the columns from the shape of the term, and any term containing an `@` is matched **exclusively** against `user_email`. The endpoint deliberately returns only id, nicename, display name, and avatar, so the address is never echoed back — but whether the result set is empty or not still reveals whether a user holding `edit_posts` has an email starting with the supplied prefix.

That makes the autocomplete a blind email-existence oracle (CWE-203). The route is gated only by `edit_post` on a post id in the URL, and crucially does not require a liveblog to be enabled, so the bar is low: a Contributor can create a draft, gain `edit_post` on it, and then probe `…/authors/admin@example.c`, extending the prefix one character at a time to confirm or reconstruct the private email of an editor or administrator. WordPress core never offers a comparable email prefix oracle to users without `list_users`, so this is a disclosure beyond core norms.

The fix pins the search to `user_login`, `user_nicename`, and `display_name`, the only columns the picker ever needs, so the term can never be matched against `user_email` regardless of its content. Both the REST `get_authors` handler and the legacy `liveblog_authors` admin-ajax handler funnel through the same `get_authors()` method, so the single change closes both. The hashtag autocomplete is unaffected — it searches the taxonomy, not users.

## Test plan

A new integration test seeds an Author with a known email and asserts that an email-prefix search returns nothing while a nicename / display-name search still resolves the user. Verified to fail against the pre-fix code (the email search returned the user) and pass with the fix.

- `composer test:integration` — green; `phpcs` clean.