### PR TITLE
Strip nested restricted shortcodes instead of reconstructing them

### DIFF
--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -626,16 +626,28 @@ class WPCOM_Liveblog_Entry {
 		// Runs the restricted shortcode array through the filter before being applied.
 		self::$restricted_shortcodes = apply_filters( 'liveblog_entry_restrict_shortcodes', self::$restricted_shortcodes );
 
-		// For each lookup key, does it exist in the content.
+		// Strip every restricted shortcode, re-applying the whole set until the
+		// content stabilises. A single pass is bypassable by nesting a restricted
+		// shortcode inside fragments of a tag name, so that removing the inner
+		// match reconstructs a working shortcode. That happens both within one tag
+		// (`[liveblog_key[liveblog_key_events]_events]` -> `[liveblog_key_events]`)
+		// and across tags when more than one is restricted (removing `[embed]`
+		// from `[gall[embed]ery]` reconstructs `[gallery]`). Looping the whole set
+		// rather than each tag in isolation removes the order dependence between
+		// tags. The loop only continues while the content strictly shrinks, so a
+		// replacement that is the same length or longer than the match (an unusual
+		// configuration) cannot make it spin.
 		if ( is_array( self::$restricted_shortcodes ) ) {
-			foreach ( self::$restricted_shortcodes as $key => $value ) {
+			do {
+				$previous = $args['content'];
 
-				// Regex pattern will match all shortcode formats.
-				$pattern = get_shortcode_regex( array( $key ) );
+				foreach ( self::$restricted_shortcodes as $key => $value ) {
+					$pattern         = '/' . get_shortcode_regex( array( $key ) ) . '/s';
+					$args['content'] = preg_replace( $pattern, $value, $args['content'] );
+				}
 
-				// If there's a match we replace it with the configured replacement.
-				$args['content'] = preg_replace( '/' . $pattern . '/s', $value, $args['content'] );
-			}
+				$shrank = ( null !== $args['content'] && strlen( $args['content'] ) < strlen( $previous ) );
+			} while ( $shrank );
 		}
 
 		// Return the original entry arguments with any modifications.

--- a/liveblog.php
+++ b/liveblog.php
@@ -388,9 +388,12 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			add_filter( 'is_protected_meta', array( __CLASS__, 'protect_liveblog_meta_key' ), 10, 2 );
 
 			// Add In the Filter hooks to Strip any Restricted Shortcodes before a new post or updating a post.
-			// Called from the WPCOM_Liveblog_Entry Class.
+			// Called from the WPCOM_Liveblog_Entry Class. Preview is included so the
+			// rendered preview matches what would be stored, and so the restriction
+			// cannot be sidestepped by rendering through the preview endpoint.
 			add_filter( 'liveblog_before_insert_entry', array( 'WPCOM_Liveblog_Entry', 'handle_restricted_shortcodes' ), 10, 1 );
 			add_filter( 'liveblog_before_update_entry', array( 'WPCOM_Liveblog_Entry', 'handle_restricted_shortcodes' ), 10, 1 );
+			add_filter( 'liveblog_before_preview_entry', array( 'WPCOM_Liveblog_Entry', 'handle_restricted_shortcodes' ), 10, 1 );
 
 			// We need to check the Liveblog autoarchive date on each time a new entry is added or updated to
 			// ensure we extend the date out correctly to the next archive point based on the configured offset.

--- a/tests/Integration/EntryTest.php
+++ b/tests/Integration/EntryTest.php
@@ -318,6 +318,71 @@ final class EntryTest extends TestCase {
 	}
 
 	/**
+	 * Restricted shortcodes nested inside fragments of their own tag must be
+	 * stripped, not reconstructed.
+	 *
+	 * A single replacement pass is bypassable: removing the inner match from
+	 * `[liveblog_key[liveblog_key_events]_events]` leaves a working
+	 * `[liveblog_key_events]` behind, which `do_shortcode()` would then execute
+	 * at render time. The strip must repeat until no valid restricted shortcode
+	 * remains (CWE-94 via CWE-185).
+	 */
+	public function test_nested_restricted_shortcodes_are_fully_stripped(): void {
+		$key     = 'liveblog_key_events';
+		$pattern = '/' . get_shortcode_regex( array( $key ) ) . '/s';
+
+		$cases = array(
+			'[liveblog_key[liveblog_key_events]_events]',
+			'prefix [liveblog_key[liveblog_key_events]_events] suffix',
+			'[liveblog_key[liveblog_key[liveblog_key_events]_events]_events]',
+		);
+
+		foreach ( $cases as $input ) {
+			$result = WPCOM_Liveblog_Entry::handle_restricted_shortcodes( array( 'content' => $input ) );
+
+			$this->assertSame(
+				0,
+				preg_match( $pattern, $result['content'] ),
+				sprintf( 'A valid [%s] shortcode survived stripping of: %s', $key, $input )
+			);
+		}
+	}
+
+	/**
+	 * Removing one restricted shortcode must not reconstruct a different
+	 * restricted shortcode.
+	 *
+	 * When more than one shortcode is restricted, removing the inner one can
+	 * join the surrounding fragments into the other — e.g. stripping [embed]
+	 * from [gall[embed]ery] yields [gallery]. Stripping must therefore re-apply
+	 * the whole restricted set until the content stabilises, independently of the
+	 * order the tags appear in. The order here ('gallery' before 'embed') is the
+	 * one that a per-tag strip would fail to clean.
+	 */
+	public function test_cross_tag_restricted_shortcode_reconstruction_is_stripped(): void {
+		$original = WPCOM_Liveblog_Entry::$restricted_shortcodes;
+
+		$filter = static function () {
+			return array(
+				'gallery' => '',
+				'embed'   => '',
+			);
+		};
+		add_filter( 'liveblog_entry_restrict_shortcodes', $filter );
+
+		$result = WPCOM_Liveblog_Entry::handle_restricted_shortcodes( array( 'content' => 'before [gall[embed]ery] after' ) );
+
+		remove_filter( 'liveblog_entry_restrict_shortcodes', $filter );
+		WPCOM_Liveblog_Entry::$restricted_shortcodes = $original;
+
+		$this->assertSame(
+			0,
+			preg_match( '/' . get_shortcode_regex( array( 'gallery' ) ) . '/s', $result['content'] ),
+			'A restricted [gallery] reconstructed from a different restricted tag survived stripping.'
+		);
+	}
+
+	/**
 	 * `author_id` for a user with `edit_posts` is accepted and the resulting
 	 * comment is attributed to that user. This is the legitimate co-author
 	 * flow and must keep working.


### PR DESCRIPTION
## Summary

`handle_restricted_shortcodes()` is the boundary that keeps configured shortcodes — by default `[liveblog_key_events]`, and on customer sites anything registered through the `liveblog_entry_restrict_shortcodes` filter — out of liveblog entries. It removed each shortcode with a single `preg_replace` pass, and a single pass is bypassable by nesting. Removing the inner match from `[liveblog_key[liveblog_key_events]_events]` leaves a perfectly valid `[liveblog_key_events]` behind; `wp_filter_post_kses()` preserves the brackets, and `render_content()` then runs `do_shortcode()` on the stored entry for every reader, executing the shortcode that was supposed to be blocked. An editor without `unfiltered_html` could smuggle a restricted shortcode into front-end output (CWE-94, via the incorrect single-pass expression, CWE-185).

The reconstruction also works **across tags** when a site restricts more than one: removing `[embed]` from `[gall[embed]ery]` yields `[gallery]`. Stripping each tag in isolation would only catch that depending on the order the tags happen to sit in the restricted array, which is fragile. So the fix re-applies the **whole** restricted set until the content stabilises rather than fixing up each tag independently — order-independent, and it subsumes the same-tag case. The loop continues only while the content strictly shrinks, so the default empty replacement (and any placeholder shorter than the shortcode) collapses arbitrarily nested forms all the way down, while a replacement that happens to be the same length or longer than the match cannot send it into an infinite loop. The strip is also now applied to the `liveblog_before_preview_entry` filter, so the rendered preview reflects what would actually be stored and the restriction cannot be sidestepped by rendering through the preview endpoint.

## A decision for review

This hardens the **write** path (insert, update, and now preview). It deliberately does **not** add stripping at render time. Doing so would also neutralise any entry that smuggled a restricted shortcode through the single-pass gap *before* this fix shipped, at the cost of running the strip on every entry render for every reader. Given the modest severity and that the injection vector itself is now closed, I have kept this PR to the write path. If you would prefer belt-and-braces protection for already-stored content, I am happy to follow up with an idempotent strip inside `render_content()` immediately before `do_shortcode()`.

## Test plan

Two integration tests exercise the strip directly:

- nested same-tag forms (`[liveblog_key[liveblog_key_events]_events]`, a variant with surrounding text, and a doubly-nested case) assert no valid `[liveblog_key_events]` survives;
- a cross-tag case restricts both `gallery` and `embed` and feeds `[gall[embed]ery]`, asserting no valid `[gallery]` is reconstructed — in the order a per-tag strip would miss.

Both were verified to fail against the relevant pre-fix code and pass with the whole-set loop. The existing flat-form test continues to pass.

- `composer test:integration` — green (147 tests); `phpcs` clean.