### PR TITLE
Coerce REST entry content to a string to avoid a type error

### DIFF
--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -556,7 +556,7 @@ class WPCOM_Liveblog_Rest_Api {
 
 		$args = array(
 			'post_id'         => $post_id,
-			'content'         => self::get_json_param( 'content', $json ),
+			'content'         => self::coerce_content_to_string( self::get_json_param( 'content', $json ) ),
 			'entry_id'        => self::get_json_param( 'entry_id', $json ),
 			'author_id'       => self::get_json_param( 'author_id', $json ),
 			'contributor_ids' => self::get_json_param( 'contributor_ids', $json ),
@@ -635,7 +635,7 @@ class WPCOM_Liveblog_Rest_Api {
 		// permission callback so a body/query value cannot change the post context.
 		$post_id       = self::get_authorised_post_id( $request );
 		$json          = $request->get_json_params();
-		$entry_content = self::get_json_param( 'entry_content', $json );
+		$entry_content = self::coerce_content_to_string( self::get_json_param( 'entry_content', $json ) );
 
 		self::set_liveblog_vars( $post_id );
 
@@ -847,5 +847,23 @@ class WPCOM_Liveblog_Rest_Api {
 			return $json[ $param ];
 		}
 		return false;
+	}
+
+	/**
+	 * Coerce a free-form entry content value from the JSON body to a string.
+	 *
+	 * The `content` and `entry_content` parameters are read straight from the
+	 * decoded JSON body, which can supply an array or object. Such a value would
+	 * otherwise flow unchanged into `wp_filter_post_kses()` and raise a TypeError
+	 * (HTTP 500) on PHP 8. Casting non-scalars to an empty string mirrors the
+	 * coercion the legacy admin-ajax path performs via `sanitize_text_field()`,
+	 * so both entry points behave the same. A missing value (`get_json_param()`
+	 * returns false) likewise becomes an empty string.
+	 *
+	 * @param mixed $content The raw content value from the JSON body.
+	 * @return string The content as a string.
+	 */
+	private static function coerce_content_to_string( $content ) {
+		return is_scalar( $content ) ? (string) $content : '';
 	}
 }

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -1254,6 +1254,35 @@ final class RestApiTest extends TestCase {
 	}
 
 	/**
+	 * A non-string `content` value in the JSON body must be handled gracefully.
+	 *
+	 * The REST handlers read content straight from the decoded JSON body. An
+	 * array value would otherwise reach wp_filter_post_kses() unscalarised and
+	 * raise a PHP TypeError (HTTP 500) on PHP 8 (CWE-20). It must be coerced to a
+	 * string and the request handled without a server error.
+	 */
+	public function test_endpoint_crud_insert_with_array_content_does_not_error(): void {
+		$author_id = $this->set_author_user();
+		$post_id   = $this->create_liveblog_post( array( 'post_author' => $author_id ) );
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'crud_action' => 'insert',
+					'content'     => array( '<p>array content</p>' ),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		// The malformed content is coerced to a string rather than fatally
+		// erroring; the insert succeeds with empty content.
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
 	 * Build the list of public read endpoint URLs that accept a post_id for testing.
 	 *
 	 * @param int $post_id  Post ID to embed.


### PR DESCRIPTION
## Summary

The `crud` and `preview` REST handlers read the free-form `content` and `entry_content` parameters directly from the decoded JSON body through `get_json_param()`, which returns whatever the client supplied. A request whose `content` is a JSON array therefore reached `wp_filter_post_kses()` unscalarised and raised a PHP `TypeError` (HTTP 500) on PHP 8, rather than being handled cleanly (CWE-20). The legacy admin-ajax handlers already coerce the same input to a string via `sanitize_text_field()`; only the REST path was unguarded, so the two entry points behaved differently for the same malformed input.

The impact is limited — the request must come from an authenticated user who already holds `edit_post` on the target liveblog, and the result is a self-inflicted error on their own request with no amplification — so this is a robustness and parity fix rather than a serious vulnerability. It is worth closing both because a 500 is a poor failure mode and because the two entry points should validate identically.

A small `coerce_content_to_string()` helper casts scalar values to a string and maps anything else (and a missing value) to an empty string. Both handlers now run the content through it, so an array, object, or absent value is handled gracefully instead of fatally.

## Test plan

A new integration test posts an `insert` with an array `content` to the crud route and asserts a 200 response rather than a 500. Verified to error with a `TypeError` against the pre-fix code and pass with the coercion in place.

- `composer test:integration` — green (146 tests); `phpcs` clean.