### PR TITLE
Guard entry author lookup against stale and anonymous IDs

### DIFF
--- a/src/php/Application/Service/EntryOperations.php
+++ b/src/php/Application/Service/EntryOperations.php
@@ -14,6 +14,7 @@ use Automattic\Liveblog\Application\Renderer\ContentRendererInterface;
 use Automattic\Liveblog\Domain\Repository\EntryRepositoryInterface;
 use Automattic\Liveblog\Domain\ValueObject\EntryId;
 use Automattic\Liveblog\Infrastructure\Repository\CommentEntryRepository;
+use WP_Comment;
 use WP_Error;
 use WP_User;
 
@@ -208,9 +209,8 @@ final class EntryOperations {
 		// Apply filter before update.
 		$args = apply_filters( 'liveblog_before_update_entry', $args );
 
-		// Get original author for the update.
-		$original_comment = get_comment( $args['entry_id'] );
-		$user             = get_userdata( $original_comment->user_id );
+		// Re-save the entry under its original author.
+		$user = $this->get_original_author( (int) $args['entry_id'] );
 
 		$entry_id = $this->entry_service->update(
 			$post_id,
@@ -256,11 +256,11 @@ final class EntryOperations {
 	 * @return EntryId The entry ID.
 	 */
 	private function execute_delete_key( array $args, int $post_id ): EntryId {
-		// Get the original author.
-		$original_comment = get_comment( $args['entry_id'] );
-		$user             = get_userdata( $original_comment->user_id );
+		$entry_id = EntryId::from_int( (int) $args['entry_id'] );
 
-		$entry_id        = EntryId::from_int( (int) $args['entry_id'] );
+		// Re-save the entry under its original author.
+		$user = $this->get_original_author( $entry_id->to_int() );
+
 		$updated_content = $this->key_event_service->remove_key_action(
 			$args['content'] ?? '',
 			$entry_id->to_int()
@@ -272,6 +272,33 @@ final class EntryOperations {
 			$updated_content,
 			$user
 		);
+	}
+
+	/**
+	 * Resolve the original author of an existing entry.
+	 *
+	 * Updates and key-event removals re-save the entry under its original
+	 * author rather than the editor performing the action. If the entry or its
+	 * author can no longer be resolved (for example a stale or anonymous entry
+	 * ID), this throws so do_crud() returns a clean WP_Error instead of letting
+	 * a TypeError surface from the typed EntryService::update() signature.
+	 *
+	 * @param int $entry_id The entry (comment) ID.
+	 * @return WP_User The original author.
+	 * @throws \InvalidArgumentException If the entry or its author cannot be found.
+	 */
+	private function get_original_author( int $entry_id ): WP_User {
+		$comment = get_comment( $entry_id );
+		if ( ! $comment instanceof WP_Comment ) {
+			throw new \InvalidArgumentException( 'Entry not found: ' . esc_html( (string) $entry_id ) );
+		}
+
+		$author = get_userdata( (int) $comment->user_id );
+		if ( ! $author instanceof WP_User ) {
+			throw new \InvalidArgumentException( 'Entry author not found for entry: ' . esc_html( (string) $entry_id ) );
+		}
+
+		return $author;
 	}
 
 	/**

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -335,6 +335,37 @@ final class RestApiTest extends IntegrationTestCase {
 	}
 
 	/**
+	 * A delete_key action for a non-existent entry returns a WP_Error, not a fatal.
+	 *
+	 * Guards the original-author lookup: a stale or invalid entry ID must not
+	 * reach the typed EntryService::update() and raise a TypeError.
+	 */
+	public function test_crud_action_delete_key_returns_error_for_unknown_entry(): void {
+		$user             = wp_get_current_user();
+		$args             = array( 'entry_id' => 999999 );
+		$entry_operations = Container::instance()->entry_operations();
+
+		$result = $entry_operations->do_crud( 'delete_key', $this->build_entry_args( $args ), $user );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'entry-invalid-args', $result->get_error_code() );
+	}
+
+	/**
+	 * An update action for a non-existent entry returns a WP_Error, not a fatal.
+	 */
+	public function test_crud_action_update_returns_error_for_unknown_entry(): void {
+		$user             = wp_get_current_user();
+		$args             = array( 'entry_id' => 999999 );
+		$entry_operations = Container::instance()->entry_operations();
+
+		$result = $entry_operations->do_crud( 'update', $this->build_entry_args( $args ), $user );
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertSame( 'entry-invalid-args', $result->get_error_code() );
+	}
+
+	/**
 	 * Test getting a preview of an entry.
 	 */
 	public function test_preview_entry(): void {


### PR DESCRIPTION
## Summary

While re-reviewing #874 (the 2.x architecture review) before merge, I noticed a latent fatal-error path in the entry mutation flow that predates that work but is worth closing now the surrounding code is fresh.

When an entry is updated or has its key event removed, the new revision is re-saved under the *original* author rather than the editor performing the action. `EntryOperations::execute_update()` and `execute_delete_key()` both resolved that author the same way: `get_comment( $entry_id )->user_id`, then `get_userdata( … )`. Neither result was checked. A missing comment (a stale or invalid `entry_id`) meant reading a property on `null`, and a genuinely anonymous author (`user_id` 0) meant `get_userdata()` returned `false`. Either value was then handed to the typed `EntryService::update( …, WP_User $author )`, raising an uncaught `TypeError`. Since `do_crud()` only catches `InvalidArgumentException` and `RuntimeException`, the request died as a fatal 500 instead of returning a client error.

The fix extracts the lookup into a single guarded `get_original_author()` helper shared by both flows. It throws `InvalidArgumentException` when the entry or its author cannot be resolved, which `do_crud()` already turns into a clean `WP_Error( 'entry-invalid-args' )`. So a stale or anonymous entry ID now produces a graceful error rather than a fatal, and the duplicated lookup is no longer repeated across two methods.

## Test plan

- [x] Two integration tests added covering `update` and `delete_key` against an unknown entry, asserting a `WP_Error` with code `entry-invalid-args` rather than a fatal.
- [x] Lint, PHPCS, the 190 unit tests, and the full 267-test integration suite all pass locally.