### PR TITLE
Disable the deprecated lazyload plugin early on init

### DIFF
--- a/src/php/Infrastructure/WordPress/PluginBootstrapper.php
+++ b/src/php/Infrastructure/WordPress/PluginBootstrapper.php
@@ -425,10 +425,18 @@ final class PluginBootstrapper {
 	 * @return void
 	 */
 	private function init_lazyload(): void {
+		// Disable the deprecated standalone Lazyload Liveblog Entries plugin early
+		// on init, before its own (default-priority) callback fires. This cannot
+		// sit on template_redirect: that hook is front-end only, so is_admin() is
+		// always false there (the admin notice never shows) and it runs after init
+		// (too late to unhook the deprecated plugin).
+		add_action( 'init', array( $this, 'handle_deprecated_lazyload_plugin' ), 0 );
+
+		// Initialise lazyload config on template_redirect, once the liveblog query
+		// state is available.
 		add_action(
 			'template_redirect',
 			function () {
-				$this->handle_deprecated_lazyload_plugin();
 				$this->container->lazyload_configuration()->initialize();
 			}
 		);
@@ -437,12 +445,14 @@ final class PluginBootstrapper {
 	/**
 	 * Disable the deprecated Lazyload Liveblog Entries plugin and surface a notice.
 	 *
-	 * The standalone plugin is now superseded by built-in lazyload support, so we
-	 * unhook its `init` callback and prompt admins to remove it.
+	 * Runs early on `init` (priority 0) so the deprecated plugin's own init
+	 * callback is unhooked before it fires, and so the admin notice is evaluated
+	 * in admin context. The standalone plugin is superseded by built-in lazyload
+	 * support. Public because it is registered as an `init` hook callback.
 	 *
 	 * @return void
 	 */
-	private function handle_deprecated_lazyload_plugin(): void {
+	public function handle_deprecated_lazyload_plugin(): void {
 		if ( ! has_action( 'init', 'Lazyload_Liveblog_Entries' ) ) {
 			return;
 		}

--- a/tests/Integration/DeprecatedLazyloadPluginTest.php
+++ b/tests/Integration/DeprecatedLazyloadPluginTest.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Tests for disabling the deprecated standalone Lazyload Liveblog Entries plugin.
+ *
+ * @package Automattic\Liveblog\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Tests\Integration;
+
+use Automattic\Liveblog\Infrastructure\WordPress\PluginBootstrapper;
+
+/**
+ * Deprecated lazyload plugin handling test case.
+ *
+ * @covers \Automattic\Liveblog\Infrastructure\WordPress\PluginBootstrapper::handle_deprecated_lazyload_plugin
+ */
+final class DeprecatedLazyloadPluginTest extends IntegrationTestCase {
+
+	/**
+	 * Remove the simulated deprecated hook so it cannot leak between tests.
+	 */
+	public function tear_down(): void {
+		remove_action( 'init', 'Lazyload_Liveblog_Entries' );
+		parent::tear_down();
+	}
+
+	/**
+	 * The handler must be hooked on init at priority 0.
+	 *
+	 * It previously ran on template_redirect, which is front-end only (so the
+	 * admin notice never showed) and fires after init (too late to unhook the
+	 * deprecated plugin). Running early on init fixes both.
+	 */
+	public function test_handler_runs_early_on_init(): void {
+		global $wp_filter;
+
+		$found_priority = null;
+		$collection     = $wp_filter['init'] ?? array();
+
+		foreach ( $collection as $priority => $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				if ( is_array( $callback['function'] )
+					&& isset( $callback['function'][1] )
+					&& 'handle_deprecated_lazyload_plugin' === $callback['function'][1]
+				) {
+					$found_priority = $priority;
+					break 2;
+				}
+			}
+		}
+
+		$this->assertNotNull( $found_priority, 'The deprecated-lazyload handler should be hooked to init.' );
+		$this->assertSame(
+			0,
+			$found_priority,
+			'The handler must run before the deprecated plugin default-priority init callback.'
+		);
+	}
+
+	/**
+	 * Invoking the handler unhooks the deprecated plugin init callback.
+	 */
+	public function test_handler_unhooks_deprecated_plugin(): void {
+		add_action( 'init', 'Lazyload_Liveblog_Entries' );
+		$this->assertNotFalse(
+			has_action( 'init', 'Lazyload_Liveblog_Entries' ),
+			'Precondition: the deprecated init callback should be registered.'
+		);
+
+		( new PluginBootstrapper( $this->container() ) )->handle_deprecated_lazyload_plugin();
+
+		$this->assertFalse(
+			has_action( 'init', 'Lazyload_Liveblog_Entries' ),
+			'The handler should remove the deprecated plugin init callback.'
+		);
+	}
+}


### PR DESCRIPTION
## Summary

While re-reviewing #874 before merge I traced the deprecated-plugin handling that the architecture work had just relocated, and found it had been quietly ineffective for far longer than that.

When the obsolete standalone *Lazyload Liveblog Entries* plugin is active, the bootstrapper is meant to unhook its `init` callback and show an admin notice prompting removal. Both jobs were wired to `template_redirect`, which is the wrong hook for either. `template_redirect` is a front-end-only hook, so `is_admin()` is always false within it and the admin notice could never appear. It also fires *after* `init`, by which point the deprecated plugin's own `init` callback has already run, so unhooking it there is too late to matter. The recent refactor only moved this code; the notice and the unhooking have been dead for much longer.

The fix registers the handler on `init` at priority 0. `init` fires in both admin and front-end contexts, which restores the admin notice, and priority 0 runs before the deprecated plugin's default-priority callback, so the unhooking now takes effect. The lazyload configuration itself stays on `template_redirect`, where it correctly waits for the liveblog query state to be resolved.

To support testing, the handler becomes a public method wired as a named `init` callback rather than an inline closure. That matches every other hook callback in this class (`register_post_type_support`, `register_routes`, and so on) and lets the tests identify it in `$wp_filter`.

## Test plan

- [x] New integration tests assert the handler is hooked on `init` at priority 0 and that invoking it removes the deprecated plugin's `init` callback.
- [x] Lint, PHPCS, the 190 unit tests, and the full 267-test integration suite all pass locally.