### PR TITLE
Port the merged 1.x security fixes to the 2.x rewrite

### DIFF
--- a/src/php/Application/Filter/AuthorFilter.php
+++ b/src/php/Application/Filter/AuthorFilter.php
@@ -345,6 +345,14 @@ final class AuthorFilter implements ContentFilterInterface {
 
 		if ( strlen( trim( $term ) ) > 0 ) {
 			$args['search'] = $term . '*';
+
+			// Restrict the search to non-PII columns. Without an explicit
+			// search_columns, WP_User_Query matches the term against user_email
+			// (exclusively when the term contains an '@'), which turns this
+			// autocomplete into a blind email-existence oracle for users holding
+			// `edit_posts` (CWE-203). The picker only ever needs to match on
+			// login, nicename, and display name.
+			$args['search_columns'] = array( 'user_login', 'user_nicename', 'display_name' );
 		}
 
 		/**

--- a/src/php/Application/Service/EntryOperations.php
+++ b/src/php/Application/Service/EntryOperations.php
@@ -203,6 +203,11 @@ final class EntryOperations {
 	 * @return EntryId The new entry ID.
 	 */
 	private function execute_update( array $args, int $post_id ): EntryId {
+		// Bind the entry to the authorised post before any mutation runs:
+		// handle_update_metadata() reassigns the original entry's author and
+		// contributors, so the check has to come first.
+		$this->assert_entry_belongs_to_post( (int) ( $args['entry_id'] ?? 0 ), $post_id );
+
 		// Handle author selection and contributors on the original entry.
 		$this->handle_update_metadata( $args );
 
@@ -233,6 +238,8 @@ final class EntryOperations {
 	 * @return EntryId The delete marker entry ID.
 	 */
 	private function execute_delete( array $args, WP_User $user, int $post_id ): EntryId {
+		$this->assert_entry_belongs_to_post( (int) ( $args['entry_id'] ?? 0 ), $post_id );
+
 		$entry_id = $this->entry_service->delete(
 			$post_id,
 			EntryId::from_int( (int) $args['entry_id'] ),
@@ -256,6 +263,10 @@ final class EntryOperations {
 	 * @return EntryId The entry ID.
 	 */
 	private function execute_delete_key( array $args, int $post_id ): EntryId {
+		// Guard before remove_key_action() runs: it deletes the referenced
+		// entry's key-event meta, so the post-binding check must happen first.
+		$this->assert_entry_belongs_to_post( (int) ( $args['entry_id'] ?? 0 ), $post_id );
+
 		$entry_id = EntryId::from_int( (int) $args['entry_id'] );
 
 		// Re-save the entry under its original author.
@@ -299,6 +310,39 @@ final class EntryOperations {
 		}
 
 		return $author;
+	}
+
+	/**
+	 * Ensure the entry being mutated belongs to the authorised post.
+	 *
+	 * The CRUD entry points authorise the caller against the post id taken from
+	 * the route URL (REST) or the permalink (admin-ajax), but the entry id
+	 * arrives separately in the request body and is not otherwise re-validated
+	 * against that post. Without binding the two together, a caller authorised to
+	 * edit their own liveblog could pass the entry id of an entry belonging to
+	 * another user's post and have the update/delete/delete_key flow mutate it
+	 * (CWE-639 IDOR, HackerOne #3742849).
+	 *
+	 * The entry must exist, be a liveblog entry (so the endpoint cannot be used
+	 * to edit or trash arbitrary non-liveblog comments), and be attached to the
+	 * authorised post. The message is deliberately generic so the endpoint cannot
+	 * be used to probe for entries on other posts.
+	 *
+	 * @param int $entry_id The entry (comment) ID supplied by the caller.
+	 * @param int $post_id  The authorised post ID.
+	 * @return void
+	 * @throws \InvalidArgumentException If the entry does not belong to the post.
+	 */
+	private function assert_entry_belongs_to_post( int $entry_id, int $post_id ): void {
+		$comment = get_comment( $entry_id );
+
+		if (
+			! $comment instanceof WP_Comment
+			|| CommentEntryRepository::COMMENT_TYPE !== $comment->comment_type
+			|| (int) $comment->comment_post_ID !== $post_id
+		) {
+			throw new \InvalidArgumentException( 'Entry not found in this liveblog.' );
+		}
 	}
 
 	/**

--- a/src/php/Application/Service/ShortcodeFilter.php
+++ b/src/php/Application/Service/ShortcodeFilter.php
@@ -53,15 +53,28 @@ final class ShortcodeFilter {
 			self::DEFAULT_RESTRICTED_SHORTCODES
 		);
 
-		// For each lookup key, check if it exists in the content.
+		// Strip every restricted shortcode, re-applying the whole set until the
+		// content stabilises. A single pass is bypassable by nesting a restricted
+		// shortcode inside fragments of a tag name, so that removing the inner
+		// match reconstructs a working shortcode. That happens both within one tag
+		// (`[liveblog_key[liveblog_key_events]_events]` -> `[liveblog_key_events]`)
+		// and across tags when more than one is restricted (removing `[embed]`
+		// from `[gall[embed]ery]` reconstructs `[gallery]`). Looping the whole set
+		// rather than each tag in isolation removes the order dependence between
+		// tags. The loop only continues while the content strictly shrinks, so a
+		// replacement that is the same length or longer than the match (an unusual
+		// configuration) cannot make it spin.
 		if ( is_array( $restricted_shortcodes ) ) {
-			foreach ( $restricted_shortcodes as $shortcode => $replacement ) {
-				// Regex pattern will match all shortcode formats.
-				$pattern = get_shortcode_regex( array( $shortcode ) );
+			do {
+				$previous = $args['content'];
 
-				// Replace matches with the configured replacement string.
-				$args['content'] = preg_replace( '/' . $pattern . '/s', $replacement, $args['content'] );
-			}
+				foreach ( $restricted_shortcodes as $shortcode => $replacement ) {
+					$pattern         = '/' . get_shortcode_regex( array( $shortcode ) ) . '/s';
+					$args['content'] = preg_replace( $pattern, $replacement, $args['content'] );
+				}
+
+				$shrank = ( null !== $args['content'] && strlen( $args['content'] ) < strlen( $previous ) );
+			} while ( $shrank );
 		}
 
 		return $args;

--- a/src/php/Infrastructure/WordPress/RestApiController.php
+++ b/src/php/Infrastructure/WordPress/RestApiController.php
@@ -516,15 +516,19 @@ final class RestApiController {
 		// Use the URL post_id as the authoritative target. The permission
 		// callback authorises against the URL post_id, so the JSON body must
 		// not be allowed to redirect the action at a different post.
-		$url_params = $request->get_url_params();
-		$post_id    = isset( $url_params['post_id'] ) ? (int) $url_params['post_id'] : 0;
+		$post_id = $this->get_authorised_post_id( $request );
+
+		// Coerce the free-form content to a string and the contributor IDs to an
+		// array, so a non-string / non-array JSON body value cannot reach the
+		// entry sinks unscalarised and raise a TypeError (HTTP 500).
+		$content = $this->get_json_param( 'content', $json );
 
 		$args = array(
 			'post_id'         => $post_id,
-			'content'         => $this->get_json_param( 'content', $json ),
+			'content'         => is_string( $content ) ? $content : '',
 			'entry_id'        => $this->get_json_param( 'entry_id', $json ),
 			'author_id'       => $this->get_json_param( 'author_id', $json ),
-			'contributor_ids' => $this->get_json_param( 'contributor_ids', $json ),
+			'contributor_ids' => $this->normalize_contributor_ids( $this->get_json_param( 'contributor_ids', $json ) ),
 		);
 
 		$this->set_liveblog_vars( $post_id );
@@ -587,7 +591,9 @@ final class RestApiController {
 	 * @return array
 	 */
 	public function format_preview_entry( WP_REST_Request $request ): array {
-		$post_id       = (int) $request->get_param( 'post_id' );
+		// The URL path post_id is authoritative; read it from the same source as
+		// the permission callback so a body/query value cannot change the context.
+		$post_id       = $this->get_authorised_post_id( $request );
 		$json          = $request->get_json_params();
 		$entry_content = $this->get_json_param( 'entry_content', $json );
 
@@ -633,14 +639,25 @@ final class RestApiController {
 	 * @return string
 	 */
 	public function update_post_state( WP_REST_Request $request ): string {
-		$post_id = (int) $request->get_param( 'post_id' );
-		$state   = $request->get_param( 'state' );
+		// The URL path post_id is authoritative for the target post; the
+		// permission callback authorises against the same source. Reading it from
+		// get_param() would let a JSON body or query `post_id` re-target the state
+		// change at a post the caller is not authorised to edit (CWE-639).
+		$post_id = $this->get_authorised_post_id( $request );
+
+		// Coerce to strings so a non-string body value cannot raise a TypeError at
+		// the set_liveblog_state() or key-event template sinks.
+		$state           = $request->get_param( 'state' );
+		$state           = is_string( $state ) ? $state : '';
+		$template_name   = $request->get_param( 'template_name' );
+		$template_format = $request->get_param( 'template_format' );
+		$limit           = $request->get_param( 'limit' );
 
 		$request_vars = array(
 			'state'                        => $state,
-			'liveblog-key-template-name'   => $request->get_param( 'template_name' ),
-			'liveblog-key-template-format' => $request->get_param( 'template_format' ),
-			'liveblog-key-limit'           => $request->get_param( 'limit' ),
+			'liveblog-key-template-name'   => is_string( $template_name ) ? $template_name : '',
+			'liveblog-key-template-format' => is_string( $template_format ) ? $template_format : '',
+			'liveblog-key-limit'           => is_scalar( $limit ) ? (string) $limit : '',
 		);
 
 		$this->set_liveblog_vars( $post_id );
@@ -771,6 +788,45 @@ final class RestApiController {
 	 */
 	public function sanitize_numeric( $param, $request, $key ): int { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed -- Required by REST API sanitize_callback signature.
 		return ( ! empty( $param ) && is_numeric( $param ) ? (int) $param : 0 );
+	}
+
+	/**
+	 * Get the authorised target post ID for a write request from the URL path.
+	 *
+	 * Write routes are scoped to the post in the route URL, and the write
+	 * permission callback ({@see current_user_can_edit_liveblog_for_request()})
+	 * authorises against that same value. Handlers must therefore read the post ID
+	 * from the URL path parameters and never from get_param(): WP_REST_Request
+	 * resolves JSON body, POST body, and query-string parameters ahead of URL path
+	 * parameters, so a body or query `post_id` could otherwise re-target the action
+	 * at a post the caller is not authorised to edit (CWE-639).
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return int The post ID from the URL path, or 0 when absent.
+	 */
+	private function get_authorised_post_id( WP_REST_Request $request ): int {
+		$url_params = $request->get_url_params();
+		return isset( $url_params['post_id'] ) ? (int) $url_params['post_id'] : 0;
+	}
+
+	/**
+	 * Normalise contributor IDs from the JSON body to an array of positive ints.
+	 *
+	 * The value arrives verbatim from the decoded JSON body, where it could be a
+	 * scalar or absent rather than the expected array. Anything that is not an
+	 * array becomes `false` (treated downstream as "no contributors"), and array
+	 * members are coerced to positive integers so arbitrary strings cannot be
+	 * persisted as contributor meta.
+	 *
+	 * @param mixed $value The raw contributor_ids value from the JSON body.
+	 * @return array<int>|false The sanitised contributor IDs, or false when absent/invalid.
+	 */
+	private function normalize_contributor_ids( $value ) {
+		if ( ! is_array( $value ) ) {
+			return false;
+		}
+
+		return array_values( array_filter( array_map( 'absint', $value ) ) );
 	}
 
 	/**

--- a/tests/Integration/EntryTest.php
+++ b/tests/Integration/EntryTest.php
@@ -185,6 +185,59 @@ final class EntryTest extends IntegrationTestCase {
 	}
 
 	/**
+	 * Restricted shortcodes nested inside fragments of their own tag must be
+	 * stripped, not reconstructed.
+	 *
+	 * A single replacement pass leaves a working [liveblog_key_events] behind from
+	 * [liveblog_key[liveblog_key_events]_events], which do_shortcode() would then
+	 * execute at render (CWE-94 via CWE-185). The strip must repeat until no valid
+	 * restricted shortcode remains.
+	 */
+	public function test_shortcode_filter_strips_nested_restricted_shortcodes(): void {
+		$shortcode_filter = new ShortcodeFilter();
+		$pattern          = '/' . get_shortcode_regex( array( 'liveblog_key_events' ) ) . '/s';
+
+		$cases = array(
+			'[liveblog_key[liveblog_key_events]_events]',
+			'prefix [liveblog_key[liveblog_key_events]_events] suffix',
+			'[liveblog_key[liveblog_key[liveblog_key_events]_events]_events]',
+		);
+
+		foreach ( $cases as $input ) {
+			$filtered = $shortcode_filter->filter( array( 'content' => $input ) );
+			$this->assertSame( 0, preg_match( $pattern, $filtered['content'] ), 'A valid restricted shortcode survived stripping of: ' . $input );
+		}
+	}
+
+	/**
+	 * Removing one restricted shortcode must not reconstruct a different one.
+	 *
+	 * With more than one restricted tag, stripping [embed] from [gall[embed]ery]
+	 * reconstructs [gallery]; the strip must re-apply the whole set until stable,
+	 * regardless of tag order. The order here ('gallery' before 'embed') is the
+	 * one a per-tag strip would fail to clean.
+	 */
+	public function test_shortcode_filter_strips_cross_tag_reconstruction(): void {
+		$restrict = static function () {
+			return array(
+				'gallery' => '',
+				'embed'   => '',
+			);
+		};
+		add_filter( 'liveblog_entry_restrict_shortcodes', $restrict );
+
+		$filtered = ( new ShortcodeFilter() )->filter( array( 'content' => 'before [gall[embed]ery] after' ) );
+
+		remove_filter( 'liveblog_entry_restrict_shortcodes', $restrict );
+
+		$this->assertSame(
+			0,
+			preg_match( '/' . get_shortcode_regex( array( 'gallery' ) ) . '/s', $filtered['content'] ),
+			'A restricted [gallery] reconstructed from a different restricted tag survived stripping.'
+		);
+	}
+
+	/**
 	 * Insert a liveblog entry using domain service.
 	 *
 	 * @param array $args Arguments for entry.

--- a/tests/Integration/ExtendFeatureAuthorsTest.php
+++ b/tests/Integration/ExtendFeatureAuthorsTest.php
@@ -55,6 +55,39 @@ final class ExtendFeatureAuthorsTest extends IntegrationTestCase {
 	}
 
 	/**
+	 * The author autocomplete must not match the search term against user_email.
+	 *
+	 * Without an explicit search_columns, WP_User_Query searches user_email when
+	 * the term contains an '@', turning the picker into a blind email-existence
+	 * oracle for users holding `edit_posts` (CWE-203). An email-prefix search must
+	 * therefore return nothing, while a nicename / display-name search must still
+	 * resolve the user.
+	 *
+	 * @covers \Automattic\Liveblog\Application\Filter\AuthorFilter::get_authors()
+	 */
+	public function test_get_authors_does_not_match_on_email(): void {
+		$user_id = self::factory()->user->create(
+			array(
+				'role'          => 'author',
+				'user_login'    => 'liveblogeditor',
+				'user_email'    => 'secret.address@example.com',
+				'display_name'  => 'Liveblog Editor',
+				'user_nicename' => 'liveblog-editor',
+			)
+		);
+
+		$filter = new AuthorFilter();
+
+		// An email-prefix search must not reveal the user.
+		$by_email = array_map( 'intval', wp_list_pluck( $filter->get_authors( 'secret.address@example' ), 'id' ) );
+		$this->assertNotContains( (int) $user_id, $by_email, 'Author autocomplete must not match on user_email.' );
+
+		// A legitimate nicename / display-name search must still find the user.
+		$by_name = array_map( 'intval', wp_list_pluck( $filter->get_authors( 'liveblog' ), 'id' ) );
+		$this->assertContains( (int) $user_id, $by_name, 'Author autocomplete should still match on nicename and display name.' );
+	}
+
+	/**
 	 * Defines a test filter to check filters are being executed correctly.
 	 *
 	 * @param mixed $example The example value.

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -910,6 +910,130 @@ final class RestApiTest extends IntegrationTestCase {
 	}
 
 	/**
+	 * A request body `post_id` must not override the URL post_id for the
+	 * post_state route (CWE-639). The permission callback authorises against the
+	 * URL post, so the state change must land on that post, not a victim post
+	 * named in the body.
+	 */
+	public function test_endpoint_update_post_state_body_post_id_cannot_override_url(): void {
+		$victim_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post_id   = $this->create_liveblog_post( array( 'post_author' => $victim_author_id ) );
+
+		$attacker_id      = $this->set_author_user();
+		$attacker_post_id = $this->create_liveblog_post( array( 'post_author' => $attacker_id ) );
+
+		// URL targets the attacker's own post (permission passes); the body tries
+		// to redirect the state change at the victim post.
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $attacker_post_id . '/post_state' );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$request->set_body_params(
+			array(
+				'post_id'         => $victim_post_id,
+				'state'           => 'archive',
+				'template_name'   => 'list',
+				'template_format' => 'full',
+				'limit'           => '5',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertSame( 'enable', get_post_meta( $victim_post_id, LiveblogConfiguration::KEY, true ) );
+		$this->assertSame( 'archive', get_post_meta( $attacker_post_id, LiveblogConfiguration::KEY, true ) );
+	}
+
+	/**
+	 * A caller authorised on their own liveblog must not update an entry that
+	 * belongs to another user's post by supplying that entry's id in the body
+	 * (CWE-639 IDOR, HackerOne #3742849).
+	 */
+	public function test_endpoint_crud_update_denies_entry_on_another_post(): void {
+		$victim_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post_id   = $this->create_liveblog_post( array( 'post_author' => $victim_author_id ) );
+		$victim_entry_id  = $this->insert_entries( 1, array( 'post_id' => $victim_post_id ) )[0]->id()->to_int();
+		$original_content = get_comment( $victim_entry_id )->comment_content;
+
+		$attacker_id      = $this->set_author_user();
+		$attacker_post_id = $this->create_liveblog_post( array( 'post_author' => $attacker_id ) );
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $attacker_post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'crud_action' => 'update',
+					'entry_id'    => $victim_entry_id,
+					'content'     => 'tampered by attacker',
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotEquals( 200, $response->get_status() );
+		$this->assertSame( $original_content, get_comment( $victim_entry_id )->comment_content );
+	}
+
+	/**
+	 * A caller authorised on their own liveblog must not delete an entry that
+	 * belongs to another user's post by supplying that entry's id in the body.
+	 */
+	public function test_endpoint_crud_delete_denies_entry_on_another_post(): void {
+		$victim_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post_id   = $this->create_liveblog_post( array( 'post_author' => $victim_author_id ) );
+		$victim_entry_id  = $this->insert_entries( 1, array( 'post_id' => $victim_post_id ) )[0]->id()->to_int();
+
+		$attacker_id      = $this->set_author_user();
+		$attacker_post_id = $this->create_liveblog_post( array( 'post_author' => $attacker_id ) );
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $attacker_post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'crud_action' => 'delete',
+					'entry_id'    => $victim_entry_id,
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotEquals( 200, $response->get_status() );
+		$comment = get_comment( $victim_entry_id );
+		$this->assertInstanceOf( 'WP_Comment', $comment );
+		$this->assertNotEquals( 'trash', $comment->comment_approved );
+	}
+
+	/**
+	 * A non-string `content`, a non-array `contributor_ids`, and a non-string
+	 * `state` in the request must be coerced rather than reaching a typed sink
+	 * and raising a PHP TypeError / HTTP 500 (CWE-20).
+	 */
+	public function test_endpoint_rejects_malformed_param_types_without_fatal(): void {
+		$author_id = $this->set_author_user();
+		$post_id   = $this->create_liveblog_post( array( 'post_author' => $author_id ) );
+
+		// Array content and a scalar contributor_ids on insert.
+		$crud = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/crud' );
+		$crud->add_header( 'content-type', 'application/json' );
+		$crud->set_body(
+			wp_json_encode(
+				array(
+					'crud_action'     => 'insert',
+					'content'         => array( '<p>array content</p>' ),
+					'contributor_ids' => 'not-an-array',
+				)
+			)
+		);
+		$this->assertEquals( 200, $this->server->dispatch( $crud )->get_status() );
+
+		// Array state on post_state.
+		$state = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/post_state' );
+		$state->add_header( 'content-type', 'application/json' );
+		$state->set_body( wp_json_encode( array( 'state' => array( 'enable' ) ) ) );
+		$this->assertNotEquals( 500, $this->server->dispatch( $state )->get_status() );
+	}
+
+	/**
 	 * Setup entry test state.
 	 *
 	 * @param int   $number_of_entries Number of entries to create.


### PR DESCRIPTION
## Summary

The 2.x rewrite already carried the 1.12.0 post-scoping work, but the hardening that landed on the 1.x line afterwards (#895 plus the four follow-up fixes in #896–#899) was never ported, so the same issues were still live in the rewritten services. A fresh security review of the 2.x branch confirmed each one was present. This PR ports them all, re-expressed against the Domain/Application/Infrastructure layering.

Two of these are the High-severity authorisation bypasses; the other three are lower-severity hardening. They are bundled here because they share files (`RestApiController`, `RestApiTest`), but each is independent and could be split if you would rather review or merge them separately.

### High — cross-post authorisation (CWE-639)

- **Entry-ownership IDOR (HackerOne #3742849), the #895 port.** The CRUD flow authorised the caller against the route/permalink post but then acted on a body-supplied `entry_id` with no check that the entry belonged to that post — so an author could update or delete entries on another user's liveblog. `EntryOperations` now asserts, before any mutation in `execute_update`/`execute_delete`/`execute_delete_key`, that the entry exists, is a `liveblog` comment, and is attached to the authorised post. Putting the guard there rather than in `EntryService` matters: the author/contributor reassignment (`handle_update_metadata`) and the key-event meta strip (`remove_key_action`) run *first*, and it also closes the null-deref that a non-existent `entry_id` previously caused.
- **`post_state` body-overrides-URL IDOR.** `update_post_state` (and `format_preview_entry`) read the post id from `get_param()`, which a JSON body or query value shadows ahead of the URL path. They now read it from the URL through a shared `get_authorised_post_id()` helper, exactly as `crud_entry` already did, so the mutation can never target a post other than the one the permission callback authorised.

### Lower-severity hardening

- **Author autocomplete email oracle (CWE-203).** `AuthorFilter::get_authors` pins `search_columns` to login, nicename, and display name, so the term can never be matched against `user_email` (which `WP_User_Query` otherwise does for any `@`-containing term, turning the picker into a blind email-existence oracle for `edit_posts` users).
- **Restricted-shortcode strip bypass (CWE-94 via CWE-185).** `ShortcodeFilter` re-applies the whole restricted set until the content stabilises, defeating both same-tag (`[liveblog_key[liveblog_key_events]_events]`) and cross-tag (`[gall[embed]ery]` → `[gallery]`) nested reconstruction that a single pass leaves behind.
- **Input coercion (CWE-20).** `crud` content is cast to a string, `contributor_ids` to an array of positive ints, and `post_state`'s `state`/template params to strings, so a malformed body value cannot reach a typed sink and raise a TypeError (HTTP 500).

## Test plan

Seven new integration tests, each verified to fail against the current 2.x code and pass with the fix:

- `RestApiTest`: post_state body-override lands on the URL post not the body post; cross-post `update`/`delete` leave the victim entry intact; malformed content/contributor/state types return without a fatal.
- `ExtendFeatureAuthorsTest`: an email-prefix search returns nothing while a nicename search still resolves the user.
- `EntryTest`: nested and cross-tag restricted shortcodes are fully stripped.

`composer test:integration` — green (272 tests); `phpcs` clean. Full report behind this work: `.context/security-review-2x-2026-06-01.md`.

> One item from the 2.x review is intentionally left out: the admin-ajax state handler verifies a nonce key/action the client never sends. It fails closed (the fallback is simply dead, not exploitable), so I have treated it as a separate correctness bug rather than folding it in here. Happy to fix it in a follow-up.