### PR TITLE
Make the admin-ajax state change verify the nonce the client sends

### DIFF
--- a/src/php/Infrastructure/WordPress/AdminController.php
+++ b/src/php/Infrastructure/WordPress/AdminController.php
@@ -11,6 +11,7 @@ namespace Automattic\Liveblog\Infrastructure\WordPress;
 
 use Automattic\Liveblog\Application\Config\LiveblogConfiguration;
 use Automattic\Liveblog\Application\Aggregate\LiveblogPost;
+use WP_Error;
 use WP_Post;
 use WP_Query;
 
@@ -181,6 +182,70 @@ final class AdminController {
 		}
 
 		return $this->get_meta_box_content( $post );
+	}
+
+	/**
+	 * Handle the admin-ajax liveblog state change request.
+	 *
+	 * Thin wrapper around {@see process_state_change()} that adapts the request
+	 * superglobal and the result to an admin-ajax JSON response. Fallback for
+	 * environments without the REST API.
+	 *
+	 * @return void
+	 */
+	public function handle_state_change_ajax(): void {
+		// Nonce and capability are verified inside process_state_change(); the
+		// whole request is forwarded so no single key is read here.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Verified in process_state_change().
+		$result = $this->process_state_change( (array) wp_unslash( $_REQUEST ) );
+
+		if ( is_wp_error( $result ) ) {
+			wp_send_json_error( $result->get_error_message() );
+		}
+
+		wp_send_json_success( $result );
+	}
+
+	/**
+	 * Validate and apply an admin-ajax liveblog state change.
+	 *
+	 * Verifies the nonce the editor client actually sends — the `NONCE_KEY`
+	 * (`_wpnonce`) request value carrying a `NONCE_ACTION` (`wp_rest`) nonce, as
+	 * localised by AssetManager and the same nonce the REST path uses — then
+	 * re-checks `edit_post` on the target post before changing its state.
+	 *
+	 * The flow takes the request data as an argument (rather than reading the
+	 * superglobal) so it is testable without the ajax response/die machinery, and
+	 * so the nonce contract cannot silently drift from the client again. The
+	 * previous handler verified a key/action (`_ajax_nonce` / `liveblog_admin_nonce`)
+	 * that the client never sends, so the fallback always failed the nonce check.
+	 *
+	 * @param array $request The unslashed request data.
+	 * @return string|WP_Error The meta box markup on success, or a WP_Error.
+	 */
+	public function process_state_change( array $request ) {
+		$nonce = isset( $request[ LiveblogConfiguration::NONCE_KEY ] )
+			? sanitize_text_field( (string) $request[ LiveblogConfiguration::NONCE_KEY ] )
+			: '';
+
+		if ( ! wp_verify_nonce( $nonce, LiveblogConfiguration::NONCE_ACTION ) ) {
+			return new WP_Error( 'invalid_nonce', __( 'Invalid nonce', 'liveblog' ) );
+		}
+
+		$post_id = isset( $request['post_id'] ) ? (int) $request['post_id'] : 0;
+
+		if ( ! self::current_user_can_edit_for_post( $post_id ) ) {
+			return new WP_Error( 'unauthorized', __( 'Unauthorized', 'liveblog' ) );
+		}
+
+		$new_state = isset( $request['state'] ) ? sanitize_text_field( (string) $request['state'] ) : '';
+
+		$result = $this->set_liveblog_state( $post_id, $new_state, $request );
+		if ( false === $result ) {
+			return new WP_Error( 'update_failed', __( 'Failed to update state', 'liveblog' ) );
+		}
+
+		return $result;
 	}
 
 	/**

--- a/src/php/Infrastructure/WordPress/PluginBootstrapper.php
+++ b/src/php/Infrastructure/WordPress/PluginBootstrapper.php
@@ -554,33 +554,10 @@ final class PluginBootstrapper {
 		// Add meta box.
 		add_action( 'add_meta_boxes', array( $admin_controller, 'add_meta_box' ) );
 
-		// Handle AJAX state change.
+		// Handle AJAX state change (fallback when the REST API is unavailable).
 		add_action(
 			'wp_ajax_set_liveblog_state_for_post',
-			function () use ( $admin_controller ) {
-				// Verify nonce first.
-				$nonce = isset( $_REQUEST['_ajax_nonce'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified below.
-					? sanitize_text_field( wp_unslash( $_REQUEST['_ajax_nonce'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					: '';
-
-				if ( ! wp_verify_nonce( $nonce, 'liveblog_admin_nonce' ) ) {
-					wp_send_json_error( 'Invalid nonce' );
-				}
-
-				// Now safe to access other request data.
-				$post_id   = isset( $_REQUEST['post_id'] ) ? (int) $_REQUEST['post_id'] : 0;
-				$new_state = isset( $_REQUEST['state'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['state'] ) ) : '';
-
-				if ( ! AdminController::current_user_can_edit_for_post( $post_id ) ) {
-					wp_send_json_error( 'Unauthorized' );
-				}
-
-				$result = $admin_controller->set_liveblog_state( $post_id, $new_state, $_REQUEST );
-				if ( false === $result ) {
-					wp_send_json_error( 'Failed to update state' );
-				}
-				wp_send_json_success( $result );
-			}
+			array( $admin_controller, 'handle_state_change_ajax' )
 		);
 
 		// Admin list filters.

--- a/tests/Integration/AdminControllerTest.php
+++ b/tests/Integration/AdminControllerTest.php
@@ -9,7 +9,10 @@ declare( strict_types=1 );
 
 namespace Automattic\Liveblog\Tests\Integration;
 
+use Automattic\Liveblog\Application\Config\LiveblogConfiguration;
+use Automattic\Liveblog\Infrastructure\DI\Container;
 use Automattic\Liveblog\Infrastructure\WordPress\AdminController;
+use WP_Error;
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 
 /**
@@ -124,5 +127,77 @@ final class AdminControllerTest extends TestCase {
 		remove_filter( 'liveblog_current_user_can_edit_liveblog', '__return_false' );
 
 		$this->assertFalse( $result );
+	}
+
+	/**
+	 * The admin-ajax state change accepts the nonce the editor client actually
+	 * sends — the NONCE_KEY request value carrying a NONCE_ACTION nonce — and
+	 * applies the state change.
+	 *
+	 * Regression guard for the previous handler, which verified a key/action
+	 * (`_ajax_nonce` / `liveblog_admin_nonce`) the client never sends, so the
+	 * admin-ajax fallback always failed the nonce check.
+	 */
+	public function test_process_state_change_accepts_client_nonce_and_applies_state(): void {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+		$post_id = self::factory()->post->create( array( 'post_author' => $editor_id ) );
+
+		$result = Container::instance()->admin_controller()->process_state_change(
+			array(
+				LiveblogConfiguration::NONCE_KEY => wp_create_nonce( LiveblogConfiguration::NONCE_ACTION ),
+				'post_id'                        => $post_id,
+				'state'                          => 'enable',
+			)
+		);
+
+		$this->assertIsString( $result );
+		$this->assertSame( 'enable', get_post_meta( $post_id, LiveblogConfiguration::KEY, true ) );
+	}
+
+	/**
+	 * A request with a missing or invalid nonce is rejected and does not change
+	 * the liveblog state.
+	 */
+	public function test_process_state_change_rejects_invalid_nonce(): void {
+		$editor_id = self::factory()->user->create( array( 'role' => 'editor' ) );
+		wp_set_current_user( $editor_id );
+		$post_id = self::factory()->post->create( array( 'post_author' => $editor_id ) );
+
+		$result = Container::instance()->admin_controller()->process_state_change(
+			array(
+				LiveblogConfiguration::NONCE_KEY => 'not-a-valid-nonce',
+				'post_id'                        => $post_id,
+				'state'                          => 'enable',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'invalid_nonce', $result->get_error_code() );
+		$this->assertSame( '', get_post_meta( $post_id, LiveblogConfiguration::KEY, true ) );
+	}
+
+	/**
+	 * A valid nonce from a user who cannot edit the target post is still
+	 * rejected by the post-scoped capability check, and the state is unchanged.
+	 */
+	public function test_process_state_change_rejects_non_owner(): void {
+		$owner_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id  = self::factory()->post->create( array( 'post_author' => $owner_id ) );
+
+		$attacker_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		wp_set_current_user( $attacker_id );
+
+		$result = Container::instance()->admin_controller()->process_state_change(
+			array(
+				LiveblogConfiguration::NONCE_KEY => wp_create_nonce( LiveblogConfiguration::NONCE_ACTION ),
+				'post_id'                        => $post_id,
+				'state'                          => 'enable',
+			)
+		);
+
+		$this->assertInstanceOf( WP_Error::class, $result );
+		$this->assertSame( 'unauthorized', $result->get_error_code() );
+		$this->assertSame( '', get_post_meta( $post_id, LiveblogConfiguration::KEY, true ) );
 	}
 }


### PR DESCRIPTION
## Summary

The admin-ajax fallback that toggles liveblog state (used when the REST API is unavailable) verified the nonce under the key `_ajax_nonce` against the action `liveblog_admin_nonce`. Nothing in the plugin produces either of those: `AssetManager` localises, and `src/admin/index.js` sends, the `NONCE_KEY` (`_wpnonce`) request value carrying a `NONCE_ACTION` (`wp_rest`) nonce — the very same nonce the REST path uses. So `wp_verify_nonce()` ran against an empty string and the wrong action on every request, and the handler always returned “Invalid nonce”.

This fails *closed* — the fallback simply never worked, so it is a correctness bug rather than a vulnerability — but it means the non-REST path was dead. It surfaced in the 2.x security review alongside the issues fixed in #903 and was deliberately deferred to here.

The fix verifies the nonce the client actually sends. Rather than read a single named key inside the hook closure (which is where the contract drifted and which could not be tested), the logic now lives in `AdminController::process_state_change()`: a method that takes the request data as an argument, picks `NONCE_KEY` out of it, verifies it against `NONCE_ACTION`, re-checks `edit_post` on the target post, and returns the new meta box markup or a `WP_Error`. `handle_state_change_ajax()` becomes a thin wrapper that forwards the whole request and renders the JSON response. Because the wrapper forwards everything and the tested method chooses the key, the class of bug — glue reading a key the client never sends — can't recur.

## Test plan

Three integration tests on `process_state_change()`:

- a `NONCE_KEY`/`NONCE_ACTION` nonce (what the client sends) is accepted and the state is applied;
- a missing/invalid nonce is rejected and the state is unchanged;
- a valid nonce from a non-owner is still rejected by the post-scoped capability check.

The first was verified to fail against the old `_ajax_nonce`/`liveblog_admin_nonce` contract and pass with the fix. `composer test:integration` — green (277 tests); `phpcs` clean.