### PR TITLE
Release 1.12.1

### DIFF
--- a/.github/workflows/cs-lint.yml
+++ b/.github/workflows/cs-lint.yml
@@ -28,7 +28,7 @@ jobs:
 
     steps:
       - name: Setup PHP
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: "7.4"
           coverage: none

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -41,7 +41,7 @@ jobs:
         run: npm install -g @wordpress/env
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php }}
           extensions: ${{ matrix.extensions }}

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -29,7 +29,7 @@ jobs:
           persist-credentials: false
 
       - name: Setup PHP ${{ matrix.php }}
-        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
+        uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # 2.37.1
         with:
           php-version: ${{ matrix.php }}
           tools: composer

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Real-time liveblogging plugin for WordPress with a React-based editor and a comm
 |----------|-------|
 | **Main file** | `liveblog.php` |
 | **Text domain** | `liveblog` |
-| **Version** | 1.12.0 |
+| **Version** | 1.12.1 |
 | **Requires PHP** | 7.4+ |
 | **Requires WP** | 6.4+ |
 | **Default branch** | `develop` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## [1.12.1] - 2026-06-02
+
+### Security
+
+* fix: bind liveblog entry CRUD to the authorised post by @GaryJones in https://github.com/Automattic/liveblog/pull/895 (CWE-639 IDOR)
+* fix: bind the post_state write route to the URL post by @GaryJones in https://github.com/Automattic/liveblog/pull/896 (CWE-639 IDOR)
+* fix: stop the author autocomplete matching on email by @GaryJones in https://github.com/Automattic/liveblog/pull/897 (CWE-203 information exposure)
+* fix: strip nested restricted shortcodes idempotently by @GaryJones in https://github.com/Automattic/liveblog/pull/898 (CWE-94 via CWE-185)
+* fix: coerce REST entry content to a string by @GaryJones in https://github.com/Automattic/liveblog/pull/899 (CWE-20)
+
+### Maintenance
+
+* npm(deps): bump qs and express by @dependabot in https://github.com/Automattic/liveblog/pull/893
+* npm(deps): bump js-cookie from 3.0.5 to 3.0.7 by @dependabot in https://github.com/Automattic/liveblog/pull/892
+* Actions(deps): bump shivammathur/setup-php from 2.37.0 to 2.37.1 in the actions group by @dependabot in https://github.com/Automattic/liveblog/pull/891
+* npm(deps-dev): bump axios from 1.15.0 to 1.16.1 by @dependabot in https://github.com/Automattic/liveblog/pull/890
+* npm(deps-dev): bump @babel/plugin-transform-modules-systemjs from 7.28.5 to 7.29.4 by @dependabot in https://github.com/Automattic/liveblog/pull/888
+* npm(deps-dev): bump fast-uri from 3.1.0 to 3.1.2 by @dependabot in https://github.com/Automattic/liveblog/pull/887
+* npm(deps-dev): bump ip-address from 10.1.0 to 10.2.0 by @dependabot in https://github.com/Automattic/liveblog/pull/885
+* npm(deps): bump @lexical/list from 0.43.0 to 0.44.0 by @dependabot in https://github.com/Automattic/liveblog/pull/884
+* npm(deps-dev): bump the dev-dependencies group with 2 updates by @dependabot in https://github.com/Automattic/liveblog/pull/883
+* npm(deps): bump @lexical/rich-text from 0.43.0 to 0.44.0 by @dependabot in https://github.com/Automattic/liveblog/pull/882
+* npm(deps): bump @lexical/link from 0.43.0 to 0.44.0 by @dependabot in https://github.com/Automattic/liveblog/pull/881
+* npm(deps): bump lexical from 0.43.0 to 0.44.0 by @dependabot in https://github.com/Automattic/liveblog/pull/880
+* npm(deps): bump @lexical/react from 0.43.0 to 0.44.0 by @dependabot in https://github.com/Automattic/liveblog/pull/879
+* npm(deps): bump @lexical/html from 0.43.0 to 0.44.0 by @dependabot in https://github.com/Automattic/liveblog/pull/878
+* npm(deps-dev): bump postcss from 8.5.6 to 8.5.12 by @dependabot in https://github.com/Automattic/liveblog/pull/877
+
 ## [1.12.0] - 2026-04-27
 
 **Breaking change (security fix):** The pre-1.12.0 `/liveblog/v1/authors/<term>` and `/liveblog/v1/hashtags/<term>` REST routes, and the matching admin-ajax `liveblog_authors` and `liveblog_terms` actions, only checked a global capability. That allowed any user holding `publish_posts` to enumerate every editor on the site and every entry in the `hashtags` taxonomy, regardless of which post — if any — they were editing (CWE-863). Closing that gap requires scoping the permission check to a specific post, which forces the post id to appear in the URL or the query string. The new shapes are `/liveblog/v1/<post_id>/authors/<term>`, `/liveblog/v1/<post_id>/hashtags/<term>`, and `admin-ajax.php?action=liveblog_authors&post_id=…` (likewise for `liveblog_terms`). The bundled JavaScript client has been updated. Anything else calling these endpoints — bespoke integrations, custom blocks, headless clients — needs to be updated to include the target post id.
@@ -326,6 +354,7 @@ Fixed problems:
 * Initial release
 
 
+[1.12.1]: https://github.com/Automattic/liveblog/compare/1.12.0...1.12.1
 [1.12.0]: https://github.com/Automattic/liveblog/compare/1.11.1...1.12.0
 [1.11.1]: https://github.com/Automattic/liveblog/compare/1.11.0...1.11.1
 [1.11.0]: https://github.com/Automattic/liveblog/compare/1.10.0...1.11.0

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tags: liveblog, live blog, real-time, news, sports
 Requires at least: 6.4  
 Requires PHP: 7.4  
 Tested up to: 6.9  
-Stable tag: 1.12.0  
+Stable tag: 1.12.1  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/classes/class-wpcom-liveblog-entry-extend-feature-authors.php
+++ b/classes/class-wpcom-liveblog-entry-extend-feature-authors.php
@@ -267,6 +267,14 @@ class WPCOM_Liveblog_Entry_Extend_Feature_Authors extends WPCOM_Liveblog_Entry_E
 		// If there is a search term, append '*' to match chars after the term.
 		if ( strlen( trim( $term ) ) > 0 ) {
 			$args['search'] = $term . '*';
+
+			// Restrict the search to non-PII columns. Without an explicit
+			// search_columns, WP_User_Query matches the term against user_email
+			// (exclusively when the term contains an '@'), which turns this
+			// autocomplete into a blind email-existence oracle for users holding
+			// `edit_posts` (CWE-203). The picker only ever needs to match on
+			// login, nicename, and display name.
+			$args['search_columns'] = array( 'user_login', 'user_nicename', 'display_name' );
 		}
 
 		// Map the authors into the expected format.

--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -403,6 +403,11 @@ class WPCOM_Liveblog_Entry {
 			return new WP_Error( 'entry-delete', __( 'Missing entry ID', 'liveblog' ) );
 		}
 
+		$entry_post_check = self::validate_entry_belongs_to_post( $args );
+		if ( is_wp_error( $entry_post_check ) ) {
+			return $entry_post_check;
+		}
+
 		// Always use the original author for the update entry, otherwise until refresh
 		// users will see the user who edited the entry as the author.
 		$args['user'] = self::user_object_from_comment_id( $args['entry_id'] );
@@ -447,6 +452,12 @@ class WPCOM_Liveblog_Entry {
 		if ( ! $args['entry_id'] ) {
 			return new WP_Error( 'entry-delete', __( 'Missing entry ID', 'liveblog' ) );
 		}
+
+		$entry_post_check = self::validate_entry_belongs_to_post( $args );
+		if ( is_wp_error( $entry_post_check ) ) {
+			return $entry_post_check;
+		}
+
 		$args['content'] = '';
 		$comment         = self::insert_comment( $args );
 		if ( is_wp_error( $comment ) ) {
@@ -485,10 +496,52 @@ class WPCOM_Liveblog_Entry {
 			return new WP_Error( 'entry-delete', __( 'Missing entry ID', 'liveblog' ) );
 		}
 
+		// Guard before remove_key_action() runs: it deletes comment meta on the
+		// referenced entry, so the post-binding check must happen first.
+		$entry_post_check = self::validate_entry_belongs_to_post( $args );
+		if ( is_wp_error( $entry_post_check ) ) {
+			return $entry_post_check;
+		}
+
 		$args['content'] = WPCOM_Liveblog_Entry_Key_Events::remove_key_action( $args['content'], $args['entry_id'] );
 
 		$entry = self::update( $args );
 		return $entry;
+	}
+
+	/**
+	 * Verify that the entry being mutated belongs to the authorised post.
+	 *
+	 * The CRUD entry points authorise the caller against the post id taken from
+	 * the route URL (REST) or the permalink (admin-ajax), but the entry id
+	 * arrives separately in the request body and is not re-validated against
+	 * that post. Without binding the two together, a caller authorised to edit
+	 * their own liveblog can pass the entry id of an entry belonging to another
+	 * user's post and have the update/delete sink mutate it (CWE-639 IDOR,
+	 * HackerOne #3742849, an incomplete-fix follow-up to the 1.12.0 post-scoped
+	 * authorisation work).
+	 *
+	 * The entry must exist, be a liveblog entry (so the endpoint cannot be used
+	 * to trash arbitrary non-liveblog comments), and be attached to the
+	 * authorised post. The error message is deliberately generic so the endpoint
+	 * cannot be used to probe for entries on other posts.
+	 *
+	 * @param array $args The entry properties. Requires `entry_id` and `post_id`.
+	 * @return true|WP_Error True when the entry belongs to the post, otherwise an error.
+	 */
+	private static function validate_entry_belongs_to_post( $args ) {
+		$post_id = isset( $args['post_id'] ) ? (int) $args['post_id'] : 0;
+		$comment = get_comment( $args['entry_id'] );
+
+		if (
+			$comment instanceof WP_Comment
+			&& 'liveblog' === $comment->comment_type
+			&& (int) $comment->comment_post_ID === $post_id
+		) {
+			return true;
+		}
+
+		return new WP_Error( 'entry-not-found', __( 'Entry not found in this liveblog.', 'liveblog' ) );
 	}
 
 	/**

--- a/classes/class-wpcom-liveblog-entry.php
+++ b/classes/class-wpcom-liveblog-entry.php
@@ -626,16 +626,28 @@ class WPCOM_Liveblog_Entry {
 		// Runs the restricted shortcode array through the filter before being applied.
 		self::$restricted_shortcodes = apply_filters( 'liveblog_entry_restrict_shortcodes', self::$restricted_shortcodes );
 
-		// For each lookup key, does it exist in the content.
+		// Strip every restricted shortcode, re-applying the whole set until the
+		// content stabilises. A single pass is bypassable by nesting a restricted
+		// shortcode inside fragments of a tag name, so that removing the inner
+		// match reconstructs a working shortcode. That happens both within one tag
+		// (`[liveblog_key[liveblog_key_events]_events]` -> `[liveblog_key_events]`)
+		// and across tags when more than one is restricted (removing `[embed]`
+		// from `[gall[embed]ery]` reconstructs `[gallery]`). Looping the whole set
+		// rather than each tag in isolation removes the order dependence between
+		// tags. The loop only continues while the content strictly shrinks, so a
+		// replacement that is the same length or longer than the match (an unusual
+		// configuration) cannot make it spin.
 		if ( is_array( self::$restricted_shortcodes ) ) {
-			foreach ( self::$restricted_shortcodes as $key => $value ) {
+			do {
+				$previous = $args['content'];
 
-				// Regex pattern will match all shortcode formats.
-				$pattern = get_shortcode_regex( array( $key ) );
+				foreach ( self::$restricted_shortcodes as $key => $value ) {
+					$pattern         = '/' . get_shortcode_regex( array( $key ) ) . '/s';
+					$args['content'] = preg_replace( $pattern, $value, $args['content'] );
+				}
 
-				// If there's a match we replace it with the configured replacement.
-				$args['content'] = preg_replace( '/' . $pattern . '/s', $value, $args['content'] );
-			}
+				$shrank = ( null !== $args['content'] && strlen( $args['content'] ) < strlen( $previous ) );
+			} while ( $shrank );
 		}
 
 		// Return the original entry arguments with any modifications.

--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -472,9 +472,8 @@ class WPCOM_Liveblog_Rest_Api {
 	 * @return true|WP_Error True when the request is permitted, otherwise a 403 error.
 	 */
 	public static function can_edit_liveblog_entries( WP_REST_Request $request ) {
-		$url_params = $request->get_url_params();
-		$post_id    = isset( $url_params['post_id'] ) ? (int) $url_params['post_id'] : 0;
-		$post       = $post_id > 0 ? get_post( $post_id ) : null;
+		$post_id = self::get_authorised_post_id( $request );
+		$post    = $post_id > 0 ? get_post( $post_id ) : null;
 
 		$allowed = ( $post instanceof WP_Post && current_user_can( 'edit_post', $post_id ) );
 
@@ -490,6 +489,25 @@ class WPCOM_Liveblog_Rest_Api {
 			__( 'Sorry, you are not allowed to edit this liveblog.', 'liveblog' ),
 			array( 'status' => rest_authorization_required_code() )
 		);
+	}
+
+	/**
+	 * Get the authorised target post ID for a write request from the URL path.
+	 *
+	 * Write routes are scoped to the post in the route URL, and the write
+	 * permission callback ({@see can_edit_liveblog_entries()}) authorises against
+	 * that same value. Handlers must therefore read the post ID from the URL path
+	 * parameters and never from get_param(): WP_REST_Request::get_param() resolves
+	 * JSON body, POST body, and query-string parameters ahead of URL path
+	 * parameters, so a body or query `post_id` could otherwise re-target the action
+	 * at a post the caller is not authorised to edit (CWE-639).
+	 *
+	 * @param WP_REST_Request $request The REST request.
+	 * @return int The post ID from the URL path, or 0 when absent.
+	 */
+	private static function get_authorised_post_id( WP_REST_Request $request ) {
+		$url_params = $request->get_url_params();
+		return isset( $url_params['post_id'] ) ? (int) $url_params['post_id'] : 0;
 	}
 
 	/**
@@ -534,8 +552,7 @@ class WPCOM_Liveblog_Rest_Api {
 		// The URL path post_id is authoritative for the target post; the permission
 		// callback uses the same source. JSON body `post_id` is ignored so a caller
 		// cannot target a different post than the one authorised by the route.
-		$url_params = $request->get_url_params();
-		$post_id    = isset( $url_params['post_id'] ) ? (int) $url_params['post_id'] : 0;
+		$post_id = self::get_authorised_post_id( $request );
 
 		$args = array(
 			'post_id'         => $post_id,
@@ -614,8 +631,9 @@ class WPCOM_Liveblog_Rest_Api {
 	 */
 	public static function format_preview_entry( WP_REST_Request $request ) {
 
-		// Get required parameters from the request.
-		$post_id       = $request->get_param( 'post_id' );
+		// The URL path post_id is authoritative; read it from the same source as the
+		// permission callback so a body/query value cannot change the post context.
+		$post_id       = self::get_authorised_post_id( $request );
 		$json          = $request->get_json_params();
 		$entry_content = self::get_json_param( 'entry_content', $json );
 
@@ -677,8 +695,11 @@ class WPCOM_Liveblog_Rest_Api {
 	 */
 	public static function update_post_state( WP_REST_Request $request ) {
 
-		// Get required parameters from the request.
-		$post_id = $request->get_param( 'post_id' );
+		// The URL path post_id is authoritative for the target post; the permission
+		// callback authorises against the same source. Reading it from get_param()
+		// would let a JSON body or query `post_id` re-target the state change at a
+		// post the caller is not authorised to edit (CWE-639).
+		$post_id = self::get_authorised_post_id( $request );
 		$state   = $request->get_param( 'state' );
 
 		// Additional request variables used in the liveblog_admin_settings_update action.

--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -556,7 +556,7 @@ class WPCOM_Liveblog_Rest_Api {
 
 		$args = array(
 			'post_id'         => $post_id,
-			'content'         => self::get_json_param( 'content', $json ),
+			'content'         => self::coerce_content_to_string( self::get_json_param( 'content', $json ) ),
 			'entry_id'        => self::get_json_param( 'entry_id', $json ),
 			'author_id'       => self::get_json_param( 'author_id', $json ),
 			'contributor_ids' => self::get_json_param( 'contributor_ids', $json ),
@@ -635,7 +635,7 @@ class WPCOM_Liveblog_Rest_Api {
 		// permission callback so a body/query value cannot change the post context.
 		$post_id       = self::get_authorised_post_id( $request );
 		$json          = $request->get_json_params();
-		$entry_content = self::get_json_param( 'entry_content', $json );
+		$entry_content = self::coerce_content_to_string( self::get_json_param( 'entry_content', $json ) );
 
 		self::set_liveblog_vars( $post_id );
 
@@ -847,5 +847,23 @@ class WPCOM_Liveblog_Rest_Api {
 			return $json[ $param ];
 		}
 		return false;
+	}
+
+	/**
+	 * Coerce a free-form entry content value from the JSON body to a string.
+	 *
+	 * The `content` and `entry_content` parameters are read straight from the
+	 * decoded JSON body, which can supply an array or object. Such a value would
+	 * otherwise flow unchanged into `wp_filter_post_kses()` and raise a TypeError
+	 * (HTTP 500) on PHP 8. Casting non-scalars to an empty string mirrors the
+	 * coercion the legacy admin-ajax path performs via `sanitize_text_field()`,
+	 * so both entry points behave the same. A missing value (`get_json_param()`
+	 * returns false) likewise becomes an empty string.
+	 *
+	 * @param mixed $content The raw content value from the JSON body.
+	 * @return string The content as a string.
+	 */
+	private static function coerce_content_to_string( $content ) {
+		return is_scalar( $content ) ? (string) $content : '';
 	}
 }

--- a/languages/liveblog.pot
+++ b/languages/liveblog.pot
@@ -2,22 +2,22 @@
 # This file is distributed under the same license as the Liveblog plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Liveblog 1.12.0\n"
+"Project-Id-Version: Liveblog 1.12.1\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/liveblog\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-27T16:51:52+00:00\n"
+"POT-Creation-Date: 2026-06-02T12:43:58+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: liveblog\n"
 
 #. Plugin Name of the plugin
 #: liveblog.php
-#: liveblog.php:1604
-#: liveblog.php:1840
+#: liveblog.php:1607
+#: liveblog.php:1843
 msgid "Liveblog"
 msgstr ""
 
@@ -124,27 +124,31 @@ msgid "Save"
 msgstr ""
 
 #: classes/class-wpcom-liveblog-entry.php:403
-#: classes/class-wpcom-liveblog-entry.php:448
-#: classes/class-wpcom-liveblog-entry.php:485
+#: classes/class-wpcom-liveblog-entry.php:453
+#: classes/class-wpcom-liveblog-entry.php:496
 msgid "Missing entry ID"
 msgstr ""
 
-#: classes/class-wpcom-liveblog-entry.php:520
+#: classes/class-wpcom-liveblog-entry.php:544
+msgid "Entry not found in this liveblog."
+msgstr ""
+
+#: classes/class-wpcom-liveblog-entry.php:573
 msgid "Error posting entry"
 msgstr ""
 
-#: classes/class-wpcom-liveblog-entry.php:524
-#: classes/class-wpcom-liveblog-entry.php:555
+#: classes/class-wpcom-liveblog-entry.php:577
+#: classes/class-wpcom-liveblog-entry.php:608
 msgid "Error retrieving comment"
 msgstr ""
 
 #. translators: 1: argument.
-#: classes/class-wpcom-liveblog-entry.php:540
+#: classes/class-wpcom-liveblog-entry.php:593
 #, php-format
 msgid "Missing entry argument: %s"
 msgstr ""
 
-#: classes/class-wpcom-liveblog-entry.php:559
+#: classes/class-wpcom-liveblog-entry.php:612
 msgid "Error retrieving user"
 msgstr ""
 
@@ -152,7 +156,7 @@ msgstr ""
 msgid "Liveblog not found."
 msgstr ""
 
-#: classes/class-wpcom-liveblog-rest-api.php:490
+#: classes/class-wpcom-liveblog-rest-api.php:489
 msgid "Sorry, you are not allowed to edit this liveblog."
 msgstr ""
 
@@ -174,181 +178,181 @@ msgstr ""
 msgid "Unable to connect to the server to get new entries"
 msgstr ""
 
-#: liveblog.php:511
+#: liveblog.php:514
 msgid "No Liveblog post ID is set yet"
 msgstr ""
 
-#: liveblog.php:637
+#: liveblog.php:640
 msgid "A timestamp is missing. Correct URL: <permalink>/liveblog/<from>/</to>/"
 msgstr ""
 
 #. translators: 1: crud action.
-#: liveblog.php:833
+#: liveblog.php:836
 #, php-format
 msgid "Invalid entry crud_action: %s"
 msgstr ""
 
-#: liveblog.php:1205
+#: liveblog.php:1208
 msgid "Unknown liveblog action"
 msgstr ""
 
-#: liveblog.php:1259
-#: liveblog.php:1366
+#: liveblog.php:1262
+#: liveblog.php:1369
 msgid "Error {error-code}: {error-message}"
 msgstr ""
 
-#: liveblog.php:1260
-#: liveblog.php:1367
+#: liveblog.php:1263
+#: liveblog.php:1370
 msgid "Error: {error-message}"
 msgstr ""
 
-#: liveblog.php:1364
+#: liveblog.php:1367
 msgid "Do you really want to delete this entry? There is no way back."
 msgstr ""
 
-#: liveblog.php:1365
+#: liveblog.php:1368
 msgid "Do you want to delete this key entry?"
 msgstr ""
 
-#: liveblog.php:1368
+#: liveblog.php:1371
 msgid "Liveblog: {number} new update"
 msgstr ""
 
-#: liveblog.php:1369
+#: liveblog.php:1372
 msgid "Liveblog: {number} new updates"
 msgstr ""
 
-#: liveblog.php:1370
+#: liveblog.php:1373
 msgid "Provide URL for link:"
 msgstr ""
 
-#: liveblog.php:1373
+#: liveblog.php:1376
 msgid "term-"
 msgstr ""
 
-#: liveblog.php:1374
+#: liveblog.php:1377
 msgid "type-alert"
 msgstr ""
 
-#: liveblog.php:1375
+#: liveblog.php:1378
 msgid "type-key"
 msgstr ""
 
-#: liveblog.php:1392
+#: liveblog.php:1395
 msgid "Loading preview…"
 msgstr ""
 
-#: liveblog.php:1393
+#: liveblog.php:1396
 msgid "New Entry"
 msgstr ""
 
-#: liveblog.php:1394
+#: liveblog.php:1397
 #: src/react/containers/EditorContainer.js:357
 msgid "Publish Update"
 msgstr ""
 
-#: liveblog.php:1395
+#: liveblog.php:1398
 msgid "Edit Entry"
 msgstr ""
 
-#: liveblog.php:1396
+#: liveblog.php:1399
 msgid "Update"
 msgstr ""
 
-#: liveblog.php:1419
+#: liveblog.php:1422
 msgid "Allowed Files"
 msgstr ""
 
-#: liveblog.php:1644
+#: liveblog.php:1647
 msgid "Visit the liveblog &rarr;"
 msgstr ""
 
-#: liveblog.php:1650
+#: liveblog.php:1653
 msgid "Enable"
 msgstr ""
 
-#: liveblog.php:1651
+#: liveblog.php:1654
 msgid "Enables liveblog on this post. Posting tools are enabled for editors, visitors get the latest updates."
 msgstr ""
 
 #. translators: %s: optional link to view the liveblog
-#: liveblog.php:1654
+#: liveblog.php:1657
 #, php-format
 msgid "There is an <strong>enabled</strong> liveblog on this post.%s"
 msgstr ""
 
-#: liveblog.php:1662
+#: liveblog.php:1665
 msgid "Archive"
 msgstr ""
 
-#: liveblog.php:1663
+#: liveblog.php:1666
 msgid "Archives the liveblog on this post. Visitors still see the liveblog entries, but posting tools are hidden."
 msgstr ""
 
 #. translators: %s: optional link to view the liveblog archive
-#: liveblog.php:1666
+#: liveblog.php:1669
 #, php-format
 msgid "There is an <strong>archived</strong> liveblog on this post.%s"
 msgstr ""
 
-#: liveblog.php:1674
+#: liveblog.php:1677
 msgid "Disable"
 msgstr ""
 
-#: liveblog.php:1675
+#: liveblog.php:1678
 msgid "Removes liveblog from this post. Existing entries are kept as comments."
 msgstr ""
 
-#: liveblog.php:1685
+#: liveblog.php:1688
 msgid "This is a normal WordPress post, without a liveblog."
 msgstr ""
 
-#: liveblog.php:1689
+#: liveblog.php:1692
 msgid "Settings have been successfully updated."
 msgstr ""
 
 #. translators: 1: post ID.
-#: liveblog.php:1715
+#: liveblog.php:1718
 #, php-format
 msgid "The post is a revision: %s"
 msgstr ""
 
 #. translators: 1: post ID.
-#: liveblog.php:1719
+#: liveblog.php:1722
 #, php-format
 msgid "Non-existing post ID: %s"
 msgstr ""
 
-#: liveblog.php:1842
+#: liveblog.php:1845
 msgid "Liveblog (archived)"
 msgstr ""
 
-#: liveblog.php:1873
+#: liveblog.php:1876
 msgid "Filter liveblogs"
 msgstr ""
 
-#: liveblog.php:1874
+#: liveblog.php:1877
 msgid "Any liveblogs"
 msgstr ""
 
-#: liveblog.php:1875
+#: liveblog.php:1878
 msgid "Enabled liveblogs"
 msgstr ""
 
-#: liveblog.php:1876
+#: liveblog.php:1879
 msgid "Archived liveblogs"
 msgstr ""
 
-#: liveblog.php:1877
+#: liveblog.php:1880
 msgid "No liveblogs"
 msgstr ""
 
-#: liveblog.php:1950
-#: liveblog.php:1985
+#: liveblog.php:1953
+#: liveblog.php:1988
 msgid "Cheatin', uh?"
 msgstr ""
 
-#: liveblog.php:1997
+#: liveblog.php:2000
 msgid "Sorry, we could not authenticate you."
 msgstr ""
 

--- a/liveblog.php
+++ b/liveblog.php
@@ -388,9 +388,12 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			add_filter( 'is_protected_meta', array( __CLASS__, 'protect_liveblog_meta_key' ), 10, 2 );
 
 			// Add In the Filter hooks to Strip any Restricted Shortcodes before a new post or updating a post.
-			// Called from the WPCOM_Liveblog_Entry Class.
+			// Called from the WPCOM_Liveblog_Entry Class. Preview is included so the
+			// rendered preview matches what would be stored, and so the restriction
+			// cannot be sidestepped by rendering through the preview endpoint.
 			add_filter( 'liveblog_before_insert_entry', array( 'WPCOM_Liveblog_Entry', 'handle_restricted_shortcodes' ), 10, 1 );
 			add_filter( 'liveblog_before_update_entry', array( 'WPCOM_Liveblog_Entry', 'handle_restricted_shortcodes' ), 10, 1 );
+			add_filter( 'liveblog_before_preview_entry', array( 'WPCOM_Liveblog_Entry', 'handle_restricted_shortcodes' ), 10, 1 );
 
 			// We need to check the Liveblog autoarchive date on each time a new entry is added or updated to
 			// ensure we extend the date out correctly to the next archive point based on the configured offset.

--- a/liveblog.php
+++ b/liveblog.php
@@ -3,7 +3,7 @@
  * Plugin Name: Liveblog
  * Plugin URI: http://wordpress.org/extend/plugins/liveblog/
  * Description: Empowers website owners to provide rich and engaging live event coverage to a large, distributed audience.
- * Version:     1.12.0
+ * Version:     1.12.1
  * Requires at least: 6.4
  * Requires PHP: 7.4
  * Author:      WordPress.com VIP, Big Bite Creative and contributors
@@ -33,7 +33,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		 *
 		 * @var string
 		 */
-		const VERSION = '1.12.0';
+		const VERSION = '1.12.1';
 
 		/**
 		 * Rewrites version for flushing rewrite rules.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "liveblog",
       "version": "1.12.0",
       "dependencies": {
-        "@lexical/html": "^0.43.0",
+        "@lexical/html": "^0.44.0",
         "@lexical/link": "^0.43.0",
         "@lexical/list": "^0.43.0",
         "@lexical/react": "^0.43.0",
@@ -3822,6 +3822,17 @@
         "lexical": "0.43.0"
       }
     },
+    "node_modules/@lexical/clipboard/node_modules/@lexical/html": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.43.0.tgz",
+      "integrity": "sha512-C6LpUQlRl9J8Hqpm/C8LCX1ZxFHyD/gvOdV+NuNGnXN06uo0jDDm9SNh/HI3VWvFu9ec4OuzUkQRCafW8WC8fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.43.0",
+        "@lexical/utils": "0.43.0",
+        "lexical": "0.43.0"
+      }
+    },
     "node_modules/@lexical/clipboard/node_modules/lexical": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
@@ -3859,6 +3870,17 @@
       "peerDependencies": {
         "react": ">=17.x",
         "react-dom": ">=17.x"
+      }
+    },
+    "node_modules/@lexical/devtools-core/node_modules/@lexical/html": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.43.0.tgz",
+      "integrity": "sha512-C6LpUQlRl9J8Hqpm/C8LCX1ZxFHyD/gvOdV+NuNGnXN06uo0jDDm9SNh/HI3VWvFu9ec4OuzUkQRCafW8WC8fQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.43.0",
+        "@lexical/utils": "0.43.0",
+        "lexical": "0.43.0"
       }
     },
     "node_modules/@lexical/devtools-core/node_modules/lexical": {
@@ -3935,21 +3957,46 @@
       "license": "MIT"
     },
     "node_modules/@lexical/html": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.43.0.tgz",
-      "integrity": "sha512-C6LpUQlRl9J8Hqpm/C8LCX1ZxFHyD/gvOdV+NuNGnXN06uo0jDDm9SNh/HI3VWvFu9ec4OuzUkQRCafW8WC8fQ==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.44.0.tgz",
+      "integrity": "sha512-5X6eGsgwtqPxABsuShUxF7ZfyB/U4GwSEyeonvwH1Vc/5Q2uQVjlB+FAYd+MNwWMHMh4d4+yZ3l70AtIuhr5eg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/extension": "0.44.0",
+        "@lexical/selection": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/html/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/html/node_modules/@lexical/extension": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
+      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.44.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/html/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/html/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@lexical/link": {
       "version": "0.43.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@lexical/link": "^0.44.0",
         "@lexical/list": "^0.43.0",
         "@lexical/react": "^0.44.0",
-        "@lexical/rich-text": "^0.43.0",
+        "@lexical/rich-text": "^0.44.0",
         "js-beautify": "^1.7.5",
         "lexical": "^0.44.0",
         "lodash-es": "^4.18.1",
@@ -3810,34 +3810,60 @@
       "license": "MIT"
     },
     "node_modules/@lexical/clipboard": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.43.0.tgz",
-      "integrity": "sha512-3dWDusVyM9EosBt4/n/ERyPIGOyuWuECj9zbvJdzGUdvu/VsqCdlyDsU5M7NxTUNQn2Fhkdj2o00UeB6bagX5Q==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.44.0.tgz",
+      "integrity": "sha512-nfmNIs7uENqlDI7cm2E4I1Yp8mDJGMhEQIrIV2rNWnL1oeHVXQ7yuYdyoPdcY1zuj/9nvkYBQYUEh0QiGwpETA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.43.0",
-        "@lexical/list": "0.43.0",
-        "@lexical/selection": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/extension": "0.44.0",
+        "@lexical/html": "0.44.0",
+        "@lexical/list": "0.44.0",
+        "@lexical/selection": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "@types/trusted-types": "^2.0.7",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/clipboard/node_modules/@lexical/html": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.43.0.tgz",
-      "integrity": "sha512-C6LpUQlRl9J8Hqpm/C8LCX1ZxFHyD/gvOdV+NuNGnXN06uo0jDDm9SNh/HI3VWvFu9ec4OuzUkQRCafW8WC8fQ==",
+    "node_modules/@lexical/clipboard/node_modules/@lexical/extension": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
+      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/utils": "0.44.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/clipboard/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/clipboard/node_modules/@lexical/list": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.44.0.tgz",
+      "integrity": "sha512-ZTCWxDz1okPrC9FBXi1yV3W5fbQQeMUlFIcSVF9HibcVPmCsPa900IxthuiQbGiTycUyXDTOB3IUYRtlJNtpjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/clipboard/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/clipboard/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@lexical/code-core": {
       "version": "0.44.0",
@@ -3917,20 +3943,44 @@
       }
     },
     "node_modules/@lexical/dragon": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.43.0.tgz",
-      "integrity": "sha512-wB2s8uO9DFwS5err1wM+7Yoz3cixtEXy1ZiU8RoJJ7tmjSEmQsLIflAQq8Lic291tCNPs+lSHKjdw+52vi0Z7Q==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.44.0.tgz",
+      "integrity": "sha512-RhlsjVDket9k1+YFEkDE0/7Qyrh2BI0vxBMzrWwPJTXX/4YFanYN9su8RSabkIukBBJ3QiNOOoC8FKK4Lkr4qg==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/extension": "0.44.0",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/dragon/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/dragon/node_modules/@lexical/extension": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
+      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.44.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/dragon/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/dragon/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@lexical/extension": {
       "version": "0.43.0",
@@ -4165,31 +4215,6 @@
         "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/markdown/node_modules/@lexical/clipboard": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.44.0.tgz",
-      "integrity": "sha512-nfmNIs7uENqlDI7cm2E4I1Yp8mDJGMhEQIrIV2rNWnL1oeHVXQ7yuYdyoPdcY1zuj/9nvkYBQYUEh0QiGwpETA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "@lexical/html": "0.44.0",
-        "@lexical/list": "0.44.0",
-        "@lexical/selection": "0.44.0",
-        "@lexical/utils": "0.44.0",
-        "@types/trusted-types": "^2.0.7",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/markdown/node_modules/@lexical/dragon": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.44.0.tgz",
-      "integrity": "sha512-RhlsjVDket9k1+YFEkDE0/7Qyrh2BI0vxBMzrWwPJTXX/4YFanYN9su8RSabkIukBBJ3QiNOOoC8FKK4Lkr4qg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
     "node_modules/@lexical/markdown/node_modules/@lexical/extension": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
@@ -4208,19 +4233,6 @@
       "license": "MIT",
       "dependencies": {
         "@lexical/extension": "0.44.0",
-        "@lexical/utils": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/markdown/node_modules/@lexical/rich-text": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.44.0.tgz",
-      "integrity": "sha512-IIdrutK5GY47ITjPlZB7KzUi9dBDwygsyFOwolnrYSL7m6TtGhAqrYiFg/YNOTT/nBzK3KQeCJRbnxpjJAVZtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/clipboard": "0.44.0",
-        "@lexical/dragon": "0.44.0",
-        "@lexical/selection": "0.44.0",
         "@lexical/utils": "0.44.0",
         "lexical": "0.44.0"
       }
@@ -4262,53 +4274,6 @@
         "@lexical/clipboard": "0.44.0",
         "@lexical/dragon": "0.44.0",
         "@lexical/selection": "0.44.0",
-        "@lexical/utils": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/plain-text/node_modules/@lexical/clipboard": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.44.0.tgz",
-      "integrity": "sha512-nfmNIs7uENqlDI7cm2E4I1Yp8mDJGMhEQIrIV2rNWnL1oeHVXQ7yuYdyoPdcY1zuj/9nvkYBQYUEh0QiGwpETA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "@lexical/html": "0.44.0",
-        "@lexical/list": "0.44.0",
-        "@lexical/selection": "0.44.0",
-        "@lexical/utils": "0.44.0",
-        "@types/trusted-types": "^2.0.7",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/plain-text/node_modules/@lexical/dragon": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.44.0.tgz",
-      "integrity": "sha512-RhlsjVDket9k1+YFEkDE0/7Qyrh2BI0vxBMzrWwPJTXX/4YFanYN9su8RSabkIukBBJ3QiNOOoC8FKK4Lkr4qg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/plain-text/node_modules/@lexical/extension": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
-      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/utils": "0.44.0",
-        "@preact/signals-core": "^1.14.1",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/plain-text/node_modules/@lexical/list": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.44.0.tgz",
-      "integrity": "sha512-ZTCWxDz1okPrC9FBXi1yV3W5fbQQeMUlFIcSVF9HibcVPmCsPa900IxthuiQbGiTycUyXDTOB3IUYRtlJNtpjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
         "@lexical/utils": "0.44.0",
         "lexical": "0.44.0"
       }
@@ -4369,31 +4334,6 @@
         }
       }
     },
-    "node_modules/@lexical/react/node_modules/@lexical/clipboard": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.44.0.tgz",
-      "integrity": "sha512-nfmNIs7uENqlDI7cm2E4I1Yp8mDJGMhEQIrIV2rNWnL1oeHVXQ7yuYdyoPdcY1zuj/9nvkYBQYUEh0QiGwpETA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "@lexical/html": "0.44.0",
-        "@lexical/list": "0.44.0",
-        "@lexical/selection": "0.44.0",
-        "@lexical/utils": "0.44.0",
-        "@types/trusted-types": "^2.0.7",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/react/node_modules/@lexical/dragon": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.44.0.tgz",
-      "integrity": "sha512-RhlsjVDket9k1+YFEkDE0/7Qyrh2BI0vxBMzrWwPJTXX/4YFanYN9su8RSabkIukBBJ3QiNOOoC8FKK4Lkr4qg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
     "node_modules/@lexical/react/node_modules/@lexical/extension": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
@@ -4412,19 +4352,6 @@
       "license": "MIT",
       "dependencies": {
         "@lexical/extension": "0.44.0",
-        "@lexical/utils": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/react/node_modules/@lexical/rich-text": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.44.0.tgz",
-      "integrity": "sha512-IIdrutK5GY47ITjPlZB7KzUi9dBDwygsyFOwolnrYSL7m6TtGhAqrYiFg/YNOTT/nBzK3KQeCJRbnxpjJAVZtQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/clipboard": "0.44.0",
-        "@lexical/dragon": "0.44.0",
-        "@lexical/selection": "0.44.0",
         "@lexical/utils": "0.44.0",
         "lexical": "0.44.0"
       }
@@ -4449,23 +4376,36 @@
       }
     },
     "node_modules/@lexical/rich-text": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.43.0.tgz",
-      "integrity": "sha512-y6uhY5X+PBLg8LSCDazSMAkUfA1RwBW6DFOuUKW5SI1DaB/oc/vpQhkR1DYGqXnytMx7hfiK+7lL51ZC0ydeWg==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.44.0.tgz",
+      "integrity": "sha512-IIdrutK5GY47ITjPlZB7KzUi9dBDwygsyFOwolnrYSL7m6TtGhAqrYiFg/YNOTT/nBzK3KQeCJRbnxpjJAVZtQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.43.0",
-        "@lexical/dragon": "0.43.0",
-        "@lexical/selection": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/clipboard": "0.44.0",
+        "@lexical/dragon": "0.44.0",
+        "@lexical/selection": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/rich-text/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/rich-text/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/rich-text/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@lexical/selection": {
       "version": "0.43.0",
@@ -4494,21 +4434,6 @@
         "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/table/node_modules/@lexical/clipboard": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.44.0.tgz",
-      "integrity": "sha512-nfmNIs7uENqlDI7cm2E4I1Yp8mDJGMhEQIrIV2rNWnL1oeHVXQ7yuYdyoPdcY1zuj/9nvkYBQYUEh0QiGwpETA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "@lexical/html": "0.44.0",
-        "@lexical/list": "0.44.0",
-        "@lexical/selection": "0.44.0",
-        "@lexical/utils": "0.44.0",
-        "@types/trusted-types": "^2.0.7",
-        "lexical": "0.44.0"
-      }
-    },
     "node_modules/@lexical/table/node_modules/@lexical/extension": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
@@ -4517,17 +4442,6 @@
       "dependencies": {
         "@lexical/utils": "0.44.0",
         "@preact/signals-core": "^1.14.1",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/table/node_modules/@lexical/list": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.44.0.tgz",
-      "integrity": "sha512-ZTCWxDz1okPrC9FBXi1yV3W5fbQQeMUlFIcSVF9HibcVPmCsPa900IxthuiQbGiTycUyXDTOB3IUYRtlJNtpjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "@lexical/utils": "0.44.0",
         "lexical": "0.44.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "liveblog",
-  "version": "1.11.1",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "liveblog",
-      "version": "1.11.1",
+      "version": "1.12.0",
       "dependencies": {
         "@lexical/html": "^0.43.0",
         "@lexical/link": "^0.43.0",
@@ -18342,9 +18342,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.12",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.12.tgz",
+      "integrity": "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,8 +30,8 @@
         "rxjs": "^7.8.0"
       },
       "devDependencies": {
-        "@wordpress/i18n": "^6.17.0",
-        "@wordpress/scripts": "^32.0.0",
+        "@wordpress/i18n": "^6.18.0",
+        "@wordpress/scripts": "^32.1.0",
         "sass-module-importer": "^1.4.0",
         "sass-mq": "^7.0.0"
       }
@@ -6161,9 +6161,9 @@
       "license": "MIT"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -6682,17 +6682,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.0.tgz",
-      "integrity": "sha512-HyAZtpdkgZwpq8Sz3FSUvCR4c+ScbuWa9AksK2Jweub7w4M3yTz4O11AqVJzLYjy/B9ZWPyc81I+mOdJU/bDQw==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.2.tgz",
+      "integrity": "sha512-j/bwmkBvHUtPNxzuWe5z6BEk3q54YRyGlBXkSsmfoih7zNrBvl5A9A98anlp/7JbyZcWIJ8KXo/3Tq/DjFLtuQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.59.0",
-        "@typescript-eslint/type-utils": "8.59.0",
-        "@typescript-eslint/utils": "8.59.0",
-        "@typescript-eslint/visitor-keys": "8.59.0",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/type-utils": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -6705,7 +6705,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.59.0",
+        "@typescript-eslint/parser": "^8.59.2",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -6721,16 +6721,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.0.tgz",
-      "integrity": "sha512-TI1XGwKbDpo9tRW8UDIXCOeLk55qe9ZFGs8MTKU6/M08HWTw52DD/IYhfQtOEhEdPhLMT26Ka/x7p70nd3dzDg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.2.tgz",
+      "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.0",
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/typescript-estree": "8.59.0",
-        "@typescript-eslint/visitor-keys": "8.59.0",
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6746,14 +6746,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.0.tgz",
-      "integrity": "sha512-Lw5ITrR5s5TbC19YSvlr63ZfLaJoU6vtKTHyB0GQOpX0W7d5/Ir6vUahWi/8Sps/nOukZQ0IB3SmlxZnjaKVnw==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.2.tgz",
+      "integrity": "sha512-+2hqvEkeyf/0FBor67duF0Ll7Ot8jyKzDQOSrxazF/danillRq2DwR9dLptsXpoZQqxE1UisSmoZewrlPas9Vw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.0",
-        "@typescript-eslint/types": "^8.59.0",
+        "@typescript-eslint/tsconfig-utils": "^8.59.2",
+        "@typescript-eslint/types": "^8.59.2",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -6768,14 +6768,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.0.tgz",
-      "integrity": "sha512-UzR16Ut8IpA3Mc4DbgAShlPPkVm8xXMWafXxB0BocaVRHs8ZGakAxGRskF7FId3sdk9lgGD73GSFaWmWFDE4dg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.2.tgz",
+      "integrity": "sha512-JzfyEpEtOU89CcFSwyNS3mu4MLvLSXqnmX05+aKBDM+TdR5jzcGOEBwxwGNxrEQ7p/z6kK2WyioCGBf2zZBnvg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/visitor-keys": "8.59.0"
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6786,9 +6786,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.0.tgz",
-      "integrity": "sha512-91Sbl3s4Kb3SybliIY6muFBmHVv+pYXfybC4Oolp3dvk8BvIE3wOPc+403CWIT7mJNkfQRGtdqghzs2+Z91Tqg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.2.tgz",
+      "integrity": "sha512-BKK4alN7oi4C/zv4VqHQ+uRU+lTa6JGIZ7s1juw7b3RHo9OfKB+bKX3u0iVZetdsUCBBkSbdWbarJbmN0fTeSw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6803,15 +6803,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.0.tgz",
-      "integrity": "sha512-3TRiZaQSltGqGeNrJzzr1+8YcEobKH9rHnqIp/1psfKFmhRQDNMGP5hBufanYTGznwShzVLs3Mz+gDN7HkWfXg==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.2.tgz",
+      "integrity": "sha512-nhqaj1nmTdVVl/BP5omXNRGO38jn5iosis2vbdmupF2txCf8ylWT8lx+JlvMYYVqzGVKtjojUFoQ3JRWK+mfzQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/typescript-estree": "8.59.0",
-        "@typescript-eslint/utils": "8.59.0",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -6828,9 +6828,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.0.tgz",
-      "integrity": "sha512-nLzdsT1gdOgFxxxwrlNVUBzSNBEEHJ86bblmk4QAS6stfig7rcJzWKqCyxFy3YRRHXDWEkb2NralA1nOYkkm/A==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.2.tgz",
+      "integrity": "sha512-e82GVOE8Ps3E++Egvb6Y3Dw0S10u8NkQ9KXmtRhCWJJ8kDhOJTvtMAWnFL16kB1583goCWXsr0NieKCZMs2/0Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6842,16 +6842,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.0.tgz",
-      "integrity": "sha512-O9Re9P1BmBLFJyikRbQpLku/QA3/AueZNO9WePLBwQrvkixTmDe8u76B6CYUAITRl/rHawggEqUGn5QIkVRLMw==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.2.tgz",
+      "integrity": "sha512-o0XPGNwcWw+FIwStOWn+BwBuEmL6QXP0rsvAFg7ET1dey1Nr6Wb1ac8p5HEsK0ygO/6mUxlk+YWQD9xcb/nnXg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.59.0",
-        "@typescript-eslint/tsconfig-utils": "8.59.0",
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/visitor-keys": "8.59.0",
+        "@typescript-eslint/project-service": "8.59.2",
+        "@typescript-eslint/tsconfig-utils": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/visitor-keys": "8.59.2",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -6922,16 +6922,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.0.tgz",
-      "integrity": "sha512-I1R/K7V07XsMJ12Oaxg/O9GfrysGTmCRhvZJBv0RE0NcULMzjqVpR5kRRQjHsz3J/bElU7HwCO7zkqL+MSUz+g==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.2.tgz",
+      "integrity": "sha512-Juw3EinkXqjaffxz6roowvV7GZT/kET5vSKKZT6upl5TXdWkLkYmNPXwDDL2Vkt2DPn0nODIS4egC/0AGxKo/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.59.0",
-        "@typescript-eslint/types": "8.59.0",
-        "@typescript-eslint/typescript-estree": "8.59.0"
+        "@typescript-eslint/scope-manager": "8.59.2",
+        "@typescript-eslint/types": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6946,13 +6946,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.0.tgz",
-      "integrity": "sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.2.tgz",
+      "integrity": "sha512-NwjLUnGy8/Zfx23fl50tRC8rYaYnM52xNRYFAXvmiil9yh1+K6aRVQMnzW6gQB/1DLgWt977lYQn7C+wtgXZiA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.59.0",
+        "@typescript-eslint/types": "8.59.2",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -7463,9 +7463,9 @@
       }
     },
     "node_modules/@wordpress/babel-preset-default": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.44.0.tgz",
-      "integrity": "sha512-6EQW8ysiQkct2MolHlhyqXfZ/Vgl0Cu9dCeHfPEf7S/8575qua1GnuDSFzEqU/8TIrEG88f2e2qP/R7VRB+EwQ==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.45.0.tgz",
+      "integrity": "sha512-xlrFFf8bsVDpOjzDW4dwkY8w040YupOIeRSVPB1FJyHBae8ObR+p2siM6E8/DrLNuDznudYoUFRnojYQ16ImjQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -7475,8 +7475,8 @@
         "@babel/plugin-transform-runtime": "7.25.7",
         "@babel/preset-env": "7.25.7",
         "@babel/preset-typescript": "7.25.7",
-        "@wordpress/browserslist-config": "^6.44.0",
-        "@wordpress/warning": "^3.44.0",
+        "@wordpress/browserslist-config": "^6.45.0",
+        "@wordpress/warning": "^3.45.0",
         "browserslist": "^4.21.10",
         "core-js": "^3.31.0",
         "react": "^18.3.0"
@@ -7681,9 +7681,9 @@
       }
     },
     "node_modules/@wordpress/base-styles": {
-      "version": "6.20.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-6.20.0.tgz",
-      "integrity": "sha512-Dsug4Zxz2xOFtK6CGThKYXwCqC9Yztw2STKQzwztrX4yW+o6iDbzkxpcwdDhsaVJs0Jt9A4LmJpZPh+pUozzLA==",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/base-styles/-/base-styles-7.0.0.tgz",
+      "integrity": "sha512-Q0BbZzfeYbQZKHnyNT4RF8RGVugN5jStGtpRKhBYQW7ut7sS61LbbpP7jR0D0sDPYoEEC8jKZQSZwSM23B4jow==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7692,9 +7692,9 @@
       }
     },
     "node_modules/@wordpress/browserslist-config": {
-      "version": "6.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.44.0.tgz",
-      "integrity": "sha512-lYtkO7U7ok9RfRBIHWvVWXhcOys6cQuLfwFr1bGuPTE6+LmVHmRyniMnImZlG8Jb3XE4pvH8gXT1ecXogpDI2Q==",
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.45.0.tgz",
+      "integrity": "sha512-iSRD/0bxD9PUHWssZN1zZa+xZ2E9FtpgNYKeceTPLKV3rd+rRPqI1h2a2iHboLzex80c1vaxe6eQ9kyZQfGtiA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7703,9 +7703,9 @@
       }
     },
     "node_modules/@wordpress/dependency-extraction-webpack-plugin": {
-      "version": "6.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.44.0.tgz",
-      "integrity": "sha512-bc6PfIUW//FxDu7DOuUoq2/oIQL2u8U33oDArFukTmyzf1fBWSIYKc2rpD3t3JMaWmnoiorlKgDpaFXfI6dCuA==",
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/dependency-extraction-webpack-plugin/-/dependency-extraction-webpack-plugin-6.45.0.tgz",
+      "integrity": "sha512-x/CvPKJXe53/ff2R9oj0IwAjshSlUFAxq47BXkb8HKMXD1LJTabQKT1dfDJXj3BeUpERxsZ1ltOmQ6Q8GblGAw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -7727,15 +7727,15 @@
       "license": "BSD"
     },
     "node_modules/@wordpress/element": {
-      "version": "6.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.44.0.tgz",
-      "integrity": "sha512-kVCRSwGMPFu7oBcAzN0VzwFQw3mwctUb/TEHkGeG5An1Uus6olruGJyvFwkHNtO9WRCdTXXunUaSk0CIA9+Wig==",
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/element/-/element-6.45.0.tgz",
+      "integrity": "sha512-WFrGNPEnj8uE+XhFW9NVbxvqraYpConaEokLv9IszFYVfyg8juXSQcHOAfEnxjC08HBPfVcayr2igu/XUgGOAw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@types/react": "^18.3.27",
         "@types/react-dom": "^18.3.1",
-        "@wordpress/escape-html": "^3.44.0",
+        "@wordpress/escape-html": "^3.45.0",
         "change-case": "^4.1.2",
         "is-plain-object": "^5.0.0",
         "react": "^18.3.0",
@@ -7747,9 +7747,9 @@
       }
     },
     "node_modules/@wordpress/escape-html": {
-      "version": "3.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.44.0.tgz",
-      "integrity": "sha512-nAEshSe6IYFr3G8sfY8o9pYNTRKvxocQ3DXs3KUesmdaEtrtJSlDmrMOI3FIgaYfv1PP6d+cDZpsygp6IZGo2w==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/escape-html/-/escape-html-3.45.0.tgz",
+      "integrity": "sha512-IW4mnA+65XKhABuBkwrQNAlbq97luC6ZIBfdSq0Tkq+AFPqE1lJTMlLo7iBkTpsHsBLyznViPXultq40fz8L7w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7758,18 +7758,18 @@
       }
     },
     "node_modules/@wordpress/eslint-plugin": {
-      "version": "25.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-25.0.0.tgz",
-      "integrity": "sha512-GYOPtbsibtFWmvFHm4ZBKUM16SREBcvpVHUuQLfh2s/CQtTP9kbC25XHmIdp0by77i2FDFvEtVGHo7aswoiRCA==",
+      "version": "25.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/eslint-plugin/-/eslint-plugin-25.1.0.tgz",
+      "integrity": "sha512-tZVfrpAZoUNQ2A03XA8nVgfejb5lINPZUvbZcg8ZlTB4Bf58daLx5XOw3zIH4ubdS+t4paRslgrdnbCCpqX4Zg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/eslint-parser": "^7.28.6",
         "@eslint-community/eslint-plugin-eslint-comments": "^4.4.0",
         "@eslint/compat": "^2.0.0",
-        "@wordpress/babel-preset-default": "^8.44.0",
-        "@wordpress/prettier-config": "^4.44.0",
-        "@wordpress/theme": "^0.11.0",
+        "@wordpress/babel-preset-default": "^8.45.0",
+        "@wordpress/prettier-config": "^4.45.0",
+        "@wordpress/theme": "^0.12.0",
         "cosmiconfig": "^7.0.0",
         "eslint-config-prettier": "^10.0.0",
         "eslint-import-resolver-typescript": "^4.4.4",
@@ -7822,9 +7822,9 @@
       }
     },
     "node_modules/@wordpress/hooks": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.44.0.tgz",
-      "integrity": "sha512-6p2vFvoFaovqnKFnIoy6Kib2XJhTwaJ1VhMXp4tM2PhSLnFMXVm1TpcHeX/kH7E6sWKJACBrDR6FH2nGYMk5dA==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/hooks/-/hooks-4.45.0.tgz",
+      "integrity": "sha512-+gOlu8TdohqL1INQNxS/7CxhM4T4MuYnKietWV9zWDmNQV2ysM0SdamNk5pWERJ4w0yY9XhtMBcwR/piJtePZg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7833,14 +7833,14 @@
       }
     },
     "node_modules/@wordpress/i18n": {
-      "version": "6.17.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.17.0.tgz",
-      "integrity": "sha512-v1SLBweg7CRzQ+5+WSC1U93i8h9d3AoB0YBvMsd6gWI5vO8Zh4YKlEMexvrHQC++WN83egwqux84fWEdeU0MUA==",
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/i18n/-/i18n-6.18.0.tgz",
+      "integrity": "sha512-6dYCih4wUwi7Csu4RNfHiAKkgWhpSQdl8YthvQUF59Sfsoia3RCdtd4K2l7W4f18ldFA/RXjShMjvSexWy6OyQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@tannin/sprintf": "^1.3.2",
-        "@wordpress/hooks": "^4.44.0",
+        "@wordpress/hooks": "^4.45.0",
         "gettext-parser": "^1.3.1",
         "memize": "^2.1.0",
         "tannin": "^1.2.0"
@@ -7854,9 +7854,9 @@
       }
     },
     "node_modules/@wordpress/jest-console": {
-      "version": "8.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.44.0.tgz",
-      "integrity": "sha512-2Dawx6Qh2zr0ZlFByFmvkfCukb6CzCrCFnTnHImdiwlQ7wKcmTaIR3QPomJg6fTxiwgBiWn9yeiO7N97vJ59eg==",
+      "version": "8.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-console/-/jest-console-8.45.0.tgz",
+      "integrity": "sha512-5hB2D170aZdYpXganoI4UXvfUEAchpqvICaFjkKteSF3IY60k27GAKBY5hYBNsGkICV2CF2sEHuAO/fYRKhuuQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -7872,13 +7872,13 @@
       }
     },
     "node_modules/@wordpress/jest-preset-default": {
-      "version": "12.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.44.0.tgz",
-      "integrity": "sha512-v5gj1/IdPfPoOOor/UZxvbuYQ8NYE1CV+De27Kf9w3MzTh1Z2KwuyZGA163X9OYMdQY36D2GfT2aa7p0RpWaFA==",
+      "version": "12.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/jest-preset-default/-/jest-preset-default-12.45.0.tgz",
+      "integrity": "sha512-8esXkIgiMi1mQ2WCCieb9/ZU51GQY9mTfPBe3VhIaxvLXUQwhBnw8ytyW1VS+t/pk3H305BA9fW+hNlMQrzElg==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/jest-console": "^8.44.0",
+        "@wordpress/jest-console": "^8.45.0",
         "babel-jest": "29.7.0"
       },
       "engines": {
@@ -7891,9 +7891,9 @@
       }
     },
     "node_modules/@wordpress/npm-package-json-lint-config": {
-      "version": "5.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.44.0.tgz",
-      "integrity": "sha512-XVu8wrLegxsJULb5lHd3Z8enlgQUWA9d+3Lsa+7AiyL5jUqDaMR1RKvHVvqAsCnlc2h2qoJiWUU7YLCVQNXd9Q==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/npm-package-json-lint-config/-/npm-package-json-lint-config-5.45.0.tgz",
+      "integrity": "sha512-0SrEJxgEuxSpVwK8Fr0NfoPAuA+m00O7WXp7icAsGsZ34I5PaHH3Vt++ddL4GIU56bUTmHIqik9VaKDKydFr4A==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7905,13 +7905,13 @@
       }
     },
     "node_modules/@wordpress/postcss-plugins-preset": {
-      "version": "5.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.44.0.tgz",
-      "integrity": "sha512-D3GGSSmPKHUywK+pIHXsfnX6MXsjMb6rfQ33hX2hfOLZUR5VVt/DFJE3teinnyveQKOKeFcytiMr1pP2gH12RA==",
+      "version": "5.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/postcss-plugins-preset/-/postcss-plugins-preset-5.45.0.tgz",
+      "integrity": "sha512-9uoIZAyNFNefuQnPrM5mJjLF2u5LUPBvnU4Evr1mLLeKIOB6SRmd50lxIsahI1k4Dlh63dh5ztmOK1y/fnTrJQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/base-styles": "^6.20.0",
+        "@wordpress/base-styles": "^7.0.0",
         "autoprefixer": "^10.4.20",
         "postcss-import": "^16.1.1"
       },
@@ -7924,9 +7924,9 @@
       }
     },
     "node_modules/@wordpress/prettier-config": {
-      "version": "4.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.44.0.tgz",
-      "integrity": "sha512-RT8Pc/dGOhMM9PwCsPamhkpIYx6zjTUDBIs/huVYKusByXImXQFoeZmaI3nK/UNus55woW6xyNNWdb2/nvvXgw==",
+      "version": "4.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/prettier-config/-/prettier-config-4.45.0.tgz",
+      "integrity": "sha512-Tj8wdH/+uwFOYbyhaQKrfe9WjtCnmGEoOi2i5zQ5KF3NgrdYgfv7ADMnd/fMW2vffxWAZvGjelvH1jybhY6XJA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7938,9 +7938,9 @@
       }
     },
     "node_modules/@wordpress/private-apis": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.44.0.tgz",
-      "integrity": "sha512-fTR1HRshYIrN4yau/Z+zxY+oRFnJz/LS8XGeXx43PT5O4B25+4kO41ApdS9FG56erg8HqUB6HoqDUcReT5pzlQ==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/private-apis/-/private-apis-1.45.0.tgz",
+      "integrity": "sha512-UjhIDpoyKKUghPM0tkqd5Whsuk4kqfAfhb5VYGoEYtunDs0rB8IxgFO7hE0PhimHL74QVgaJOlprRZVRCCoQ6w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -7949,25 +7949,25 @@
       }
     },
     "node_modules/@wordpress/scripts": {
-      "version": "32.0.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-32.0.0.tgz",
-      "integrity": "sha512-IAPf3vZnXch4zvsEyT5gyX43WHqJRtUlFpBxrqiyApZO5i0CtEc800Ys2sxQmpoMlO/nBui+zN+Y4ka4/mzHIA==",
+      "version": "32.1.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/scripts/-/scripts-32.1.0.tgz",
+      "integrity": "sha512-sxtibypx47GdibpWFaeAjHXLevcwNyNA0qu7fBUTFt+vgBPxAdx2FIhvg7m7eWjVx6Zr5xjgXQWUE5cFrBpweA==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
         "@babel/core": "7.25.7",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.11",
         "@svgr/webpack": "^8.0.1",
-        "@wordpress/babel-preset-default": "^8.44.0",
-        "@wordpress/browserslist-config": "^6.44.0",
-        "@wordpress/dependency-extraction-webpack-plugin": "^6.44.0",
-        "@wordpress/e2e-test-utils-playwright": "^1.44.0",
-        "@wordpress/eslint-plugin": "^25.0.0",
-        "@wordpress/jest-preset-default": "^12.44.0",
-        "@wordpress/npm-package-json-lint-config": "^5.44.0",
-        "@wordpress/postcss-plugins-preset": "^5.44.0",
-        "@wordpress/prettier-config": "^4.44.0",
-        "@wordpress/stylelint-config": "^23.36.0",
+        "@wordpress/babel-preset-default": "^8.45.0",
+        "@wordpress/browserslist-config": "^6.45.0",
+        "@wordpress/dependency-extraction-webpack-plugin": "^6.45.0",
+        "@wordpress/e2e-test-utils-playwright": "^1.45.0",
+        "@wordpress/eslint-plugin": "^25.1.0",
+        "@wordpress/jest-preset-default": "^12.45.0",
+        "@wordpress/npm-package-json-lint-config": "^5.45.0",
+        "@wordpress/postcss-plugins-preset": "^5.45.0",
+        "@wordpress/prettier-config": "^4.45.0",
+        "@wordpress/stylelint-config": "^23.37.0",
         "adm-zip": "^0.5.9",
         "babel-jest": "29.7.0",
         "babel-loader": "9.2.1",
@@ -8098,9 +8098,9 @@
       }
     },
     "node_modules/@wordpress/scripts/node_modules/@wordpress/e2e-test-utils-playwright": {
-      "version": "1.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.44.0.tgz",
-      "integrity": "sha512-iUKHGH8TjW1s0cpkcHF6y/APOmy4YnwBfzdBNCITK4+4fuSZnTV7vZyzBU3adthGcBSMGQ9w8MTE2AzGLtlG3w==",
+      "version": "1.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/e2e-test-utils-playwright/-/e2e-test-utils-playwright-1.45.0.tgz",
+      "integrity": "sha512-2hqpRI6J8UcDyP1ObSCGP2lcc2VG15AyG/DwnzMdpgIUC/1zNvQwD9eNlyvHAISgnQ8m41aifE0FVtx5BTLuRQ==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
@@ -8322,14 +8322,14 @@
       "peer": true
     },
     "node_modules/@wordpress/stylelint-config": {
-      "version": "23.36.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.36.0.tgz",
-      "integrity": "sha512-UJIrrJjdHD28tzjHZLS/KmaJjuaVZ5r5zYHguPSJfa5lxXP6JEqYPN4sQV6Ebjd5YtB4ZPKNVQDJHLQqtgRSdA==",
+      "version": "23.37.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/stylelint-config/-/stylelint-config-23.37.0.tgz",
+      "integrity": "sha512-1IYD9qro2/+h8+jGosIFzxQtjEEyTT7t679LzzoWdeWX7kacnIdDv4QZzK2JAzW+PaZit3cnZQgqxZvgBoXk4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@stylistic/stylelint-plugin": "^3.0.1",
-        "@wordpress/theme": "^0.11.0",
+        "@wordpress/theme": "^0.12.0",
         "stylelint-config-recommended": "^14.0.1",
         "stylelint-config-recommended-scss": "^14.1.0"
       },
@@ -8343,14 +8343,14 @@
       }
     },
     "node_modules/@wordpress/theme": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.11.0.tgz",
-      "integrity": "sha512-jXilt+3codfAEFRHvLpnULeOaaycwJByyv+m/TIlspZ4r0l4X9iA1KL7GkXOHz2AJWWvS7FUnS/GHBuIrUgAWg==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/theme/-/theme-0.12.0.tgz",
+      "integrity": "sha512-AmEVO0B+kI9tsxkLnna/S+7yi+EPCMTuaPqagje7pnlXeDfykVQfeDeWJfU+QvhcqHXCySn89vvw1Ihep0rj7w==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "dependencies": {
-        "@wordpress/element": "^6.44.0",
-        "@wordpress/private-apis": "^1.44.0",
+        "@wordpress/element": "^6.45.0",
+        "@wordpress/private-apis": "^1.45.0",
         "colorjs.io": "^0.6.0",
         "memize": "^2.1.0"
       },
@@ -8370,9 +8370,9 @@
       }
     },
     "node_modules/@wordpress/warning": {
-      "version": "3.44.0",
-      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.44.0.tgz",
-      "integrity": "sha512-avxdbIYhDuUh2qi2oiq7KeqYOVv2RubqV8UI/Q7bctZSFSXJE8RQGSR/W2YjABeyWBIjlyX/U5lOxVs2PIfy/w==",
+      "version": "3.45.0",
+      "resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.45.0.tgz",
+      "integrity": "sha512-NQ9tAhPdwhfceVIzWra1rbumvgAFAEDTgZlWsX880zLiq1F8JTwBouwW6wfIhA3XLcY6Yj7cBBYLa8vnNiDZDw==",
       "dev": true,
       "license": "GPL-2.0-or-later",
       "engines": {
@@ -9075,9 +9075,9 @@
       }
     },
     "node_modules/axe-core": {
-      "version": "4.11.3",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.3.tgz",
-      "integrity": "sha512-zBQouZixDTbo3jMGqHKyePxYxr1e5W8UdTmBQ7sNtaA9M2bE32daxxPLS/jojhKOHxQ7LWwPjfiwf/fhaJWzlg==",
+      "version": "4.11.4",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.11.4.tgz",
+      "integrity": "sha512-KunSNx+TVpkAw/6ULfhnx+HWRecjqZGTOyquAoWHYLRSdK1tB5Ihce1ZW+UY3fj33bYAFWPu7W/GRSmmrCGuxA==",
       "dev": true,
       "license": "MPL-2.0",
       "engines": {
@@ -12344,9 +12344,9 @@
       }
     },
     "node_modules/eslint-plugin-playwright/node_modules/globals": {
-      "version": "17.5.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.5.0.tgz",
-      "integrity": "sha512-qoV+HK2yFl/366t2/Cb3+xxPUo5BuMynomoDmiaZBIdbs+0pYbjfZU+twLhGKp4uCZ/+NbtpVepH5bGCxRyy2g==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -16643,9 +16643,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/lighthouse/node_modules/@puppeteer/browsers": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
-      "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.1.tgz",
+      "integrity": "sha512-zmS4RTK9fbrc++WlAJhxYbfz3IjDeOmkK/CwwbLmk7ydfS9e2CiEeRJHEPvjDVElO/bwXbidwGA37Bsm6LzCnQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -16665,19 +16665,19 @@
       }
     },
     "node_modules/lighthouse/node_modules/puppeteer-core": {
-      "version": "24.42.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.42.0.tgz",
-      "integrity": "sha512-T4zXokk/izH01fYPhyyev1A4piWiOKrYq7CUFpdoYQxmOnXoV6YjUabmfIjCYkNspSoAXIxRid3Tw+Vg0fthYg==",
+      "version": "24.43.0",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.0.tgz",
+      "integrity": "sha512-cCRNXsUlhyPoKDz6+TiSpfZpRS3mD6Y1YFKhkdr6ik6TMfuJb7fAtXq9ThUFc4sphxObDk3BuAvdxc1Y6YOnqQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.13.0",
+        "@puppeteer/browsers": "2.13.1",
         "chromium-bidi": "14.0.0",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1595872",
-        "typed-query-selector": "^2.12.1",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
         "webdriver-bidi-protocol": "0.4.1",
-        "ws": "^8.19.0"
+        "ws": "^8.20.0"
       },
       "engines": {
         "node": ">=18"
@@ -16698,9 +16698,9 @@
       }
     },
     "node_modules/lighthouse/node_modules/puppeteer-core/node_modules/devtools-protocol": {
-      "version": "0.0.1595872",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
-      "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
       "dev": true,
       "license": "BSD-3-Clause"
     },
@@ -19795,9 +19795,9 @@
       }
     },
     "node_modules/qified/node_modules/hookified": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.1.1.tgz",
-      "integrity": "sha512-AHb76R16GB5EsPBE2J7Ko5kiEyXwviB9P5SMrAKcuAu4vJPZttViAbj9+tZeaQE5zjDme+1vcHP78Yj/WoAveA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/hookified/-/hookified-2.2.0.tgz",
+      "integrity": "sha512-p/LgFzRN5FeoD3DLS6bkUapeye6E4SI6yJs6KetENd18S+FBthqYq2amJUWpt5z0EQwwHemidjY5OqJGEKm5uA==",
       "dev": true,
       "license": "MIT"
     },
@@ -22585,9 +22585,9 @@
       }
     },
     "node_modules/table/node_modules/ajv": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
-      "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -22927,20 +22927,20 @@
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
-      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.30.tgz",
+      "integrity": "sha512-uiHN8PIB1VmWyS98eZYja4xzlYqeFZVjb4OuYlJQnZAuJhMw4PbKQOKgHKhBdJR3FE/t5mUQ1Kd80++B+qhD1Q==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/tldts-icann": {
-      "version": "7.0.28",
-      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.28.tgz",
-      "integrity": "sha512-brkN3yIgYTzBpSxB71XYBwUMDgutmKmA+6TWzgGD/EPcvCc6LHMTRaYj9ik1u3BxhSW53qIK/7cgjA2rF7BgbA==",
+      "version": "7.0.30",
+      "resolved": "https://registry.npmjs.org/tldts-icann/-/tldts-icann-7.0.30.tgz",
+      "integrity": "sha512-o+sKcCCZQOh78GHfpmlcKoef0c+UVfltkqmgKmUHWiMiUhSfer8k5mEkQL2RBqwuC90fluI7ZN50H7+I2bJ1jw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.28"
+        "tldts-core": "^7.0.30"
       }
     },
     "node_modules/tldts/node_modules/tldts-core": {
@@ -23267,9 +23267,9 @@
       }
     },
     "node_modules/typed-query-selector": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.1.tgz",
-      "integrity": "sha512-uzR+FzI8qrUEIu96oaeBJmd9E7CFEiQ3goA5qCVgc4s5llSubcfGHq9yUstZx/k4s9dXHVKsE35YWoFyvEqEHA==",
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/typed-query-selector/-/typed-query-selector-2.12.2.tgz",
+      "integrity": "sha512-EOPFbyIub4ngnEdqi2yOcNeDLaX/0jcE1JoAXQDDMIthap7FoN795lc/SHfIq2d416VufXpM8z/lD+WRm2gfOQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -23289,16 +23289,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.0.tgz",
-      "integrity": "sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==",
+      "version": "8.59.2",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.2.tgz",
+      "integrity": "sha512-pJw051uomb3ZeCzGTpRb8RbEqB5Y4WWet8gl/GcTlU35BSx0PVdZ86/bqkQCyKKuraVQEK7r6kBHQXF+fBhkoQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.59.0",
-        "@typescript-eslint/parser": "8.59.0",
-        "@typescript-eslint/typescript-estree": "8.59.0",
-        "@typescript-eslint/utils": "8.59.0"
+        "@typescript-eslint/eslint-plugin": "8.59.2",
+        "@typescript-eslint/parser": "8.59.2",
+        "@typescript-eslint/typescript-estree": "8.59.2",
+        "@typescript-eslint/utils": "8.59.2"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "dependencies": {
         "@lexical/html": "^0.44.0",
         "@lexical/link": "^0.44.0",
-        "@lexical/list": "^0.43.0",
+        "@lexical/list": "^0.44.0",
         "@lexical/react": "^0.44.0",
         "@lexical/rich-text": "^0.44.0",
         "js-beautify": "^1.7.5",
@@ -3824,47 +3824,6 @@
         "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/clipboard/node_modules/@lexical/extension": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
-      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/utils": "0.44.0",
-        "@preact/signals-core": "^1.14.1",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/clipboard/node_modules/@lexical/list": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.44.0.tgz",
-      "integrity": "sha512-ZTCWxDz1okPrC9FBXi1yV3W5fbQQeMUlFIcSVF9HibcVPmCsPa900IxthuiQbGiTycUyXDTOB3IUYRtlJNtpjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "@lexical/utils": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/clipboard/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/clipboard/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
     "node_modules/@lexical/code-core": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@lexical/code-core/-/code-core-0.44.0.tgz",
@@ -3872,36 +3831,6 @@
       "license": "MIT",
       "dependencies": {
         "@lexical/extension": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/code-core/node_modules/@lexical/extension": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
-      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/utils": "0.44.0",
-        "@preact/signals-core": "^1.14.1",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/code-core/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/code-core/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
         "lexical": "0.44.0"
       }
     },
@@ -3923,25 +3852,6 @@
         "react-dom": ">=17.x"
       }
     },
-    "node_modules/@lexical/devtools-core/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/devtools-core/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
     "node_modules/@lexical/dragon": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.44.0.tgz",
@@ -3952,7 +3862,7 @@
         "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/dragon/node_modules/@lexical/extension": {
+    "node_modules/@lexical/extension": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
       "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
@@ -3962,42 +3872,6 @@
         "@preact/signals-core": "^1.14.1",
         "lexical": "0.44.0"
       }
-    },
-    "node_modules/@lexical/dragon/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/dragon/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/extension": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.43.0.tgz",
-      "integrity": "sha512-hCFj//3RhsPrCmx8VRTTLIsWtC2n5GG03ZDdyrgmeLzXNuknwDqhzaGAfQi9LSYn+NU+j3yCUROu8pZqaedtvw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/utils": "0.43.0",
-        "@preact/signals-core": "^1.14.1",
-        "lexical": "0.43.0"
-      }
-    },
-    "node_modules/@lexical/extension/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
     },
     "node_modules/@lexical/hashtag": {
       "version": "0.44.0",
@@ -4010,25 +3884,6 @@
         "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/hashtag/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/hashtag/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
     "node_modules/@lexical/history": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.44.0.tgz",
@@ -4037,36 +3892,6 @@
       "dependencies": {
         "@lexical/extension": "0.44.0",
         "@lexical/utils": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/history/node_modules/@lexical/extension": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
-      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/utils": "0.44.0",
-        "@preact/signals-core": "^1.14.1",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/history/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/history/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
         "lexical": "0.44.0"
       }
     },
@@ -4082,36 +3907,6 @@
         "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/html/node_modules/@lexical/extension": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
-      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/utils": "0.44.0",
-        "@preact/signals-core": "^1.14.1",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/html/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/html/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
     "node_modules/@lexical/link": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.44.0.tgz",
@@ -4123,53 +3918,16 @@
         "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/link/node_modules/@lexical/extension": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
-      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/utils": "0.44.0",
-        "@preact/signals-core": "^1.14.1",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/link/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/link/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
     "node_modules/@lexical/list": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.43.0.tgz",
-      "integrity": "sha512-WyYVeQa2x1LrI8Emr9AiWTjSMiZw77Zy7MRnohPTdX/4fu3Njfw61lpoonCNHlv/r5Mb/RHkIAwWjtjcSzwA+g==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.44.0.tgz",
+      "integrity": "sha512-ZTCWxDz1okPrC9FBXi1yV3W5fbQQeMUlFIcSVF9HibcVPmCsPa900IxthuiQbGiTycUyXDTOB3IUYRtlJNtpjw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.43.0",
-        "@lexical/selection": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/extension": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
       }
-    },
-    "node_modules/@lexical/list/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
     },
     "node_modules/@lexical/mark": {
       "version": "0.44.0",
@@ -4178,25 +3936,6 @@
       "license": "MIT",
       "dependencies": {
         "@lexical/utils": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/mark/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/mark/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
         "lexical": "0.44.0"
       }
     },
@@ -4212,47 +3951,6 @@
         "@lexical/rich-text": "0.44.0",
         "@lexical/text": "0.44.0",
         "@lexical/utils": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/markdown/node_modules/@lexical/extension": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
-      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/utils": "0.44.0",
-        "@preact/signals-core": "^1.14.1",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/markdown/node_modules/@lexical/list": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.44.0.tgz",
-      "integrity": "sha512-ZTCWxDz1okPrC9FBXi1yV3W5fbQQeMUlFIcSVF9HibcVPmCsPa900IxthuiQbGiTycUyXDTOB3IUYRtlJNtpjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "@lexical/utils": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/markdown/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/markdown/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
         "lexical": "0.44.0"
       }
     },
@@ -4275,25 +3973,6 @@
         "@lexical/dragon": "0.44.0",
         "@lexical/selection": "0.44.0",
         "@lexical/utils": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/plain-text/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/plain-text/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
         "lexical": "0.44.0"
       }
     },
@@ -4334,47 +4013,6 @@
         }
       }
     },
-    "node_modules/@lexical/react/node_modules/@lexical/extension": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
-      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/utils": "0.44.0",
-        "@preact/signals-core": "^1.14.1",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/react/node_modules/@lexical/list": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.44.0.tgz",
-      "integrity": "sha512-ZTCWxDz1okPrC9FBXi1yV3W5fbQQeMUlFIcSVF9HibcVPmCsPa900IxthuiQbGiTycUyXDTOB3IUYRtlJNtpjw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "@lexical/utils": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/react/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/react/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
     "node_modules/@lexical/rich-text": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.44.0.tgz",
@@ -4388,7 +4026,7 @@
         "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/rich-text/node_modules/@lexical/selection": {
+    "node_modules/@lexical/selection": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
       "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
@@ -4396,31 +4034,6 @@
       "dependencies": {
         "lexical": "0.44.0"
       }
-    },
-    "node_modules/@lexical/rich-text/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/selection": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.43.0.tgz",
-      "integrity": "sha512-sdKdXIFggtHxTctvXjTyx2RgWuKOOP3PhrzRJF+COGfckrr/YzDtQCOfyvktElyKEeYXa3t9sx/R6Ep3n074fA==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.43.0"
-      }
-    },
-    "node_modules/@lexical/selection/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
     },
     "node_modules/@lexical/table": {
       "version": "0.44.0",
@@ -4434,36 +4047,6 @@
         "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/table/node_modules/@lexical/extension": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
-      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/utils": "0.44.0",
-        "@preact/signals-core": "^1.14.1",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/table/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/table/node_modules/@lexical/utils": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
-      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/selection": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
     "node_modules/@lexical/text": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.44.0.tgz",
@@ -4474,20 +4057,14 @@
       }
     },
     "node_modules/@lexical/utils": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.43.0.tgz",
-      "integrity": "sha512-Y9wzFwoeI9KLDJsztTz45Aobp6sACHSRqUtyjxpCsU0jwL60Tt9rD71QVz7SvpmzxjtnBb040s6LHa6vP0gY+A==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
       }
-    },
-    "node_modules/@lexical/utils/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
     },
     "node_modules/@lexical/yjs": {
       "version": "0.44.0",
@@ -4500,15 +4077,6 @@
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
-      }
-    },
-    "node_modules/@lexical/yjs/node_modules/@lexical/selection": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
-      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
-      "license": "MIT",
-      "dependencies": {
-        "lexical": "0.44.0"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.12.0",
       "dependencies": {
         "@lexical/html": "^0.44.0",
-        "@lexical/link": "^0.43.0",
+        "@lexical/link": "^0.44.0",
         "@lexical/list": "^0.43.0",
         "@lexical/react": "^0.44.0",
         "@lexical/rich-text": "^0.43.0",
@@ -3897,28 +3897,6 @@
         "react-dom": ">=17.x"
       }
     },
-    "node_modules/@lexical/devtools-core/node_modules/@lexical/extension": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
-      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/utils": "0.44.0",
-        "@preact/signals-core": "^1.14.1",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/devtools-core/node_modules/@lexical/link": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.44.0.tgz",
-      "integrity": "sha512-uvEqEol/mLEzGVQd8Rok9I48RgYPKokM/nsclI9nYcEdccVOM2Nri4ntoRwodhbccFLtjMPl8OBldwXbfc77tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "@lexical/utils": "0.44.0",
-        "lexical": "0.44.0"
-      }
-    },
     "node_modules/@lexical/devtools-core/node_modules/@lexical/selection": {
       "version": "0.44.0",
       "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
@@ -4085,21 +4063,45 @@
       }
     },
     "node_modules/@lexical/link": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.43.0.tgz",
-      "integrity": "sha512-jjU9PVWWBA2yEssbVkLQpu1ZIpXi3JwYb+JO20R47hzUm7T8SAPDd/VwU+2tcjqz065YntSGIaQ79dCft7WOJw==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.44.0.tgz",
+      "integrity": "sha512-uvEqEol/mLEzGVQd8Rok9I48RgYPKokM/nsclI9nYcEdccVOM2Nri4ntoRwodhbccFLtjMPl8OBldwXbfc77tQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/extension": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/link/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/link/node_modules/@lexical/extension": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
+      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.44.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/link/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/link/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@lexical/list": {
       "version": "0.43.0",
@@ -4196,17 +4198,6 @@
       "dependencies": {
         "@lexical/utils": "0.44.0",
         "@preact/signals-core": "^1.14.1",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/markdown/node_modules/@lexical/link": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.44.0.tgz",
-      "integrity": "sha512-uvEqEol/mLEzGVQd8Rok9I48RgYPKokM/nsclI9nYcEdccVOM2Nri4ntoRwodhbccFLtjMPl8OBldwXbfc77tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "@lexical/utils": "0.44.0",
         "lexical": "0.44.0"
       }
     },
@@ -4411,17 +4402,6 @@
       "dependencies": {
         "@lexical/utils": "0.44.0",
         "@preact/signals-core": "^1.14.1",
-        "lexical": "0.44.0"
-      }
-    },
-    "node_modules/@lexical/react/node_modules/@lexical/link": {
-      "version": "0.44.0",
-      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.44.0.tgz",
-      "integrity": "sha512-uvEqEol/mLEzGVQd8Rok9I48RgYPKokM/nsclI9nYcEdccVOM2Nri4ntoRwodhbccFLtjMPl8OBldwXbfc77tQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lexical/extension": "0.44.0",
-        "@lexical/utils": "0.44.0",
         "lexical": "0.44.0"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@lexical/react": "^0.43.0",
         "@lexical/rich-text": "^0.43.0",
         "js-beautify": "^1.7.5",
-        "lexical": "^0.43.0",
+        "lexical": "^0.44.0",
         "lodash-es": "^4.18.1",
         "prop-types": "^15.6.0",
         "react": "^18.3.1",
@@ -3822,6 +3822,12 @@
         "lexical": "0.43.0"
       }
     },
+    "node_modules/@lexical/clipboard/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
+    },
     "node_modules/@lexical/code-core": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@lexical/code-core/-/code-core-0.43.0.tgz",
@@ -3830,6 +3836,12 @@
       "dependencies": {
         "lexical": "0.43.0"
       }
+    },
+    "node_modules/@lexical/code-core/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
     },
     "node_modules/@lexical/devtools-core": {
       "version": "0.43.0",
@@ -3849,6 +3861,12 @@
         "react-dom": ">=17.x"
       }
     },
+    "node_modules/@lexical/devtools-core/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
+    },
     "node_modules/@lexical/dragon": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.43.0.tgz",
@@ -3858,6 +3876,12 @@
         "@lexical/extension": "0.43.0",
         "lexical": "0.43.0"
       }
+    },
+    "node_modules/@lexical/dragon/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
     },
     "node_modules/@lexical/extension": {
       "version": "0.43.0",
@@ -3870,6 +3894,12 @@
         "lexical": "0.43.0"
       }
     },
+    "node_modules/@lexical/extension/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
+    },
     "node_modules/@lexical/hashtag": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.43.0.tgz",
@@ -3880,6 +3910,12 @@
         "@lexical/utils": "0.43.0",
         "lexical": "0.43.0"
       }
+    },
+    "node_modules/@lexical/hashtag/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
     },
     "node_modules/@lexical/history": {
       "version": "0.43.0",
@@ -3892,6 +3928,12 @@
         "lexical": "0.43.0"
       }
     },
+    "node_modules/@lexical/history/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
+    },
     "node_modules/@lexical/html": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.43.0.tgz",
@@ -3903,6 +3945,12 @@
         "lexical": "0.43.0"
       }
     },
+    "node_modules/@lexical/html/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
+    },
     "node_modules/@lexical/link": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.43.0.tgz",
@@ -3913,6 +3961,12 @@
         "@lexical/utils": "0.43.0",
         "lexical": "0.43.0"
       }
+    },
+    "node_modules/@lexical/link/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
     },
     "node_modules/@lexical/list": {
       "version": "0.43.0",
@@ -3926,6 +3980,12 @@
         "lexical": "0.43.0"
       }
     },
+    "node_modules/@lexical/list/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
+    },
     "node_modules/@lexical/mark": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.43.0.tgz",
@@ -3935,6 +3995,12 @@
         "@lexical/utils": "0.43.0",
         "lexical": "0.43.0"
       }
+    },
+    "node_modules/@lexical/mark/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
     },
     "node_modules/@lexical/markdown": {
       "version": "0.43.0",
@@ -3951,6 +4017,12 @@
         "lexical": "0.43.0"
       }
     },
+    "node_modules/@lexical/markdown/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
+    },
     "node_modules/@lexical/offset": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.43.0.tgz",
@@ -3960,6 +4032,12 @@
         "lexical": "0.43.0"
       }
     },
+    "node_modules/@lexical/offset/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
+    },
     "node_modules/@lexical/overflow": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.43.0.tgz",
@@ -3968,6 +4046,12 @@
       "dependencies": {
         "lexical": "0.43.0"
       }
+    },
+    "node_modules/@lexical/overflow/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
     },
     "node_modules/@lexical/plain-text": {
       "version": "0.43.0",
@@ -3981,6 +4065,12 @@
         "@lexical/utils": "0.43.0",
         "lexical": "0.43.0"
       }
+    },
+    "node_modules/@lexical/plain-text/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
     },
     "node_modules/@lexical/react": {
       "version": "0.43.0",
@@ -4013,6 +4103,12 @@
         "react-dom": ">=17.x"
       }
     },
+    "node_modules/@lexical/react/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
+    },
     "node_modules/@lexical/rich-text": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.43.0.tgz",
@@ -4026,6 +4122,12 @@
         "lexical": "0.43.0"
       }
     },
+    "node_modules/@lexical/rich-text/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
+    },
     "node_modules/@lexical/selection": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.43.0.tgz",
@@ -4034,6 +4136,12 @@
       "dependencies": {
         "lexical": "0.43.0"
       }
+    },
+    "node_modules/@lexical/selection/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
     },
     "node_modules/@lexical/table": {
       "version": "0.43.0",
@@ -4047,6 +4155,12 @@
         "lexical": "0.43.0"
       }
     },
+    "node_modules/@lexical/table/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
+    },
     "node_modules/@lexical/text": {
       "version": "0.43.0",
       "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.43.0.tgz",
@@ -4055,6 +4169,12 @@
       "dependencies": {
         "lexical": "0.43.0"
       }
+    },
+    "node_modules/@lexical/text/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
     },
     "node_modules/@lexical/utils": {
       "version": "0.43.0",
@@ -4065,6 +4185,12 @@
         "@lexical/selection": "0.43.0",
         "lexical": "0.43.0"
       }
+    },
+    "node_modules/@lexical/utils/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
     },
     "node_modules/@lexical/yjs": {
       "version": "0.43.0",
@@ -4079,6 +4205,12 @@
       "peerDependencies": {
         "yjs": ">=13.5.22"
       }
+    },
+    "node_modules/@lexical/yjs/node_modules/lexical": {
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
+      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -16116,9 +16248,9 @@
       }
     },
     "node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.44.0.tgz",
+      "integrity": "sha512-ReDUjRlFgkGoPWzvdjr7s16PUVpHATN+2NH2NiZs+PLlISTaIFFgKil2P467oP3Vg+XgmpDsUgmWZsFJTztYjg==",
       "license": "MIT"
     },
     "node_modules/lib0": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@lexical/html": "^0.44.0",
         "@lexical/link": "^0.43.0",
         "@lexical/list": "^0.43.0",
-        "@lexical/react": "^0.43.0",
+        "@lexical/react": "^0.44.0",
         "@lexical/rich-text": "^0.43.0",
         "js-beautify": "^1.7.5",
         "lexical": "^0.44.0",
@@ -3840,54 +3840,103 @@
       "license": "MIT"
     },
     "node_modules/@lexical/code-core": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/code-core/-/code-core-0.43.0.tgz",
-      "integrity": "sha512-8NtEOI4+hM688Pmd0Qh/aTCS5uovps902V53LGB15DUUwwL+Z5U+Hz7ZYozhyM6W755FQ3x15qtEGIIbDHE5bQ==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/code-core/-/code-core-0.44.0.tgz",
+      "integrity": "sha512-m57JyXTIvW1tsqw/Vuogk8jqWCZZIeFQbWybRc46ytR8ReDgzPRODpN8+dacIIeRH5yC5UC3lAa743mtdNkxqg==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.43.0"
+        "@lexical/extension": "0.44.0",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/code-core/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
-    },
-    "node_modules/@lexical/devtools-core": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.43.0.tgz",
-      "integrity": "sha512-Hyz8vxvmo0aThXjq3+t0mabozmQeb6U+pxKceAgBSxE9oLWbQmP7RW8jYPZW20bYqEcX1Kgmu+CdW8e3eSF7Kw==",
+    "node_modules/@lexical/code-core/node_modules/@lexical/extension": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
+      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/html": "0.43.0",
-        "@lexical/link": "0.43.0",
-        "@lexical/mark": "0.43.0",
-        "@lexical/table": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/utils": "0.44.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/code-core/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/code-core/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/devtools-core": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/devtools-core/-/devtools-core-0.44.0.tgz",
+      "integrity": "sha512-X3uNG3P1vOsdzmEcy+7m9DxAcIVtVUZnvskmLqqLs6VluVVwH9xy7h1bPsvlDKvj1Nj73tWJ3TW0qXQWDTo5tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/html": "0.44.0",
+        "@lexical/link": "0.44.0",
+        "@lexical/mark": "0.44.0",
+        "@lexical/table": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
         "react-dom": ">=17.x"
       }
     },
-    "node_modules/@lexical/devtools-core/node_modules/@lexical/html": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/html/-/html-0.43.0.tgz",
-      "integrity": "sha512-C6LpUQlRl9J8Hqpm/C8LCX1ZxFHyD/gvOdV+NuNGnXN06uo0jDDm9SNh/HI3VWvFu9ec4OuzUkQRCafW8WC8fQ==",
+    "node_modules/@lexical/devtools-core/node_modules/@lexical/extension": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
+      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/selection": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/utils": "0.44.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/devtools-core/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/devtools-core/node_modules/@lexical/link": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.44.0.tgz",
+      "integrity": "sha512-uvEqEol/mLEzGVQd8Rok9I48RgYPKokM/nsclI9nYcEdccVOM2Nri4ntoRwodhbccFLtjMPl8OBldwXbfc77tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/devtools-core/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/devtools-core/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@lexical/dragon": {
       "version": "0.43.0",
@@ -3923,38 +3972,75 @@
       "license": "MIT"
     },
     "node_modules/@lexical/hashtag": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.43.0.tgz",
-      "integrity": "sha512-oCKjY8/jkxJuu8iBnNX0WSLA6ZIYTn+v3NLpJxDqnAFZJCnJ2i/nM8GKzPMzHCDzJVNxbQB08fOptdXf8eN0Fg==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/hashtag/-/hashtag-0.44.0.tgz",
+      "integrity": "sha512-0WATahDSqYKVTudQv3KpFbLeCpmrCpRptPFbjxOMckAX2MRpYlrExlqKfgfpri5BSQPtG49EPSGeNfSx/Faavw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/text": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/text": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/hashtag/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/hashtag/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/hashtag/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@lexical/history": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.43.0.tgz",
-      "integrity": "sha512-SdrH3xgtUcolVRLihbQwiANQIiwSLdkKBon9oSsZNNnzVgEb7DUQUtJQGf33oW8HHWObIuWkh72W0fN1dZixOw==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/history/-/history-0.44.0.tgz",
+      "integrity": "sha512-RGXcbFTgYL1GIWaReBI26mNSsJTfiA9EAtDY4LBeZ14NrIQhYNokKgNiOxq5Bn8xXrl2+mawQEqoMfgpWp/5YA==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/extension": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/extension": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/history/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/history/node_modules/@lexical/extension": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
+      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.44.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/history/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/history/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@lexical/html": {
       "version": "0.44.0",
@@ -4034,127 +4120,353 @@
       "license": "MIT"
     },
     "node_modules/@lexical/mark": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.43.0.tgz",
-      "integrity": "sha512-pgwR5ia2ECDS0pyQxIrFvMOKjffI6fo2cGwqYg+Jz+ANMqE5zD4PoOUs7FEuZYAKPOAQR9GrETB7YAVSzKjk3Q==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/mark/-/mark-0.44.0.tgz",
+      "integrity": "sha512-bWMowllwe6BcgYMAkrsZx6Z+CX/72qCQpFKhlkR4ael92yOWSBkz68xp1wxxkSnQX9zoI1gYTeWBofVsSDKcsQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/mark/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/mark/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/mark/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@lexical/markdown": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.43.0.tgz",
-      "integrity": "sha512-bJYhISQkdRo6XxcajgP9T+c8XAGfkJ/DHnSvM5nyJnHD0vZSH/2RZd2Lgt0eAnMVEt9ECG8cUkR557QSaPeJBA==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/markdown/-/markdown-0.44.0.tgz",
+      "integrity": "sha512-DwlXdp85pYMo3exDF6W3iz8plpuP+RQ4Me4Iljm7O5aPDp0SSrIoZxyX4zS668mVAoz5HHj1Ka0kQkft8mq26Q==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/code-core": "0.43.0",
-        "@lexical/link": "0.43.0",
-        "@lexical/list": "0.43.0",
-        "@lexical/rich-text": "0.43.0",
-        "@lexical/text": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/code-core": "0.44.0",
+        "@lexical/link": "0.44.0",
+        "@lexical/list": "0.44.0",
+        "@lexical/rich-text": "0.44.0",
+        "@lexical/text": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/markdown/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
-    },
-    "node_modules/@lexical/offset": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/offset/-/offset-0.43.0.tgz",
-      "integrity": "sha512-SYNF16Hk17ePaxFtPcBx3rzSM8yxDYSAzkSOdnUUePSzfTW3DUDzvUfe7q/7QCe/UlZd+4ULI0VjNgYRlR8Uiw==",
+    "node_modules/@lexical/markdown/node_modules/@lexical/clipboard": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.44.0.tgz",
+      "integrity": "sha512-nfmNIs7uENqlDI7cm2E4I1Yp8mDJGMhEQIrIV2rNWnL1oeHVXQ7yuYdyoPdcY1zuj/9nvkYBQYUEh0QiGwpETA==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.43.0"
+        "@lexical/extension": "0.44.0",
+        "@lexical/html": "0.44.0",
+        "@lexical/list": "0.44.0",
+        "@lexical/selection": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "@types/trusted-types": "^2.0.7",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/offset/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/markdown/node_modules/@lexical/dragon": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.44.0.tgz",
+      "integrity": "sha512-RhlsjVDket9k1+YFEkDE0/7Qyrh2BI0vxBMzrWwPJTXX/4YFanYN9su8RSabkIukBBJ3QiNOOoC8FKK4Lkr4qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/markdown/node_modules/@lexical/extension": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
+      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.44.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/markdown/node_modules/@lexical/link": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.44.0.tgz",
+      "integrity": "sha512-uvEqEol/mLEzGVQd8Rok9I48RgYPKokM/nsclI9nYcEdccVOM2Nri4ntoRwodhbccFLtjMPl8OBldwXbfc77tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/markdown/node_modules/@lexical/list": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.44.0.tgz",
+      "integrity": "sha512-ZTCWxDz1okPrC9FBXi1yV3W5fbQQeMUlFIcSVF9HibcVPmCsPa900IxthuiQbGiTycUyXDTOB3IUYRtlJNtpjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/markdown/node_modules/@lexical/rich-text": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.44.0.tgz",
+      "integrity": "sha512-IIdrutK5GY47ITjPlZB7KzUi9dBDwygsyFOwolnrYSL7m6TtGhAqrYiFg/YNOTT/nBzK3KQeCJRbnxpjJAVZtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.44.0",
+        "@lexical/dragon": "0.44.0",
+        "@lexical/selection": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/markdown/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/markdown/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@lexical/overflow": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.43.0.tgz",
-      "integrity": "sha512-Usm7UfIwydhsg+qMbkBav79AOKqYa32zXY+TXveTqbaA+IAoIl3vFYP9x9ie4cHz/kgrmt/QuQs66cwPefRakg==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/overflow/-/overflow-0.44.0.tgz",
+      "integrity": "sha512-5GYaYjSxn27pqHRfU+tQ2STF10wgJvI+MUnwTnUFSzy3dko1b+oV94K/Yx0TuEewPbwDibfoFA8CwqUvOLHAyw==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.43.0"
+        "lexical": "0.44.0"
       }
-    },
-    "node_modules/@lexical/overflow/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
     },
     "node_modules/@lexical/plain-text": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.43.0.tgz",
-      "integrity": "sha512-wza2z2+OSsq3UPsFseqsVvnAWvW9s3W/rjQuf6Bk2/Xde2F3R7fvu3kArsaaVPzUKTVeOPCD8hUKIUpxP5OT2g==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/plain-text/-/plain-text-0.44.0.tgz",
+      "integrity": "sha512-bIV4Lljk0x70zFhkZIwzSPK5q3m9FpDisjGm2/3Q/chb+5BW3Tv8QJmqnpCiSO6S2KXO7gfSy81ZfkQ1dcd4EQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.43.0",
-        "@lexical/dragon": "0.43.0",
-        "@lexical/selection": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/clipboard": "0.44.0",
+        "@lexical/dragon": "0.44.0",
+        "@lexical/selection": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/plain-text/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/plain-text/node_modules/@lexical/clipboard": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.44.0.tgz",
+      "integrity": "sha512-nfmNIs7uENqlDI7cm2E4I1Yp8mDJGMhEQIrIV2rNWnL1oeHVXQ7yuYdyoPdcY1zuj/9nvkYBQYUEh0QiGwpETA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "@lexical/html": "0.44.0",
+        "@lexical/list": "0.44.0",
+        "@lexical/selection": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "@types/trusted-types": "^2.0.7",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/plain-text/node_modules/@lexical/dragon": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.44.0.tgz",
+      "integrity": "sha512-RhlsjVDket9k1+YFEkDE0/7Qyrh2BI0vxBMzrWwPJTXX/4YFanYN9su8RSabkIukBBJ3QiNOOoC8FKK4Lkr4qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/plain-text/node_modules/@lexical/extension": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
+      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.44.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/plain-text/node_modules/@lexical/list": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.44.0.tgz",
+      "integrity": "sha512-ZTCWxDz1okPrC9FBXi1yV3W5fbQQeMUlFIcSVF9HibcVPmCsPa900IxthuiQbGiTycUyXDTOB3IUYRtlJNtpjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/plain-text/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/plain-text/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@lexical/react": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.43.0.tgz",
-      "integrity": "sha512-Ov9PCS7Ghm83fmjSDr6CafDLsuMhf7A7FFfEr4DmDM/6Lw2w0a0QQJP+KqxPqaVaRgeQMJAVg38Zgrvuk3v7tw==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/react/-/react-0.44.0.tgz",
+      "integrity": "sha512-p/NQd/fMh3pXb1XqegE2ruvWDcUmfB12OidQ9nwtMtj5VfcUjQu2I+trUhgGRIADxSYxMWmw+8PPj5YSf4m5oA==",
       "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
-        "@lexical/devtools-core": "0.43.0",
-        "@lexical/dragon": "0.43.0",
-        "@lexical/extension": "0.43.0",
-        "@lexical/hashtag": "0.43.0",
-        "@lexical/history": "0.43.0",
-        "@lexical/link": "0.43.0",
-        "@lexical/list": "0.43.0",
-        "@lexical/mark": "0.43.0",
-        "@lexical/markdown": "0.43.0",
-        "@lexical/overflow": "0.43.0",
-        "@lexical/plain-text": "0.43.0",
-        "@lexical/rich-text": "0.43.0",
-        "@lexical/table": "0.43.0",
-        "@lexical/text": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "@lexical/yjs": "0.43.0",
-        "lexical": "0.43.0",
+        "@lexical/devtools-core": "0.44.0",
+        "@lexical/dragon": "0.44.0",
+        "@lexical/extension": "0.44.0",
+        "@lexical/hashtag": "0.44.0",
+        "@lexical/history": "0.44.0",
+        "@lexical/link": "0.44.0",
+        "@lexical/list": "0.44.0",
+        "@lexical/mark": "0.44.0",
+        "@lexical/markdown": "0.44.0",
+        "@lexical/overflow": "0.44.0",
+        "@lexical/plain-text": "0.44.0",
+        "@lexical/rich-text": "0.44.0",
+        "@lexical/table": "0.44.0",
+        "@lexical/text": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "@lexical/yjs": "0.44.0",
+        "lexical": "0.44.0",
         "react-error-boundary": "^6.0.0"
       },
       "peerDependencies": {
         "react": ">=17.x",
-        "react-dom": ">=17.x"
+        "react-dom": ">=17.x",
+        "yjs": ">=13.5.22"
+      },
+      "peerDependenciesMeta": {
+        "yjs": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@lexical/react/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/react/node_modules/@lexical/clipboard": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.44.0.tgz",
+      "integrity": "sha512-nfmNIs7uENqlDI7cm2E4I1Yp8mDJGMhEQIrIV2rNWnL1oeHVXQ7yuYdyoPdcY1zuj/9nvkYBQYUEh0QiGwpETA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "@lexical/html": "0.44.0",
+        "@lexical/list": "0.44.0",
+        "@lexical/selection": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "@types/trusted-types": "^2.0.7",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/react/node_modules/@lexical/dragon": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/dragon/-/dragon-0.44.0.tgz",
+      "integrity": "sha512-RhlsjVDket9k1+YFEkDE0/7Qyrh2BI0vxBMzrWwPJTXX/4YFanYN9su8RSabkIukBBJ3QiNOOoC8FKK4Lkr4qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/react/node_modules/@lexical/extension": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
+      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.44.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/react/node_modules/@lexical/link": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/link/-/link-0.44.0.tgz",
+      "integrity": "sha512-uvEqEol/mLEzGVQd8Rok9I48RgYPKokM/nsclI9nYcEdccVOM2Nri4ntoRwodhbccFLtjMPl8OBldwXbfc77tQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/react/node_modules/@lexical/list": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.44.0.tgz",
+      "integrity": "sha512-ZTCWxDz1okPrC9FBXi1yV3W5fbQQeMUlFIcSVF9HibcVPmCsPa900IxthuiQbGiTycUyXDTOB3IUYRtlJNtpjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/react/node_modules/@lexical/rich-text": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/rich-text/-/rich-text-0.44.0.tgz",
+      "integrity": "sha512-IIdrutK5GY47ITjPlZB7KzUi9dBDwygsyFOwolnrYSL7m6TtGhAqrYiFg/YNOTT/nBzK3KQeCJRbnxpjJAVZtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/clipboard": "0.44.0",
+        "@lexical/dragon": "0.44.0",
+        "@lexical/selection": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/react/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/react/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@lexical/rich-text": {
       "version": "0.43.0",
@@ -4191,37 +4503,81 @@
       "license": "MIT"
     },
     "node_modules/@lexical/table": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.43.0.tgz",
-      "integrity": "sha512-oLrOBzRwpmdHDpGVRgwBVgO1ro0w50rMdtOVQ6KsL53ijZ6OiI1YE2ZNOy4qfJvjub+2dgp83gKpB7YcmXAP3w==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/table/-/table-0.44.0.tgz",
+      "integrity": "sha512-5Uq0O/fBCxcZp9y17fXUONY7dU9lVo/mB5JHy23laIiKzBKP5IzzTLMU9ikZTppIXbMNxYXd+R2pmy7PYTLyvw==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/clipboard": "0.43.0",
-        "@lexical/extension": "0.43.0",
-        "@lexical/utils": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/clipboard": "0.44.0",
+        "@lexical/extension": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
       }
     },
-    "node_modules/@lexical/table/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/table/node_modules/@lexical/clipboard": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/clipboard/-/clipboard-0.44.0.tgz",
+      "integrity": "sha512-nfmNIs7uENqlDI7cm2E4I1Yp8mDJGMhEQIrIV2rNWnL1oeHVXQ7yuYdyoPdcY1zuj/9nvkYBQYUEh0QiGwpETA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "@lexical/html": "0.44.0",
+        "@lexical/list": "0.44.0",
+        "@lexical/selection": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "@types/trusted-types": "^2.0.7",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/table/node_modules/@lexical/extension": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/extension/-/extension-0.44.0.tgz",
+      "integrity": "sha512-BsYtoc+0EU0pqcOpf/lIUDU6LQVO6zX2AawZoUWJzT3Wzfov23qsqZWvl2WGM9dnRTN5iISJL3Fl53bQVxiXxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/utils": "0.44.0",
+        "@preact/signals-core": "^1.14.1",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/table/node_modules/@lexical/list": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/list/-/list-0.44.0.tgz",
+      "integrity": "sha512-ZTCWxDz1okPrC9FBXi1yV3W5fbQQeMUlFIcSVF9HibcVPmCsPa900IxthuiQbGiTycUyXDTOB3IUYRtlJNtpjw==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/extension": "0.44.0",
+        "@lexical/utils": "0.44.0",
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/table/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
+    },
+    "node_modules/@lexical/table/node_modules/@lexical/utils": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/utils/-/utils-0.44.0.tgz",
+      "integrity": "sha512-/D2ptztNevfBJgtkj4uaiYBeRcvSy+1mQj6pNYaCFZIoPJIwl6H5fXwWAvpvr11vcQKP9DEEoXR+V4qkMOA+EA==",
+      "license": "MIT",
+      "dependencies": {
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@lexical/text": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.43.0.tgz",
-      "integrity": "sha512-dtUZ79WaAv3nEYBIWPBZIrjwCUPONN8HcgtReY3qku7WQkzqy3FaMwT/lBa92cUhqsn4ChLIBO3lPFhWRALyvg==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/text/-/text-0.44.0.tgz",
+      "integrity": "sha512-1XJD8ZbwaXljTl8k4+jjiopdhnYZm26IJw9Gv8+cIThVC0b6B3JZ/WxH97BMDcSloKvWHFkGiPztxRwNwA29Rw==",
       "license": "MIT",
       "dependencies": {
-        "lexical": "0.43.0"
+        "lexical": "0.44.0"
       }
-    },
-    "node_modules/@lexical/text/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
     },
     "node_modules/@lexical/utils": {
       "version": "0.43.0",
@@ -4240,24 +4596,26 @@
       "license": "MIT"
     },
     "node_modules/@lexical/yjs": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.43.0.tgz",
-      "integrity": "sha512-3ghY9BYZVo3Hg2TmY2+H3Q6+AhhGwNIhnr6mvCbdLBEsnSTXr4VZSPMXN2ae5phCPrI19eHrx4MvFNYodQcqrA==",
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/yjs/-/yjs-0.44.0.tgz",
+      "integrity": "sha512-b3QTub9J/3LuwSSdooynb6GbMHBRyBT4xUbXzXqNPbDHgYe6CDrqf/uJIHRihIjAhOnPaHYqo9XUzitl++N1DQ==",
       "license": "MIT",
       "dependencies": {
-        "@lexical/offset": "0.43.0",
-        "@lexical/selection": "0.43.0",
-        "lexical": "0.43.0"
+        "@lexical/selection": "0.44.0",
+        "lexical": "0.44.0"
       },
       "peerDependencies": {
         "yjs": ">=13.5.22"
       }
     },
-    "node_modules/@lexical/yjs/node_modules/lexical": {
-      "version": "0.43.0",
-      "resolved": "https://registry.npmjs.org/lexical/-/lexical-0.43.0.tgz",
-      "integrity": "sha512-waSeXyt1HxTFpU8KNRA3IQcvjvpw0lZNaSbGopfOi4bLV0FF9zYpqiScTnEUMP/b1W7qWmD4Z2Detw43XICxqQ==",
-      "license": "MIT"
+    "node_modules/@lexical/yjs/node_modules/@lexical/selection": {
+      "version": "0.44.0",
+      "resolved": "https://registry.npmjs.org/@lexical/selection/-/selection-0.44.0.tgz",
+      "integrity": "sha512-AEyeZJFFr5YRLeqVR+X0QAW19c4Fk4MFAQu52z2gxAyDGTj9xwVJxjfepVpfUp4P9K+sPtJ/yaqfMXH506ksSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "lexical": "0.44.0"
+      }
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
@@ -6377,6 +6735,12 @@
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
       "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
       "license": "MIT"
     },
     "node_modules/@types/use-sync-external-store": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14561,9 +14561,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9085,15 +9085,43 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/axios/node_modules/proxy-from-env": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -72,12 +72,12 @@
       "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -146,13 +146,13 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-      "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+      "version": "7.29.1",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
+      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.28.5",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/types": "^7.29.0",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -272,28 +272,28 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.27.1",
-        "@babel/types": "^7.27.1"
+        "@babel/traverse": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.27.1",
-        "@babel/traverse": "^7.28.3"
+        "@babel/helper-module-imports": "^7.28.6",
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/traverse": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -316,9 +316,9 @@
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
-      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
+      "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -433,12 +433,12 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-      "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.28.5"
+        "@babel/types": "^7.29.0"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -1238,16 +1238,16 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.28.5.tgz",
-      "integrity": "sha512-vn5Jma98LCOeBy/KpeQhXcV2WZgaRUtjwQmjoBuLNlOmkg0fB5pdvYVeWRYI69wWKwK2cD1QbMiUQnoujWvrew==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-transforms": "^7.28.3",
-        "@babel/helper-plugin-utils": "^7.27.1",
+        "@babel/helper-module-transforms": "^7.28.6",
+        "@babel/helper-plugin-utils": "^7.28.6",
         "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.5"
+        "@babel/traverse": "^7.29.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1963,31 +1963,31 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.27.2",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/parser": "^7.27.2",
-        "@babel/types": "^7.27.1"
+        "@babel/code-frame": "^7.28.6",
+        "@babel/parser": "^7.28.6",
+        "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-      "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
+      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.27.1",
-        "@babel/generator": "^7.28.5",
+        "@babel/code-frame": "^7.29.0",
+        "@babel/generator": "^7.29.0",
         "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.28.5",
-        "@babel/template": "^7.27.2",
-        "@babel/types": "^7.28.5",
+        "@babel/parser": "^7.29.0",
+        "@babel/template": "^7.28.6",
+        "@babel/types": "^7.29.0",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -1995,9 +1995,9 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-      "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13019,9 +13019,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9080,9 +9080,9 @@
       }
     },
     "node_modules/body-parser": {
-      "version": "1.20.4",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-      "integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+      "version": "1.20.5",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.5.tgz",
+      "integrity": "sha512-3grm+/2tUOvu2cjJkvsIxrv/wVpfXQW4PsQHYm7yk4vfpu7Ekl6nEsYBoJUL6qDwZUx8wUhQ8tR2qz+ad9c9OA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9094,7 +9094,7 @@
         "http-errors": "~2.0.1",
         "iconv-lite": "~0.4.24",
         "on-finished": "~2.4.1",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "raw-body": "~2.5.3",
         "type-is": "~1.6.18",
         "unpipe": "~1.0.0"
@@ -12439,15 +12439,15 @@
       "license": "MIT"
     },
     "node_modules/express": {
-      "version": "4.22.1",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-      "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+      "version": "4.22.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+      "integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
-        "body-parser": "~1.20.3",
+        "body-parser": "~1.20.5",
         "content-disposition": "~0.5.4",
         "content-type": "~1.0.4",
         "cookie": "~0.7.1",
@@ -12466,7 +12466,7 @@
         "parseurl": "~1.3.3",
         "path-to-regexp": "~0.1.12",
         "proxy-addr": "~2.0.7",
-        "qs": "~6.14.0",
+        "qs": "~6.15.1",
         "range-parser": "~1.2.1",
         "safe-buffer": "5.2.1",
         "send": "~0.19.0",
@@ -19398,9 +19398,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.14.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-      "integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16254,12 +16254,12 @@
       }
     },
     "node_modules/js-cookie": {
-      "version": "3.0.5",
-      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
-      "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.7.tgz",
+      "integrity": "sha512-z/wZZgDrkNV1eA0ULjM/F9/50Ya8fbzgKneSpoPsXSGd0KnpdtHfOZWK+GcwLk+EZbS4F9RBhU+K2RgzuDaItw==",
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=20"
       }
     },
     "node_modules/js-library-detector": {

--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
   "author": "Automattic",
   "private": true,
   "devDependencies": {
-    "@wordpress/i18n": "^6.17.0",
-    "@wordpress/scripts": "^32.0.0",
+    "@wordpress/i18n": "^6.18.0",
+    "@wordpress/scripts": "^32.1.0",
     "sass-module-importer": "^1.4.0",
     "sass-mq": "^7.0.0"
   },

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@lexical/html": "^0.44.0",
     "@lexical/link": "^0.44.0",
-    "@lexical/list": "^0.43.0",
+    "@lexical/list": "^0.44.0",
     "@lexical/react": "^0.44.0",
     "@lexical/rich-text": "^0.44.0",
     "js-beautify": "^1.7.5",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@lexical/html": "^0.44.0",
-    "@lexical/link": "^0.43.0",
+    "@lexical/link": "^0.44.0",
     "@lexical/list": "^0.43.0",
     "@lexical/react": "^0.44.0",
     "@lexical/rich-text": "^0.43.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "sass-mq": "^7.0.0"
   },
   "dependencies": {
-    "@lexical/html": "^0.43.0",
+    "@lexical/html": "^0.44.0",
     "@lexical/link": "^0.43.0",
     "@lexical/list": "^0.43.0",
     "@lexical/react": "^0.43.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "@lexical/react": "^0.43.0",
     "@lexical/rich-text": "^0.43.0",
     "js-beautify": "^1.7.5",
-    "lexical": "^0.43.0",
+    "lexical": "^0.44.0",
     "lodash-es": "^4.18.1",
     "prop-types": "^15.6.0",
     "react": "^18.3.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "@lexical/html": "^0.44.0",
     "@lexical/link": "^0.43.0",
     "@lexical/list": "^0.43.0",
-    "@lexical/react": "^0.43.0",
+    "@lexical/react": "^0.44.0",
     "@lexical/rich-text": "^0.43.0",
     "js-beautify": "^1.7.5",
     "lexical": "^0.44.0",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@lexical/link": "^0.44.0",
     "@lexical/list": "^0.43.0",
     "@lexical/react": "^0.44.0",
-    "@lexical/rich-text": "^0.43.0",
+    "@lexical/rich-text": "^0.44.0",
     "js-beautify": "^1.7.5",
     "lexical": "^0.44.0",
     "lodash-es": "^4.18.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liveblog",
   "description": "Liveblogging done right. Using WordPress",
-  "version": "1.12.0",
+  "version": "1.12.1",
   "author": "Automattic",
   "private": true,
   "devDependencies": {

--- a/tests/Integration/EntryTest.php
+++ b/tests/Integration/EntryTest.php
@@ -11,6 +11,7 @@ namespace Automattic\Liveblog\Tests\Integration;
 
 use Yoast\WPTestUtils\WPIntegration\TestCase;
 use WPCOM_Liveblog_Entry;
+use WPCOM_Liveblog_Entry_Key_Events;
 use WPCOM_Liveblog_Entry_Query;
 use ReflectionProperty;
 
@@ -157,6 +158,103 @@ final class EntryTest extends TestCase {
 		WPCOM_Liveblog_Entry::delete( $this->build_entry_args( array( 'entry_id' => $entry->get_id() ) ) );
 		$query = new WPCOM_Liveblog_Entry_Query( $entry->get_post_id(), 'liveblog' );
 		$this->assertNull( $query->get_by_id( $entry->get_id() ) );
+	}
+
+	/**
+	 * The update() method must reject an entry that belongs to a different post.
+	 *
+	 * Defence-in-depth at the mutation sink for HackerOne #3742849 (CWE-639
+	 * IDOR): the CRUD permission check authorises a post id, but the entry id is
+	 * supplied separately and must be bound to that post before wp_update_comment()
+	 * runs.
+	 */
+	public function test_update_rejects_entry_belonging_to_another_post(): void {
+		$entry            = WPCOM_Liveblog_Entry::insert( $this->build_entry_args( array( 'post_id' => 100 ) ) );
+		$entry_id         = (int) $entry->get_id();
+		$original_content = get_comment( $entry_id )->comment_content;
+
+		$result = WPCOM_Liveblog_Entry::update(
+			$this->build_entry_args(
+				array(
+					'post_id'  => 200,
+					'entry_id' => $entry_id,
+					'content'  => 'tampered',
+				)
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertEquals( $original_content, get_comment( $entry_id )->comment_content );
+	}
+
+	/**
+	 * The delete() method must reject an entry that belongs to a different post.
+	 */
+	public function test_delete_rejects_entry_belonging_to_another_post(): void {
+		$entry    = WPCOM_Liveblog_Entry::insert( $this->build_entry_args( array( 'post_id' => 100 ) ) );
+		$entry_id = (int) $entry->get_id();
+
+		$result = WPCOM_Liveblog_Entry::delete(
+			$this->build_entry_args(
+				array(
+					'post_id'  => 200,
+					'entry_id' => $entry_id,
+				)
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		$this->assertNotEquals( 'trash', get_comment( $entry_id )->comment_approved );
+	}
+
+	/**
+	 * The delete_key() method must reject an entry that belongs to a different
+	 * post before it strips the key-event comment meta. remove_key_action()
+	 * mutates the referenced entry, so the post-binding guard has to run first.
+	 */
+	public function test_delete_key_rejects_entry_belonging_to_another_post(): void {
+		$entry    = WPCOM_Liveblog_Entry::insert( $this->build_entry_args( array( 'post_id' => 100 ) ) );
+		$entry_id = (int) $entry->get_id();
+		add_comment_meta( $entry_id, WPCOM_Liveblog_Entry_Key_Events::META_KEY, WPCOM_Liveblog_Entry_Key_Events::META_VALUE );
+
+		$result = WPCOM_Liveblog_Entry::delete_key(
+			$this->build_entry_args(
+				array(
+					'post_id'  => 200,
+					'entry_id' => $entry_id,
+					'content'  => 'tampered',
+				)
+			)
+		);
+
+		$this->assertInstanceOf( 'WP_Error', $result );
+		// The key-event meta on the foreign entry must be untouched.
+		$this->assertEquals(
+			WPCOM_Liveblog_Entry_Key_Events::META_VALUE,
+			get_comment_meta( $entry_id, WPCOM_Liveblog_Entry_Key_Events::META_KEY, true )
+		);
+	}
+
+	/**
+	 * A legitimate update on an entry that belongs to the supplied post is
+	 * still allowed. Guards against the post-binding check over-reaching.
+	 */
+	public function test_update_allows_entry_belonging_to_the_same_post(): void {
+		$entry    = WPCOM_Liveblog_Entry::insert( $this->build_entry_args( array( 'post_id' => 100 ) ) );
+		$entry_id = (int) $entry->get_id();
+
+		$result = WPCOM_Liveblog_Entry::update(
+			$this->build_entry_args(
+				array(
+					'post_id'  => 100,
+					'entry_id' => $entry_id,
+					'content'  => 'legitimately updated',
+				)
+			)
+		);
+
+		$this->assertInstanceOf( WPCOM_Liveblog_Entry::class, $result );
+		$this->assertEquals( 'legitimately updated', get_comment( $entry_id )->comment_content );
 	}
 
 	/**

--- a/tests/Integration/EntryTest.php
+++ b/tests/Integration/EntryTest.php
@@ -318,6 +318,71 @@ final class EntryTest extends TestCase {
 	}
 
 	/**
+	 * Restricted shortcodes nested inside fragments of their own tag must be
+	 * stripped, not reconstructed.
+	 *
+	 * A single replacement pass is bypassable: removing the inner match from
+	 * `[liveblog_key[liveblog_key_events]_events]` leaves a working
+	 * `[liveblog_key_events]` behind, which `do_shortcode()` would then execute
+	 * at render time. The strip must repeat until no valid restricted shortcode
+	 * remains (CWE-94 via CWE-185).
+	 */
+	public function test_nested_restricted_shortcodes_are_fully_stripped(): void {
+		$key     = 'liveblog_key_events';
+		$pattern = '/' . get_shortcode_regex( array( $key ) ) . '/s';
+
+		$cases = array(
+			'[liveblog_key[liveblog_key_events]_events]',
+			'prefix [liveblog_key[liveblog_key_events]_events] suffix',
+			'[liveblog_key[liveblog_key[liveblog_key_events]_events]_events]',
+		);
+
+		foreach ( $cases as $input ) {
+			$result = WPCOM_Liveblog_Entry::handle_restricted_shortcodes( array( 'content' => $input ) );
+
+			$this->assertSame(
+				0,
+				preg_match( $pattern, $result['content'] ),
+				sprintf( 'A valid [%s] shortcode survived stripping of: %s', $key, $input )
+			);
+		}
+	}
+
+	/**
+	 * Removing one restricted shortcode must not reconstruct a different
+	 * restricted shortcode.
+	 *
+	 * When more than one shortcode is restricted, removing the inner one can
+	 * join the surrounding fragments into the other — e.g. stripping [embed]
+	 * from [gall[embed]ery] yields [gallery]. Stripping must therefore re-apply
+	 * the whole restricted set until the content stabilises, independently of the
+	 * order the tags appear in. The order here ('gallery' before 'embed') is the
+	 * one that a per-tag strip would fail to clean.
+	 */
+	public function test_cross_tag_restricted_shortcode_reconstruction_is_stripped(): void {
+		$original = WPCOM_Liveblog_Entry::$restricted_shortcodes;
+
+		$filter = static function () {
+			return array(
+				'gallery' => '',
+				'embed'   => '',
+			);
+		};
+		add_filter( 'liveblog_entry_restrict_shortcodes', $filter );
+
+		$result = WPCOM_Liveblog_Entry::handle_restricted_shortcodes( array( 'content' => 'before [gall[embed]ery] after' ) );
+
+		remove_filter( 'liveblog_entry_restrict_shortcodes', $filter );
+		WPCOM_Liveblog_Entry::$restricted_shortcodes = $original;
+
+		$this->assertSame(
+			0,
+			preg_match( '/' . get_shortcode_regex( array( 'gallery' ) ) . '/s', $result['content'] ),
+			'A restricted [gallery] reconstructed from a different restricted tag survived stripping.'
+		);
+	}
+
+	/**
 	 * `author_id` for a user with `edit_posts` is accepted and the resulting
 	 * comment is attributed to that user. This is the legitimate co-author
 	 * flow and must keep working.

--- a/tests/Integration/ExtendFeatureAuthorsTest.php
+++ b/tests/Integration/ExtendFeatureAuthorsTest.php
@@ -47,4 +47,37 @@ final class ExtendFeatureAuthorsTest extends TestCase {
 		}
 		return $example;
 	}
+
+	/**
+	 * The author autocomplete must not match the search term against user_email.
+	 *
+	 * Without an explicit search_columns, WP_User_Query searches user_email when
+	 * the term contains an '@', turning the picker into a blind email-existence
+	 * oracle for users holding `edit_posts` (CWE-203). An email-prefix search must
+	 * therefore return nothing, while a nicename / display-name search must still
+	 * resolve the user.
+	 *
+	 * @covers WPCOM_Liveblog_Entry_Extend_Feature_Authors::get_authors()
+	 */
+	public function test_get_authors_does_not_match_on_email(): void {
+		$user_id = self::factory()->user->create(
+			array(
+				'role'          => 'author',
+				'user_login'    => 'liveblogeditor',
+				'user_email'    => 'secret.address@example.com',
+				'display_name'  => 'Liveblog Editor',
+				'user_nicename' => 'liveblog-editor',
+			)
+		);
+
+		$feature = new WPCOM_Liveblog_Entry_Extend_Feature_Authors();
+
+		// An email-prefix search must not reveal the user.
+		$by_email = array_map( 'intval', wp_list_pluck( $feature->get_authors( 'secret.address@example' ), 'id' ) );
+		$this->assertNotContains( (int) $user_id, $by_email, 'Author autocomplete must not match on user_email.' );
+
+		// A legitimate nicename / display-name search must still find the user.
+		$by_name = array_map( 'intval', wp_list_pluck( $feature->get_authors( 'liveblog' ), 'id' ) );
+		$this->assertContains( (int) $user_id, $by_name, 'Author autocomplete should still match on nicename and display name.' );
+	}
 }

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -1105,6 +1105,87 @@ final class RestApiTest extends TestCase {
 	}
 
 	/**
+	 * An Author authorised on their own liveblog must not update an entry that
+	 * belongs to another user's post by supplying that entry's id in the body.
+	 *
+	 * Covers HackerOne report #3742849 (CWE-639 IDOR): an incomplete-fix
+	 * follow-up to the 1.12.0 post-scoped authorisation. The permission check
+	 * passes against the attacker-owned URL post, but the entry id must still be
+	 * bound to that post before the update sink runs.
+	 */
+	public function test_endpoint_crud_update_denied_for_entry_on_another_post(): void {
+		// Victim post (owned by another author) with a seeded entry.
+		$victim_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post_id   = $this->create_liveblog_post( array( 'post_author' => $victim_author_id ) );
+		$victim_entry     = $this->insert_entries( 1, array( 'post_id' => $victim_post_id ) )[0];
+		$victim_entry_id  = (int) $victim_entry->get_id();
+		$original_content = get_comment( $victim_entry_id )->comment_content;
+
+		// Attacker authorises against their own liveblog post.
+		$attacker_id      = $this->set_author_user();
+		$attacker_post_id = $this->create_liveblog_post( array( 'post_author' => $attacker_id ) );
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $attacker_post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'crud_action' => 'update',
+					'entry_id'    => $victim_entry_id,
+					'content'     => 'Tampered by attacker.',
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		// The request must not succeed in mutating the victim entry.
+		$this->assertNotEquals( 200, $response->get_status() );
+
+		// The victim entry content is unchanged and it has not been replaced.
+		$this->assertEquals( $original_content, get_comment( $victim_entry_id )->comment_content );
+		$replacements = get_comments(
+			array(
+				'meta_key'   => WPCOM_Liveblog_Entry::REPLACES_META_KEY, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => $victim_entry_id, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			)
+		);
+		$this->assertEmpty( $replacements, 'No replacement entry should have been created for the victim entry.' );
+	}
+
+	/**
+	 * An Author authorised on their own liveblog must not delete an entry that
+	 * belongs to another user's post by supplying that entry's id in the body.
+	 *
+	 * Covers HackerOne report #3742849 (CWE-639 IDOR).
+	 */
+	public function test_endpoint_crud_delete_denied_for_entry_on_another_post(): void {
+		$victim_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post_id   = $this->create_liveblog_post( array( 'post_author' => $victim_author_id ) );
+		$victim_entry     = $this->insert_entries( 1, array( 'post_id' => $victim_post_id ) )[0];
+		$victim_entry_id  = (int) $victim_entry->get_id();
+
+		$attacker_id      = $this->set_author_user();
+		$attacker_post_id = $this->create_liveblog_post( array( 'post_author' => $attacker_id ) );
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $attacker_post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'crud_action' => 'delete',
+					'entry_id'    => $victim_entry_id,
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		$this->assertNotEquals( 200, $response->get_status() );
+
+		// The victim entry must still be present and not trashed.
+		$this->assertNotEquals( 'trash', get_comment( $victim_entry_id )->comment_approved );
+	}
+
+	/**
 	 * The update_post_state route must be denied for an Author who does not own the post.
 	 */
 	public function test_endpoint_update_post_state_denied_for_non_owner_author(): void {

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -1210,6 +1210,50 @@ final class RestApiTest extends TestCase {
 	}
 
 	/**
+	 * A request body `post_id` must not override the URL post_id for the
+	 * post_state route.
+	 *
+	 * The permission callback authorises against the URL post, so the state change
+	 * must land on that post — never on a victim post supplied in the request body
+	 * or query string. Covers a cross-post IDOR (CWE-639) analogous to HackerOne
+	 * #3742849: an Author authorised on their own liveblog could otherwise enable,
+	 * archive, or disable the liveblog on any post by passing its id in the body.
+	 */
+	public function test_endpoint_update_post_state_body_post_id_cannot_override_url(): void {
+		// Victim post owned by another author, with an enabled liveblog.
+		$victim_author_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$victim_post_id   = $this->create_liveblog_post( array( 'post_author' => $victim_author_id ) );
+
+		// Attacker authorises against their own enabled liveblog post.
+		$attacker_id      = $this->set_author_user();
+		$attacker_post_id = $this->create_liveblog_post( array( 'post_author' => $attacker_id ) );
+
+		// URL path targets the attacker's own post (permission passes); the body
+		// tries to redirect the state change at the victim post.
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $attacker_post_id . '/post_state' );
+		$request->add_header( 'content-type', 'application/x-www-form-urlencoded' );
+		$request->set_body_params(
+			array(
+				'post_id'         => $victim_post_id,
+				'state'           => 'archive',
+				'template_name'   => 'list',
+				'template_format' => 'full',
+				'limit'           => '5',
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		// The request is authorised against the attacker's own post, so it succeeds.
+		$this->assertEquals( 200, $response->get_status() );
+
+		// The victim's liveblog state is untouched (still 'enable', not 'archive').
+		$this->assertEquals( 'enable', get_post_meta( $victim_post_id, WPCOM_Liveblog::KEY, true ) );
+
+		// The state change landed on the URL post (the attacker's own post).
+		$this->assertEquals( 'archive', get_post_meta( $attacker_post_id, WPCOM_Liveblog::KEY, true ) );
+	}
+
+	/**
 	 * Build the list of public read endpoint URLs that accept a post_id for testing.
 	 *
 	 * @param int $post_id  Post ID to embed.

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -1254,6 +1254,35 @@ final class RestApiTest extends TestCase {
 	}
 
 	/**
+	 * A non-string `content` value in the JSON body must be handled gracefully.
+	 *
+	 * The REST handlers read content straight from the decoded JSON body. An
+	 * array value would otherwise reach wp_filter_post_kses() unscalarised and
+	 * raise a PHP TypeError (HTTP 500) on PHP 8 (CWE-20). It must be coerced to a
+	 * string and the request handled without a server error.
+	 */
+	public function test_endpoint_crud_insert_with_array_content_does_not_error(): void {
+		$author_id = $this->set_author_user();
+		$post_id   = $this->create_liveblog_post( array( 'post_author' => $author_id ) );
+
+		$request = new WP_REST_Request( 'POST', self::ENDPOINT_BASE . '/' . $post_id . '/crud' );
+		$request->add_header( 'content-type', 'application/json' );
+		$request->set_body(
+			wp_json_encode(
+				array(
+					'crud_action' => 'insert',
+					'content'     => array( '<p>array content</p>' ),
+				)
+			)
+		);
+		$response = $this->server->dispatch( $request );
+
+		// The malformed content is coerced to a string rather than fatally
+		// erroring; the insert succeeds with empty content.
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
 	 * Build the list of public read endpoint URLs that accept a post_id for testing.
 	 *
 	 * @param int $post_id  Post ID to embed.


### PR DESCRIPTION
## Summary

This is the 1.12.1 release. It is a security and maintenance patch on top of 1.12.0, gathering everything merged to `develop` since that release and adding the changelog, translation template, and version bumps that make it a release.

The substance is a cluster of five security fixes found while reviewing the 1.12.0 post-scoping work. Two were cross-post authorisation bypasses (CWE-639): the entry CRUD path and the `post_state` write route both authorised against the URL post but then acted on a request-supplied id without binding the two together, letting an author authorised on their own liveblog reach another user's entry or post state. The other three close an author autocomplete that matched on, and so could disclose, editor email addresses (CWE-203); a restricted-shortcode strip that a single-pass regex could leave reconstructable (CWE-94 via CWE-185); and a REST entry content value that was not coerced to a string before use, risking a type error on PHP 8 (CWE-20). Alongside these sit the routine dependabot dependency and action bumps. None of the changes are breaking, so unlike 1.12.0 the changelog needs no upgrade callout.

The release itself is prepared as three reviewable commits, in the order the release process prescribes: the changelog entry, then the regenerated POT (which picks up the new version header, the shifted line references, and one new translatable string), then the version bump across the five places it is advertised — the plugin header and `VERSION` constant, `package.json`, the `README.md` stable tag, and the `AGENTS.md` knowledge table.

## Test plan

- [x] Full integration suite green on the release branch (150 tests, 307 assertions) via wp-env
- [x] Unit suite green (3 tests)
- [x] `composer i18n` regenerates the POT with no warnings
- [x] phpcs clean on the changed PHP
- [x] CI green on the PR
- [x] Manual smoke test of a liveblog entry create/update/delete on a test site before tagging

Once merged, tag `1.12.1` at the head of `main` to trigger the GitHub Release and WordPress.org deploy, then sync `main` back to `develop`.