### PR TITLE
Drop the dead admin-ajax fallback and go REST-only

### DIFF
--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -1,9 +1,8 @@
 import './styles.scss';
 
-/* global ajaxurl, liveblog_admin_settings, jQuery */
+/* global liveblog_admin_settings, jQuery */
 jQuery( function( $ ) {
 	var $meta_box = $( '#liveblog' ),
-		post_id = $( '#post_ID' ).val(),
 		show_error = function( status, code ) {
 			var template = code? liveblog_admin_settings.error_message_template : liveblog_admin_settings.short_error_message_template,
 				message = template.replace( '{error-message}', status ).replace( '{error-code}', code );
@@ -13,25 +12,17 @@ jQuery( function( $ ) {
 		e.preventDefault();
 		var data = {};
 
-		if (liveblog_admin_settings.use_rest_api == 1) {
-			var url = liveblog_admin_settings.endpoint_url;
-			data['state']                           = encodeURIComponent( $( this ).val() );
-			data['template_name']                   = encodeURIComponent( $( '#liveblog-key-template-name' ).val() );
-			data['template_format']                 = encodeURIComponent( $( '#liveblog-key-template-format' ).val() );
-			data['limit']                           = encodeURIComponent( $( '#liveblog-key-limit' ).val() );
-			data[liveblog_admin_settings.nonce_key] = liveblog_admin_settings.nonce;
-			var method = 'POST';
-
-		} else {
-			var url    = ajaxurl + '?action=set_liveblog_state_for_post&post_id=' + encodeURIComponent( post_id ) + '&state=' + encodeURIComponent( $( this ).val() ) + '&' + liveblog_admin_settings.nonce_key + '=' + liveblog_admin_settings.nonce;
-			url       += '&' + $('input, textarea, select', $meta_box).serialize();
-			var method = 'GET';
-		}
+		var url = liveblog_admin_settings.endpoint_url;
+		data['state']                           = encodeURIComponent( $( this ).val() );
+		data['template_name']                   = encodeURIComponent( $( '#liveblog-key-template-name' ).val() );
+		data['template_format']                 = encodeURIComponent( $( '#liveblog-key-template-format' ).val() );
+		data['limit']                           = encodeURIComponent( $( '#liveblog-key-limit' ).val() );
+		data[liveblog_admin_settings.nonce_key] = liveblog_admin_settings.nonce;
 
 		$.ajax( url, {
 			dataType: 'json',
 			data: data,
-			method: method,
+			method: 'POST',
 			success: function( response, status, xhr ) {
 				// Replace the metabox
 				$( '.inside', $meta_box ).empty().append( response );

--- a/src/php/Application/Config/LiveblogConfiguration.php
+++ b/src/php/Application/Config/LiveblogConfiguration.php
@@ -32,11 +32,6 @@ final class LiveblogConfiguration {
 	public const MIN_WP_VERSION = '4.4';
 
 	/**
-	 * Minimum WordPress REST API version required.
-	 */
-	public const MIN_WP_REST_API_VERSION = '4.4';
-
-	/**
 	 * Meta key for liveblog state.
 	 */
 	public const KEY = 'liveblog';
@@ -105,11 +100,6 @@ final class LiveblogConfiguration {
 	 * Cache-Control max-age value for cacheable JSON responses.
 	 */
 	public const RESPONSE_CACHE_MAX_AGE = DAY_IN_SECONDS;
-
-	/**
-	 * Whether to use the REST API.
-	 */
-	public const USE_REST_API = true;
 
 	/**
 	 * The default image size to use when inserting media from the media library.
@@ -246,25 +236,6 @@ final class LiveblogConfiguration {
 		}
 
 		self::$supported_post_types = $post_types;
-	}
-
-	/**
-	 * Check if REST API should be used.
-	 *
-	 * @return bool True if REST API should be used.
-	 */
-	public static function use_rest_api(): bool {
-		return self::USE_REST_API && self::can_use_rest_api();
-	}
-
-	/**
-	 * Check if WordPress version supports REST API.
-	 *
-	 * @return bool True if REST API is supported.
-	 */
-	public static function can_use_rest_api(): bool {
-		global $wp_version;
-		return version_compare( $wp_version, self::MIN_WP_REST_API_VERSION, '>=' );
 	}
 
 	/**

--- a/src/php/Application/Filter/AuthorFilter.php
+++ b/src/php/Application/Filter/AuthorFilter.php
@@ -149,9 +149,6 @@ final class AuthorFilter implements ContentFilterInterface {
 
 		// Add CSS classes to entries.
 		add_filter( 'comment_class', array( $this, 'add_author_class_to_entry' ), 10, 3 );
-
-		// Add AJAX endpoint for autocomplete.
-		add_action( 'wp_ajax_liveblog_authors', array( $this, 'ajax_authors' ) );
 	}
 
 	/**
@@ -253,11 +250,7 @@ final class AuthorFilter implements ContentFilterInterface {
 	 * @return array<string, mixed>|null
 	 */
 	public function get_autocomplete_config(): ?array {
-		$endpoint_url = admin_url( 'admin-ajax.php' ) . '?action=liveblog_authors';
-
-		if ( LiveblogConfiguration::use_rest_api() ) {
-			$endpoint_url = trailingslashit( trailingslashit( RestApiController::build_endpoint_base() ) . 'authors' );
-		}
+		$endpoint_url = trailingslashit( trailingslashit( RestApiController::build_endpoint_base() ) . 'authors' );
 
 		/**
 		 * Filter the author autocomplete config.
@@ -305,29 +298,6 @@ final class AuthorFilter implements ContentFilterInterface {
 		);
 
 		return array_merge( $classes, $authors[0] );
-	}
-
-	/**
-	 * AJAX handler for author autocomplete.
-	 *
-	 * @return void
-	 */
-	public function ajax_authors(): void {
-		// Only users who can edit a liveblog should be able to enumerate the
-		// author list. Without this any authenticated user (including
-		// subscribers) could scrape every user holding `edit_posts`.
-		if ( ! RestApiController::current_user_can_edit_liveblog() ) {
-			wp_send_json_error( null, 403 );
-		}
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public autocomplete endpoint.
-		$term = isset( $_GET['autocomplete'] ) ? sanitize_text_field( wp_unslash( $_GET['autocomplete'] ) ) : '';
-
-		$users = $this->get_authors( $term );
-
-		header( 'Content-Type: application/json' );
-		echo wp_json_encode( $users );
-		exit;
 	}
 
 	/**

--- a/src/php/Application/Filter/HashtagFilter.php
+++ b/src/php/Application/Filter/HashtagFilter.php
@@ -184,9 +184,6 @@ final class HashtagFilter implements ContentFilterInterface {
 
 		// Register the hashtag taxonomy.
 		add_action( 'init', array( $this, 'add_hashtag_taxonomy' ) );
-
-		// Add AJAX endpoint for autocomplete.
-		add_action( 'wp_ajax_liveblog_terms', array( $this, 'ajax_terms' ) );
 	}
 
 	/**
@@ -282,11 +279,7 @@ final class HashtagFilter implements ContentFilterInterface {
 	 * @return array<string, mixed>|null
 	 */
 	public function get_autocomplete_config(): ?array {
-		$endpoint_url = admin_url( 'admin-ajax.php' ) . '?action=liveblog_terms';
-
-		if ( LiveblogConfiguration::use_rest_api() ) {
-			$endpoint_url = trailingslashit( trailingslashit( RestApiController::build_endpoint_base() ) . 'hashtags' );
-		}
+		$endpoint_url = trailingslashit( trailingslashit( RestApiController::build_endpoint_base() ) . 'hashtags' );
 
 		/**
 		 * Filter the hashtag autocomplete config.
@@ -333,29 +326,6 @@ final class HashtagFilter implements ContentFilterInterface {
 		);
 
 		return array_merge( $classes, $terms[0] );
-	}
-
-	/**
-	 * AJAX handler for hashtag autocomplete.
-	 *
-	 * @return void
-	 */
-	public function ajax_terms(): void {
-		// Mirrors the REST hashtag endpoint's permission check. Without this any
-		// authenticated user could scrape the full hashtag taxonomy.
-		if ( ! RestApiController::current_user_can_edit_liveblog() ) {
-			wp_send_json_error( null, 403 );
-		}
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Public autocomplete endpoint.
-		$search_term = isset( $_GET['autocomplete'] ) ? sanitize_text_field( wp_unslash( $_GET['autocomplete'] ) ) : '';
-
-		$terms = $this->get_hashtag_terms( $search_term );
-
-		header( 'Content-Type: application/json' );
-		echo wp_json_encode( $terms );
-
-		exit;
 	}
 
 	/**

--- a/src/php/Infrastructure/WordPress/AssetManager.php
+++ b/src/php/Infrastructure/WordPress/AssetManager.php
@@ -108,13 +108,7 @@ final class AssetManager {
 			return;
 		}
 
-		$endpoint_url = '';
-		$use_rest_api = 0;
-
-		if ( LiveblogConfiguration::use_rest_api() ) {
-			$endpoint_url = RestApiController::build_endpoint_base() . $post_id . '/post_state';
-			$use_rest_api = 1;
-		}
+		$endpoint_url = RestApiController::build_endpoint_base() . $post_id . '/post_state';
 
 		$asset = $this->load_asset_file( 'admin' );
 
@@ -141,7 +135,6 @@ final class AssetManager {
 				'nonce'                        => wp_create_nonce( LiveblogConfiguration::NONCE_ACTION ),
 				'error_message_template'       => __( 'Error {error-code}: {error-message}', 'liveblog' ),
 				'short_error_message_template' => __( 'Error: {error-message}', 'liveblog' ),
-				'use_rest_api'                 => $use_rest_api,
 				'endpoint_url'                 => $endpoint_url,
 			)
 		);
@@ -307,7 +300,6 @@ final class AssetManager {
 			'delay_multiplier'             => LiveblogConfiguration::DELAY_MULTIPLIER,
 			'fade_out_duration'            => LiveblogConfiguration::FADE_OUT_DURATION,
 
-			'use_rest_api'                 => intval( LiveblogConfiguration::use_rest_api() ),
 			'endpoint_url'                 => $endpoint_url,
 			'cross_domain'                 => false,
 

--- a/src/php/Infrastructure/WordPress/PluginBootstrapper.php
+++ b/src/php/Infrastructure/WordPress/PluginBootstrapper.php
@@ -243,9 +243,7 @@ final class PluginBootstrapper {
 	 * @return void
 	 */
 	private function init_rest_api(): void {
-		if ( LiveblogConfiguration::use_rest_api() ) {
-			$this->container->rest_api_controller()->init();
-		}
+		$this->container->rest_api_controller()->init();
 	}
 
 	/**
@@ -553,35 +551,6 @@ final class PluginBootstrapper {
 
 		// Add meta box.
 		add_action( 'add_meta_boxes', array( $admin_controller, 'add_meta_box' ) );
-
-		// Handle AJAX state change.
-		add_action(
-			'wp_ajax_set_liveblog_state_for_post',
-			function () use ( $admin_controller ) {
-				// Verify nonce first.
-				$nonce = isset( $_REQUEST['_ajax_nonce'] ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Nonce verified below.
-					? sanitize_text_field( wp_unslash( $_REQUEST['_ajax_nonce'] ) ) // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-					: '';
-
-				if ( ! wp_verify_nonce( $nonce, 'liveblog_admin_nonce' ) ) {
-					wp_send_json_error( 'Invalid nonce' );
-				}
-
-				// Now safe to access other request data.
-				$post_id   = isset( $_REQUEST['post_id'] ) ? (int) $_REQUEST['post_id'] : 0;
-				$new_state = isset( $_REQUEST['state'] ) ? sanitize_text_field( wp_unslash( $_REQUEST['state'] ) ) : '';
-
-				if ( ! AdminController::current_user_can_edit_for_post( $post_id ) ) {
-					wp_send_json_error( 'Unauthorized' );
-				}
-
-				$result = $admin_controller->set_liveblog_state( $post_id, $new_state, $_REQUEST );
-				if ( false === $result ) {
-					wp_send_json_error( 'Failed to update state' );
-				}
-				wp_send_json_success( $result );
-			}
-		);
 
 		// Admin list filters.
 		add_filter( 'display_post_states', array( $admin_controller, 'add_display_post_state' ), 10, 2 );

--- a/wpcom-helper.php
+++ b/wpcom-helper.php
@@ -5,8 +5,6 @@
  * @package Liveblog
  */
 
-use Automattic\Liveblog\Application\Config\LiveblogConfiguration;
-
 /*
  * Disable Socket support.
  */
@@ -24,45 +22,6 @@ function wpcom_vip_liveblog_bump_stats_extras( $stat, $extra ) { // phpcs:ignore
 		bump_stats_extras( $stat, $extra );
 	}
 }
-
-// Use an AJAX URL, which is easier to match in server configs.
-// Using an endpoint can be ambiguous.
-add_action(
-	'after_liveblog_init',
-	function () {
-
-		// No need to use an Ajax URL if we're using the REST API.
-		if ( LiveblogConfiguration::use_rest_api() ) {
-			return;
-		}
-
-		add_filter(
-			'liveblog_endpoint_url',
-			function ( $url, $post_id ) {
-				return home_url( '__liveblog_' . $post_id . '/' );
-			},
-			10,
-			2
-		);
-		add_rewrite_rule( '^__liveblog_([0-9]+)/(.*)/?', 'index.php?p=$matches[1]&liveblog=$matches[2]', 'top' );
-
-		add_filter(
-			'liveblog_refresh_interval',
-			function ( $refresh_interval ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found -- Required by filter signature.
-				return 3; // More frequent updates; we can handle it.
-			}
-		);
-		// If a site's permalink structure does not end with a trailing slash the URL created by liveblog will redirect.
-		if ( isset( $_SERVER['REQUEST_URI'] ) && false !== strpos( sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ), '__liveblog_' ) ) { // Input var ok.
-			add_action(
-				'wp',
-				function () {
-					remove_action( 'template_redirect', 'redirect_canonical' );
-				}
-			);
-		}
-	}
-);
 
 // Load the Twitter scripts on every page.
 // The sacrifice of a script is better than


### PR DESCRIPTION
## Summary

This removes the REST-vs-admin-ajax transport duality, which is dead code. It follows from #904 (closed): rather than secure an admin-ajax fallback the bundled client never reaches, the duality goes away.

### Why it's dead

The whole fallback is gated by `LiveblogConfiguration::use_rest_api()`, which is `USE_REST_API && can_use_rest_api()`. Both are always true:

- `USE_REST_API` is a hardcoded `const true` — no filter, no `define()`, nothing flips it.
- `can_use_rest_api()` only returns false below WP 4.4, but 4.4 is the plugin's own minimum and is where the REST API shipped in core.

So the gate is always true on any supported install: the bundled admin metabox JS always takes the REST branch, and the React frontend is already REST-only (`src/react/services/api.js` uses the REST `endpoint_url` and `X-WP-Nonce` exclusively, with no fallback). The admin-ajax branches are unreachable through the shipped client.

The only thing the dead paths achieved was extra attack surface and contract drift. The admin-ajax state handler verified a nonce key/action the client never sends, so it silently never worked (the issue behind #904). The `liveblog_authors` / `liveblog_terms` admin-ajax handlers duplicated the REST autocomplete routes behind a weaker, **non-post-scoped** capability check.

### What changes

- Remove `use_rest_api()` / `USE_REST_API` / `can_use_rest_api()` and the `MIN_WP_REST_API_VERSION` constant from `LiveblogConfiguration`.
- Register the REST API unconditionally (`init_rest_api()`).
- Delete the three dead admin-ajax handlers — `set_liveblog_state_for_post`, `ajax_authors`, `ajax_terms` — and the `get_autocomplete_config()` branches that pointed at them (they now always resolve to the REST routes, which is what happened in practice anyway).
- `AssetManager` always localises the REST endpoint and no longer emits the now-unread `use_rest_api` flag.
- `src/admin/index.js` drops the admin-ajax `else` branch and posts to the REST endpoint only.
- `wpcom-helper.php` drops the `after_liveblog_init` block that swapped in the legacy `__liveblog_…` permalink endpoint when REST was "off" — also dead.

`RequestRouter` and the `URL_ENDPOINT` rewrite are deliberately **kept**: `RequestRouter` is the shared entry-query service used by both the REST controller and AMP, and the rewrite endpoint is harmless. The legacy permalink *dispatch* (reading entries off that endpoint) was already unwired — there is no `template_redirect → handle_request`, so nothing services it.

Net −178 lines.

## Test plan

`composer test:integration` — green (274 tests, unchanged); `phpcs` clean. No test changes were needed: the autocomplete-config and admin-scripts tests still pass because, with the always-true gate removed, the produced endpoint URLs are exactly what they already were. CI builds and lints the JS (`build/` is not committed).

> Separate observation, not addressed here: the REST autocomplete routes (`/authors/<term>`, `/hashtags/<term>`) use a global `current_user_can_edit_liveblog()` permission callback rather than being post-scoped as the 1.x 1.12.0 work made them. Removing the admin-ajax duplicates does not change that posture, but it looks like a missed port of the autocomplete post-scoping (CWE-863). Happy to look at it as a follow-up.