### PR TITLE
Post-scope the author and hashtag autocomplete REST routes

### DIFF
--- a/src/php/Application/Filter/AuthorFilter.php
+++ b/src/php/Application/Filter/AuthorFilter.php
@@ -250,7 +250,10 @@ final class AuthorFilter implements ContentFilterInterface {
 	 * @return array<string, mixed>|null
 	 */
 	public function get_autocomplete_config(): ?array {
-		$endpoint_url = trailingslashit( trailingslashit( RestApiController::build_endpoint_base() ) . 'authors' );
+		// Post-scoped REST route (`/<post_id>/authors`). The config is built
+		// without a post in scope, so the `%POST_ID%` placeholder is substituted
+		// by AssetManager when the config is localised for a specific post.
+		$endpoint_url = trailingslashit( trailingslashit( RestApiController::build_endpoint_base() ) . '%POST_ID%/authors' );
 
 		/**
 		 * Filter the author autocomplete config.

--- a/src/php/Application/Filter/HashtagFilter.php
+++ b/src/php/Application/Filter/HashtagFilter.php
@@ -279,7 +279,10 @@ final class HashtagFilter implements ContentFilterInterface {
 	 * @return array<string, mixed>|null
 	 */
 	public function get_autocomplete_config(): ?array {
-		$endpoint_url = trailingslashit( trailingslashit( RestApiController::build_endpoint_base() ) . 'hashtags' );
+		// Post-scoped REST route (`/<post_id>/hashtags`). The config is built
+		// without a post in scope, so the `%POST_ID%` placeholder is substituted
+		// by AssetManager when the config is localised for a specific post.
+		$endpoint_url = trailingslashit( trailingslashit( RestApiController::build_endpoint_base() ) . '%POST_ID%/hashtags' );
 
 		/**
 		 * Filter the hashtag autocomplete config.

--- a/src/php/Infrastructure/WordPress/AssetManager.php
+++ b/src/php/Infrastructure/WordPress/AssetManager.php
@@ -304,7 +304,7 @@ final class AssetManager {
 			'cross_domain'                 => false,
 
 			'features'                     => $this->content_filter_registry->get_enabled_features(),
-			'autocomplete'                 => $this->content_filter_registry->get_autocomplete_config(),
+			'autocomplete'                 => $this->post_scope_autocomplete_urls( $this->content_filter_registry->get_autocomplete_config(), $post_id ),
 			'command_class'                => apply_filters( 'liveblog_command_class', CommandFilter::DEFAULT_CLASS_PREFIX ),
 
 			// Internationalization strings.
@@ -328,6 +328,31 @@ final class AssetManager {
 		);
 
 		return apply_filters( 'liveblog_settings', $settings );
+	}
+
+	/**
+	 * Substitute the post id into the autocomplete endpoint URLs.
+	 *
+	 * The author and hashtag autocomplete configs are post-scoped REST routes
+	 * (`/<post_id>/authors`, `/<post_id>/hashtags`) whose permission check
+	 * requires `edit_post` on the target post. Their configs are built with a
+	 * `%POST_ID%` placeholder because they are produced without a post in scope;
+	 * this fills it in for the post being rendered. The bundled client appends the
+	 * search term to the URL, so the post id must already be baked in here.
+	 *
+	 * @param array $configs The autocomplete configs.
+	 * @param int   $post_id The current post ID.
+	 * @return array The configs with post-scoped URLs.
+	 */
+	private function post_scope_autocomplete_urls( array $configs, int $post_id ): array {
+		foreach ( $configs as &$config ) {
+			if ( isset( $config['url'] ) && is_string( $config['url'] ) ) {
+				$config['url'] = str_replace( '%POST_ID%', (string) $post_id, $config['url'] );
+			}
+		}
+		unset( $config );
+
+		return $configs;
 	}
 
 	/**

--- a/src/php/Infrastructure/WordPress/RestApiController.php
+++ b/src/php/Infrastructure/WordPress/RestApiController.php
@@ -134,22 +134,6 @@ final class RestApiController {
 	}
 
 	/**
-	 * Check if the current user can edit the liveblog.
-	 *
-	 * Static method for REST API permission callbacks that have no post in the URL
-	 * (e.g. authors and hashtags autocomplete). Gates on the configured global
-	 * editor capability without any post context.
-	 *
-	 * @return bool True if the current user can edit.
-	 */
-	public static function current_user_can_edit_liveblog(): bool {
-		$cap    = LiveblogConfiguration::get_edit_capability();
-		$retval = current_user_can( $cap );
-
-		return (bool) apply_filters( 'liveblog_current_user_can_edit_liveblog', $retval );
-	}
-
-	/**
 	 * Permission callback for REST write routes that target a specific post.
 	 *
 	 * The CRUD, preview and post_state routes all live under
@@ -381,30 +365,34 @@ final class RestApiController {
 			)
 		);
 
-		// Authors autocomplete.
+		// Authors autocomplete. Post-scoped so the permission check can require
+		// `edit_post` on the target post rather than a global capability that any
+		// `publish_posts` holder satisfies (CWE-863 user enumeration).
 		register_rest_route(
 			$this->api_namespace,
-			'/authors([/]*)(?P<term>.*)',
+			'/(?P<post_id>\d+)/authors([/]*)(?P<term>.*)',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_authors' ),
-				'permission_callback' => array( self::class, 'current_user_can_edit_liveblog' ),
+				'permission_callback' => array( self::class, 'current_user_can_edit_liveblog_for_request' ),
 				'args'                => array(
-					'term' => array( 'required' => false ),
+					'post_id' => array( 'required' => true ),
+					'term'    => array( 'required' => false ),
 				),
 			)
 		);
 
-		// Hashtags autocomplete.
+		// Hashtags autocomplete. Post-scoped for the same reason as the authors route.
 		register_rest_route(
 			$this->api_namespace,
-			'/hashtags([/]*)(?P<term>.*)',
+			'/(?P<post_id>\d+)/hashtags([/]*)(?P<term>.*)',
 			array(
 				'methods'             => WP_REST_Server::READABLE,
 				'callback'            => array( $this, 'get_hashtag_terms' ),
-				'permission_callback' => array( self::class, 'current_user_can_edit_liveblog' ),
+				'permission_callback' => array( self::class, 'current_user_can_edit_liveblog_for_request' ),
 				'args'                => array(
-					'term' => array( 'required' => false ),
+					'post_id' => array( 'required' => true ),
+					'term'    => array( 'required' => false ),
 				),
 			)
 		);

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -572,8 +572,9 @@ final class RestApiTest extends IntegrationTestCase {
 	 * Integration test - Test accessing the get authors endpoint.
 	 */
 	public function test_endpoint_get_authors(): void {
-		// Create an author and set as the current user.
-		$this->set_author_user();
+		// Create an author who owns the post being edited.
+		$author_id = $this->set_author_user();
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
 
 		// Create 2 authors.
 		self::factory()->user->create(
@@ -590,7 +591,7 @@ final class RestApiTest extends IntegrationTestCase {
 			)
 		);
 
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/authors/jo' );
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/authors/jo' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert successful response.
@@ -604,8 +605,9 @@ final class RestApiTest extends IntegrationTestCase {
 	 * Integration test - Test accessing the get hashtags endpoint.
 	 */
 	public function test_endpoint_get_hashtags(): void {
-		// Create an author and set as the current user.
-		$this->set_author_user();
+		// Create an author who owns the post being edited.
+		$author_id = $this->set_author_user();
+		$post_id   = self::factory()->post->create( array( 'post_author' => $author_id ) );
 
 		// Create 2 hashtags.
 		self::factory()->term->create(
@@ -623,7 +625,7 @@ final class RestApiTest extends IntegrationTestCase {
 			)
 		);
 
-		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/hashtags/cool' );
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/hashtags/cool' );
 		$response = $this->server->dispatch( $request );
 
 		// Assert successful response.
@@ -631,6 +633,40 @@ final class RestApiTest extends IntegrationTestCase {
 
 		// The array should contain 2 authors.
 		$this->assertCount( 2, $response->get_data() );
+	}
+
+	/**
+	 * The authors autocomplete must be denied for a user who cannot edit the
+	 * target post. The route is post-scoped so a global capability is not enough
+	 * (CWE-863 user enumeration).
+	 */
+	public function test_endpoint_get_authors_denied_for_non_owner(): void {
+		$owner_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id  = self::factory()->post->create( array( 'post_author' => $owner_id ) );
+
+		// A different author, who holds publish_posts but cannot edit the post.
+		$this->set_author_user();
+
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/authors/jo' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertTrue( $response->get_status() === 403 || $response->get_status() === 401 );
+	}
+
+	/**
+	 * The hashtags autocomplete must be denied for a user who cannot edit the
+	 * target post.
+	 */
+	public function test_endpoint_get_hashtags_denied_for_non_owner(): void {
+		$owner_id = self::factory()->user->create( array( 'role' => 'author' ) );
+		$post_id  = self::factory()->post->create( array( 'post_author' => $owner_id ) );
+
+		$this->set_author_user();
+
+		$request  = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/hashtags/cool' );
+		$response = $this->server->dispatch( $request );
+
+		$this->assertTrue( $response->get_status() === 403 || $response->get_status() === 401 );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The author and hashtag autocomplete REST routes were `/authors/<term>` and `/hashtags/<term>`, gated by a **global** capability check — `current_user_can_edit_liveblog()`, which tests `publish_posts`. Any user holding that capability (every default Author and above) could therefore enumerate every user with the editor capability, and every term in the `hashtags` taxonomy, regardless of whether they could edit any particular liveblog — and without any post in scope at all (CWE-863).

The 1.x line closed this in 1.12.0 by scoping the routes to a specific post and requiring `edit_post` on it. This was a missed port: the 2.x rewrite shipped the pre-fix global-cap shape. I noticed it while removing the duplicate admin-ajax autocomplete handlers in #907 and flagged it there; this fixes it.

The routes become `/(?P<post_id>\d+)/authors` and `/(?P<post_id>\d+)/hashtags`, authorised by `current_user_can_edit_liveblog_for_request()` — the same post-scoped callback the crud, preview and post_state routes already use, which requires `edit_post` on the URL post. The autocomplete result set itself is unchanged (the post is purely an authorisation boundary, not a filter), matching 1.x.

The autocomplete configs are built without a post in scope, so they now carry a `%POST_ID%` placeholder that `AssetManager` substitutes when localising for the post being rendered (`esc_url` preserves the placeholder, and `liveblog_settings.post_id` is already available). The bundled client appends the search term to that URL, so no JavaScript change is needed. The now-orphaned global `current_user_can_edit_liveblog()` callback is removed.

## Test plan

The existing endpoint tests are updated to dispatch against `/<post_id>/authors/jo` and `/<post_id>/hashtags/cool` for a post the current user owns (still 200). Two new tests assert that a different author — who holds `publish_posts` but cannot edit the post — is denied (403). The authors denial test was verified to fail when the route's permission is opened, confirming it enforces the post scope.

`composer test:integration` — green (276 tests); `phpcs` clean. CI rebuilds/lints the JS (`build/` isn't committed); no client change was required.