### PR TITLE
Gate liveblog reads on the post password requirement

### DIFF
--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -406,6 +406,8 @@ class WPCOM_Liveblog_Rest_Api {
 	 * - Liveblog to be enabled (or archived) on the post.
 	 * - The post to be published, or the current user to have the `read_post` capability
 	 *   for it.
+	 * - The post password requirement to be satisfied for the current request, so that
+	 *   password-protected published posts do not leak their entries.
 	 *
 	 * All failure paths return a 404 so the endpoint cannot be used as an oracle for
 	 * post existence or status.
@@ -426,10 +428,22 @@ class WPCOM_Liveblog_Rest_Api {
 		$post_id = (int) $request->get_param( 'post_id' );
 		$post    = $post_id > 0 ? get_post( $post_id ) : null;
 
+		// The post-status gate is necessary but not sufficient: a password-protected post
+		// keeps post_status = 'publish', and `read_post` resolves to the bare `read`
+		// capability for published posts, so both anonymous and logged-in callers would
+		// otherwise bypass the password boundary. Require the password to be satisfied for
+		// the current request as well, mirroring core's front-end content gating via
+		// post_password_required() (which also honours the `post_password_required` filter).
+		$status_allowed = (
+			$post instanceof WP_Post
+			&& ( 'publish' === $post->post_status || current_user_can( 'read_post', $post_id ) )
+		);
+
 		$allowed = (
 			$post instanceof WP_Post
 			&& WPCOM_Liveblog::is_liveblog_post( $post_id )
-			&& ( 'publish' === $post->post_status || current_user_can( 'read_post', $post_id ) )
+			&& $status_allowed
+			&& ! post_password_required( $post )
 		);
 
 		/**

--- a/liveblog.php
+++ b/liveblog.php
@@ -2222,6 +2222,14 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 				return $metadata;
 			}
 
+			// Do not expose entry bodies for a password-protected post until the password
+			// has been supplied. WordPress renders the password form (not the content) to
+			// such visitors, so the JSON-LD/AMP metadata must not become a side channel that
+			// discloses the protected entries.
+			if ( post_password_required( $post ) ) {
+				return $metadata;
+			}
+
 			$request = self::get_request_data();
 
 			$entries = self::get_entries_paged( $request->page, $request->last );

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -919,6 +919,79 @@ final class RestApiTest extends TestCase {
 	}
 
 	/**
+	 * Anonymous requests must not retrieve liveblog entries for a password-protected post.
+	 *
+	 * A password-protected post keeps post_status = 'publish', so the status gate alone
+	 * lets it through. Covers HackerOne report #3710276 (CWE-639/CWE-200, password
+	 * boundary bypass via the public read routes).
+	 */
+	public function test_public_read_endpoints_deny_anonymous_for_password_protected_post(): void {
+		$post_id = $this->create_liveblog_post( array( 'post_password' => 'secret-3710276' ) );
+		$entry   = $this->insert_entries( 1, array( 'post_id' => $post_id ) )[0];
+
+		foreach ( $this->public_read_urls_for_post( $post_id, (int) $entry->get_id() ) as $url ) {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+
+			$this->assertEquals(
+				404,
+				$response->get_status(),
+				sprintf( 'Expected 404 on %s for a password-protected post', $url )
+			);
+		}
+	}
+
+	/**
+	 * A logged-in subscriber must not read entries for a password-protected post.
+	 *
+	 * `read_post` resolves to the bare `read` capability for published posts, so a
+	 * subscriber would bypass the password boundary if the gate relied on capability
+	 * alone. Access must require the password, not merely being logged in.
+	 */
+	public function test_public_read_endpoints_deny_subscriber_for_password_protected_post(): void {
+		$post_id = $this->create_liveblog_post( array( 'post_password' => 'secret-3710276' ) );
+		$entry   = $this->insert_entries( 1, array( 'post_id' => $post_id ) )[0];
+
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+
+		foreach ( $this->public_read_urls_for_post( $post_id, (int) $entry->get_id() ) as $url ) {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+
+			$this->assertEquals(
+				404,
+				$response->get_status(),
+				sprintf( 'Expected 404 on %s for a logged-in subscriber without the password', $url )
+			);
+		}
+	}
+
+	/**
+	 * Satisfying the post password requirement unlocks the public read routes.
+	 *
+	 * Confirms the gate does not permanently lock out legitimate readers once the password
+	 * boundary is satisfied. The `post_password_required` filter stands in for a visitor who
+	 * has supplied the correct password (the same mechanism WordPress core consults), which
+	 * keeps the test independent of cookie-hashing internals. The permission callback is
+	 * exercised directly so the assertion focuses on the gate rather than the route handler.
+	 */
+	public function test_can_read_liveblog_allows_when_password_satisfied(): void {
+		$post_id = $this->create_liveblog_post( array( 'post_password' => 'secret-3710276' ) );
+		$this->insert_entries( 1, array( 'post_id' => $post_id ) );
+
+		// Without the password satisfied, the gate denies (404).
+		$request = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/entry/1' );
+		$request->set_param( 'post_id', $post_id );
+		$this->assertWPError( WPCOM_Liveblog_Rest_Api::can_read_liveblog( $request ) );
+
+		// With the password satisfied, the gate allows.
+		add_filter( 'post_password_required', '__return_false' );
+		$allowed = WPCOM_Liveblog_Rest_Api::can_read_liveblog( $request );
+		remove_filter( 'post_password_required', '__return_false' );
+
+		$this->assertTrue( $allowed );
+	}
+
+	/**
 	 * An editor user can read liveblog entries on a draft post they have permission to read.
 	 */
 	public function test_public_read_endpoints_allow_editor_on_draft_post(): void {

--- a/tests/Integration/SchemaMetadataTest.php
+++ b/tests/Integration/SchemaMetadataTest.php
@@ -309,6 +309,56 @@ final class SchemaMetadataTest extends TestCase {
 	}
 
 	/**
+	 * Test that no entry metadata is emitted for a password-protected post.
+	 *
+	 * WordPress renders the password form (not the content) to visitors who have not
+	 * supplied the password, so the JSON-LD/AMP metadata must not disclose the protected
+	 * entries. Covers HackerOne report #3710276 (Vector 2, structured-data side channel).
+	 */
+	public function test_no_entries_for_password_protected_post_without_password(): void {
+		wp_update_post(
+			array(
+				'ID'            => $this->post_id,
+				'post_password' => 'secret-3710276',
+			)
+		);
+
+		$this->insert_entry( array( 'content' => '<p>Protected entry body</p>' ) );
+
+		$metadata = WPCOM_Liveblog::get_liveblog_metadata( array(), get_post( $this->post_id ) );
+
+		// The filter bails before adding any liveblog metadata, so the passed-in array is
+		// returned untouched: no entry bodies and none of the LiveBlogPosting properties.
+		$this->assertArrayNotHasKey( 'liveBlogUpdate', $metadata );
+		$this->assertArrayNotHasKey( '@type', $metadata );
+	}
+
+	/**
+	 * Test that entry metadata is emitted once the password requirement is satisfied.
+	 *
+	 * The `post_password_required` filter stands in for a visitor who has supplied the
+	 * correct password (the same mechanism WordPress core consults), keeping the test
+	 * independent of cookie-hashing internals.
+	 */
+	public function test_entries_present_for_password_protected_post_with_password(): void {
+		wp_update_post(
+			array(
+				'ID'            => $this->post_id,
+				'post_password' => 'secret-3710276',
+			)
+		);
+
+		$this->insert_entry( array( 'content' => '<p>Protected entry body</p>' ) );
+
+		add_filter( 'post_password_required', '__return_false' );
+		$metadata = WPCOM_Liveblog::get_liveblog_metadata( array(), get_post( $this->post_id ) );
+		remove_filter( 'post_password_required', '__return_false' );
+
+		$this->assertArrayHasKey( 'liveBlogUpdate', $metadata );
+		$this->assertNotEmpty( $metadata['liveBlogUpdate'] );
+	}
+
+	/**
 	 * Insert a liveblog entry.
 	 *
 	 * @param array $args Arguments for entry.


### PR DESCRIPTION
## Summary

Reported via HackerOne #3710276 (CWE-639 / CWE-200). This closes a password-boundary bypass that survived the earlier REST read-gate hardening.

The `can_read_liveblog` permission callback treated `post_status` as the public/private boundary, permitting any post whose status is `publish`. WordPress password-protected posts keep `post_status = publish`, so the six public read routes returned protected entry bodies to callers who had never supplied the password. The exposure is wider than the report's anonymous-only framing: `read_post` resolves to the bare `read` capability for published posts, so even a logged-in subscriber could read the entries. A naive "is the caller logged in" check would not have closed it.

The same disclosure existed on the protected parent page itself. The JSON-LD `liveBlogUpdate` block — and the AMP metadata path, which shares `get_liveblog_metadata()` — printed the protected entry bodies even though WordPress renders the password form rather than the content to such visitors.

Both paths now consult `post_password_required()`, which mirrors core's front-end content gating and honours the `post_password_required` filter, so any site-level bypass policy stays consistent across core and Liveblog. The REST gate keeps the existing status check and layers the password check on top; the metadata builder bails before adding any liveblog data when the password is required. Editors and admins are unaffected in practice — they manage entries through the authenticated edit routes, and on the front end core already shows them the password form too.

## Test plan

New integration tests cover the gate from both sides:

- Anonymous and logged-in subscriber requests to all six public read routes return 404 for a password-protected post.
- The JSON-LD/AMP metadata omits `liveBlogUpdate` (and the `LiveBlogPosting` properties) for a protected post.
- Satisfying the password requirement restores access through both the REST gate and the metadata builder.

The positive cases use the `post_password_required` filter as the "password supplied" stand-in (keeping them independent of cookie-hashing internals) and exercise `can_read_liveblog()` directly so the assertion focuses on the gate rather than the route handler.

- [ ] `composer test:integration` — new password tests green; manually verify in wp-env that a password-protected liveblog no longer leaks entries via REST or JSON-LD before tagging.