### PR TITLE
Gate liveblog reads on the post password requirement (2.x)

### DIFF
--- a/src/php/Application/Aggregate/LiveblogPost.php
+++ b/src/php/Application/Aggregate/LiveblogPost.php
@@ -324,6 +324,20 @@ final class LiveblogPost {
 	}
 
 	/**
+	 * Check whether the post password requirement is unmet for the current request.
+	 *
+	 * A password-protected post keeps post_status = 'publish', so {@see is_published()}
+	 * alone is not a sufficient access boundary. This wraps WordPress core's
+	 * post_password_required() (which also honours the `post_password_required` filter)
+	 * so callers can refuse to disclose entries until the password has been supplied.
+	 *
+	 * @return bool True when a password is required but has not been satisfied.
+	 */
+	public function requires_password(): bool {
+		return post_password_required( $this->post );
+	}
+
+	/**
 	 * Check if we're currently viewing a liveblog post.
 	 *
 	 * This static helper checks if the current request is viewing a

--- a/src/php/Application/Presenter/MetadataPresenter.php
+++ b/src/php/Application/Presenter/MetadataPresenter.php
@@ -87,6 +87,14 @@ final class MetadataPresenter {
 			return $existing_metadata;
 		}
 
+		// Do not expose entry bodies for a password-protected post until the password
+		// has been supplied. WordPress renders the password form (not the content) to
+		// such visitors, so the JSON-LD/AMP metadata must not become a side channel that
+		// discloses the protected entries.
+		if ( $liveblog_post->requires_password() ) {
+			return $existing_metadata;
+		}
+
 		$entries        = $this->get_paginated_entries( $post->ID );
 		$blog_updates   = $this->build_blog_updates( $entries, $existing_metadata );
 		$liveblog_state = $liveblog_post->state();

--- a/src/php/Infrastructure/WordPress/RestApiController.php
+++ b/src/php/Infrastructure/WordPress/RestApiController.php
@@ -174,6 +174,8 @@ final class RestApiController {
 	 * - The post exists and its post type supports liveblog.
 	 * - Liveblog is enabled or archived on the post.
 	 * - The post is published, or the current user has `read_post` for it.
+	 * - The post password requirement is satisfied for the current request, so a
+	 *   password-protected published post does not leak its entries.
 	 *
 	 * All failure paths return a 404 so the endpoint cannot be used as an oracle
 	 * for post existence, status or liveblog-ness.
@@ -185,10 +187,21 @@ final class RestApiController {
 		$post_id       = (int) $request->get_param( 'post_id' );
 		$liveblog_post = $post_id > 0 ? LiveblogPost::from_id( $post_id ) : null;
 
+		// The status check is necessary but not sufficient: a password-protected post
+		// keeps post_status = 'publish', and `read_post` resolves to the bare `read`
+		// capability for published posts, so both anonymous and logged-in callers would
+		// otherwise bypass the password boundary. Require the password to be satisfied
+		// too, mirroring core's front-end content gating.
+		$status_allowed = (
+			$liveblog_post instanceof LiveblogPost
+			&& ( $liveblog_post->is_published() || current_user_can( 'read_post', $post_id ) )
+		);
+
 		$allowed = (
 			$liveblog_post instanceof LiveblogPost
 			&& $liveblog_post->is_liveblog()
-			&& ( $liveblog_post->is_published() || current_user_can( 'read_post', $post_id ) )
+			&& $status_allowed
+			&& ! $liveblog_post->requires_password()
 		);
 
 		/**

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -1241,6 +1241,80 @@ final class RestApiTest extends IntegrationTestCase {
 	}
 
 	/**
+	 * Anonymous requests must not retrieve liveblog entries for a password-protected post.
+	 *
+	 * A password-protected post keeps post_status = 'publish', so the status gate alone
+	 * lets it through. Covers HackerOne report #3710276 (CWE-639/CWE-200, password
+	 * boundary bypass via the public read routes).
+	 */
+	public function test_public_read_endpoints_deny_anonymous_for_password_protected_post(): void {
+		$post_id = $this->create_liveblog_post( array( 'post_password' => 'secret-3710276' ) );
+		$entry   = $this->insert_entries( 1, array( 'post_id' => $post_id ) )[0];
+
+		foreach ( $this->public_read_urls_for_post( $post_id, $entry->id()->to_int() ) as $url ) {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+
+			$this->assertEquals(
+				404,
+				$response->get_status(),
+				sprintf( 'Expected 404 on %s for a password-protected post', $url )
+			);
+		}
+	}
+
+	/**
+	 * A logged-in subscriber must not read entries for a password-protected post.
+	 *
+	 * `read_post` resolves to the bare `read` capability for published posts, so a
+	 * subscriber would bypass the password boundary if the gate relied on capability
+	 * alone. Access must require the password, not merely being logged in.
+	 */
+	public function test_public_read_endpoints_deny_subscriber_for_password_protected_post(): void {
+		$post_id = $this->create_liveblog_post( array( 'post_password' => 'secret-3710276' ) );
+		$entry   = $this->insert_entries( 1, array( 'post_id' => $post_id ) )[0];
+
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+
+		foreach ( $this->public_read_urls_for_post( $post_id, $entry->id()->to_int() ) as $url ) {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+
+			$this->assertEquals(
+				404,
+				$response->get_status(),
+				sprintf( 'Expected 404 on %s for a logged-in subscriber without the password', $url )
+			);
+		}
+	}
+
+	/**
+	 * Satisfying the post password requirement unlocks the public read routes.
+	 *
+	 * Confirms the gate does not permanently lock out legitimate readers once the password
+	 * boundary is satisfied. The `post_password_required` filter stands in for a visitor who
+	 * has supplied the correct password (the same mechanism WordPress core consults), which
+	 * keeps the test independent of cookie-hashing internals. The permission callback is
+	 * exercised directly so the assertion focuses on the gate rather than the route handler.
+	 */
+	public function test_can_read_liveblog_allows_when_password_satisfied(): void {
+		$post_id = $this->create_liveblog_post( array( 'post_password' => 'secret-3710276' ) );
+		$this->insert_entries( 1, array( 'post_id' => $post_id ) );
+
+		$request = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/entry/1' );
+		$request->set_param( 'post_id', $post_id );
+
+		// Without the password satisfied, the gate denies (404).
+		$this->assertWPError( RestApiController::can_read_liveblog( $request ) );
+
+		// With the password satisfied, the gate allows.
+		add_filter( 'post_password_required', '__return_false' );
+		$allowed = RestApiController::can_read_liveblog( $request );
+		remove_filter( 'post_password_required', '__return_false' );
+
+		$this->assertTrue( $allowed );
+	}
+
+	/**
 	 * An editor user can read liveblog entries on a draft post they have permission to read.
 	 */
 	public function test_public_read_endpoints_allow_editor_on_draft_post(): void {

--- a/tests/Integration/SchemaMetadataTest.php
+++ b/tests/Integration/SchemaMetadataTest.php
@@ -344,6 +344,62 @@ final class SchemaMetadataTest extends IntegrationTestCase {
 	}
 
 	/**
+	 * Test that no entry metadata is emitted for a password-protected post.
+	 *
+	 * WordPress renders the password form (not the content) to visitors who have not
+	 * supplied the password, so the JSON-LD/AMP metadata must not disclose the protected
+	 * entries. Covers HackerOne report #3710276 (Vector 2, structured-data side channel).
+	 *
+	 * @covers ::generate
+	 */
+	public function test_no_entries_for_password_protected_post_without_password(): void {
+		wp_update_post(
+			array(
+				'ID'            => $this->post_id,
+				'post_password' => 'secret-3710276',
+			)
+		);
+
+		$this->insert_entry( array( 'content' => '<p>Protected entry body</p>' ) );
+
+		$metadata_presenter = Container::instance()->metadata_presenter();
+		$metadata           = $metadata_presenter->generate( get_post( $this->post_id ), array() );
+
+		// The presenter bails before adding any liveblog metadata, so the passed-in array
+		// is returned untouched: no entry bodies and none of the LiveBlogPosting properties.
+		$this->assertArrayNotHasKey( 'liveBlogUpdate', $metadata );
+		$this->assertArrayNotHasKey( '@type', $metadata );
+	}
+
+	/**
+	 * Test that entry metadata is emitted once the password requirement is satisfied.
+	 *
+	 * The `post_password_required` filter stands in for a visitor who has supplied the
+	 * correct password (the same mechanism WordPress core consults), keeping the test
+	 * independent of cookie-hashing internals.
+	 *
+	 * @covers ::generate
+	 */
+	public function test_entries_present_for_password_protected_post_with_password(): void {
+		wp_update_post(
+			array(
+				'ID'            => $this->post_id,
+				'post_password' => 'secret-3710276',
+			)
+		);
+
+		$this->insert_entry( array( 'content' => '<p>Protected entry body</p>' ) );
+
+		add_filter( 'post_password_required', '__return_false' );
+		$metadata_presenter = Container::instance()->metadata_presenter();
+		$metadata           = $metadata_presenter->generate( get_post( $this->post_id ), array() );
+		remove_filter( 'post_password_required', '__return_false' );
+
+		$this->assertArrayHasKey( 'liveBlogUpdate', $metadata );
+		$this->assertNotEmpty( $metadata['liveBlogUpdate'] );
+	}
+
+	/**
 	 * Insert a liveblog entry.
 	 *
 	 * @param array $args Arguments for entry.


### PR DESCRIPTION
## Summary

Ports the develop fix for HackerOne #3710276 (CWE-639 / CWE-200) to the 2.x hexagonal codebase. See #910 for the develop equivalent.

The `can_read_liveblog` permission callback treated `post_status` as the public/private boundary, permitting any post whose status is `publish`. WordPress password-protected posts keep `post_status = publish`, so the six public read routes returned protected entry bodies to callers who had never supplied the password. The exposure is wider than anonymous access alone: `read_post` resolves to the bare `read` capability for published posts, so even a logged-in subscriber could read the entries.

The same disclosure existed on the protected parent page. The JSON-LD `liveBlogUpdate` block — and the AMP metadata path, which shares `MetadataPresenter::generate()` — printed the protected entry bodies even though WordPress renders the password form rather than the content.

The fix follows the architecture rather than reaching for `post_password_required()` ad hoc: a new `LiveblogPost::requires_password()` method on the aggregate wraps core's `post_password_required()`, keeping the WordPress dependency in one place and mirroring core's front-end content gating (including the `post_password_required` filter). `RestApiController::can_read_liveblog` layers the password check on top of the existing status check, and `MetadataPresenter::generate()` bails before adding any liveblog data when the password is required. Because the AMP integration also routes through `generate()`, that single guard covers both disclosure paths.

## Test plan

New integration tests mirror those in #910:

- Anonymous and logged-in subscriber requests to all six public read routes return 404 for a password-protected post.
- The JSON-LD/AMP metadata omits `liveBlogUpdate` for a protected post.
- Satisfying the password requirement restores access through both the gate and the metadata presenter.

- [ ] `composer test:integration` — full suite green (281 tests locally, including the 5 new password tests).