### PR TITLE
Release 1.12.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Real-time liveblogging plugin for WordPress with a React-based editor and a comm
 |----------|-------|
 | **Main file** | `liveblog.php` |
 | **Text domain** | `liveblog` |
-| **Version** | 1.12.1 |
+| **Version** | 1.12.2 |
 | **Requires PHP** | 7.4+ |
 | **Requires WP** | 6.4+ |
 | **Default branch** | `develop` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.12.2] - 2026-06-03
+
+### Security
+
+* fix: gate liveblog reads on the post password requirement by @GaryJones in https://github.com/Automattic/liveblog/pull/910 (CWE-639 / CWE-200)
+
 ## [1.12.1] - 2026-06-02
 
 ### Security
@@ -354,6 +360,7 @@ Fixed problems:
 * Initial release
 
 
+[1.12.2]: https://github.com/Automattic/liveblog/compare/1.12.1...1.12.2
 [1.12.1]: https://github.com/Automattic/liveblog/compare/1.12.0...1.12.1
 [1.12.0]: https://github.com/Automattic/liveblog/compare/1.11.1...1.12.0
 [1.11.1]: https://github.com/Automattic/liveblog/compare/1.11.0...1.11.1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tags: liveblog, live blog, real-time, news, sports
 Requires at least: 6.4  
 Requires PHP: 7.4  
 Tested up to: 6.9  
-Stable tag: 1.12.1  
+Stable tag: 1.12.2  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/classes/class-wpcom-liveblog-rest-api.php
+++ b/classes/class-wpcom-liveblog-rest-api.php
@@ -406,6 +406,8 @@ class WPCOM_Liveblog_Rest_Api {
 	 * - Liveblog to be enabled (or archived) on the post.
 	 * - The post to be published, or the current user to have the `read_post` capability
 	 *   for it.
+	 * - The post password requirement to be satisfied for the current request, so that
+	 *   password-protected published posts do not leak their entries.
 	 *
 	 * All failure paths return a 404 so the endpoint cannot be used as an oracle for
 	 * post existence or status.
@@ -426,10 +428,22 @@ class WPCOM_Liveblog_Rest_Api {
 		$post_id = (int) $request->get_param( 'post_id' );
 		$post    = $post_id > 0 ? get_post( $post_id ) : null;
 
+		// The post-status gate is necessary but not sufficient: a password-protected post
+		// keeps post_status = 'publish', and `read_post` resolves to the bare `read`
+		// capability for published posts, so both anonymous and logged-in callers would
+		// otherwise bypass the password boundary. Require the password to be satisfied for
+		// the current request as well, mirroring core's front-end content gating via
+		// post_password_required() (which also honours the `post_password_required` filter).
+		$status_allowed = (
+			$post instanceof WP_Post
+			&& ( 'publish' === $post->post_status || current_user_can( 'read_post', $post_id ) )
+		);
+
 		$allowed = (
 			$post instanceof WP_Post
 			&& WPCOM_Liveblog::is_liveblog_post( $post_id )
-			&& ( 'publish' === $post->post_status || current_user_can( 'read_post', $post_id ) )
+			&& $status_allowed
+			&& ! post_password_required( $post )
 		);
 
 		/**

--- a/languages/liveblog.pot
+++ b/languages/liveblog.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the Liveblog plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Liveblog 1.12.1\n"
+"Project-Id-Version: Liveblog 1.12.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/liveblog\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-02T12:43:58+00:00\n"
+"POT-Creation-Date: 2026-06-03T13:11:49+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: liveblog\n"
@@ -152,11 +152,11 @@ msgstr ""
 msgid "Error retrieving user"
 msgstr ""
 
-#: classes/class-wpcom-liveblog-rest-api.php:455
+#: classes/class-wpcom-liveblog-rest-api.php:469
 msgid "Liveblog not found."
 msgstr ""
 
-#: classes/class-wpcom-liveblog-rest-api.php:489
+#: classes/class-wpcom-liveblog-rest-api.php:503
 msgid "Sorry, you are not allowed to edit this liveblog."
 msgstr ""
 

--- a/liveblog.php
+++ b/liveblog.php
@@ -2222,6 +2222,14 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 				return $metadata;
 			}
 
+			// Do not expose entry bodies for a password-protected post until the password
+			// has been supplied. WordPress renders the password form (not the content) to
+			// such visitors, so the JSON-LD/AMP metadata must not become a side channel that
+			// discloses the protected entries.
+			if ( post_password_required( $post ) ) {
+				return $metadata;
+			}
+
 			$request = self::get_request_data();
 
 			$entries = self::get_entries_paged( $request->page, $request->last );

--- a/liveblog.php
+++ b/liveblog.php
@@ -3,7 +3,7 @@
  * Plugin Name: Liveblog
  * Plugin URI: http://wordpress.org/extend/plugins/liveblog/
  * Description: Empowers website owners to provide rich and engaging live event coverage to a large, distributed audience.
- * Version:     1.12.1
+ * Version:     1.12.2
  * Requires at least: 6.4
  * Requires PHP: 7.4
  * Author:      WordPress.com VIP, Big Bite Creative and contributors
@@ -33,7 +33,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		 *
 		 * @var string
 		 */
-		const VERSION = '1.12.1';
+		const VERSION = '1.12.2';
 
 		/**
 		 * Rewrites version for flushing rewrite rules.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "liveblog",
-  "version": "1.12.0",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "liveblog",
-      "version": "1.12.0",
+      "version": "1.12.2",
       "dependencies": {
         "@lexical/html": "^0.44.0",
         "@lexical/link": "^0.44.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liveblog",
   "description": "Liveblogging done right. Using WordPress",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "author": "Automattic",
   "private": true,
   "devDependencies": {

--- a/tests/Integration/RestApiTest.php
+++ b/tests/Integration/RestApiTest.php
@@ -919,6 +919,79 @@ final class RestApiTest extends TestCase {
 	}
 
 	/**
+	 * Anonymous requests must not retrieve liveblog entries for a password-protected post.
+	 *
+	 * A password-protected post keeps post_status = 'publish', so the status gate alone
+	 * lets it through. Covers HackerOne report #3710276 (CWE-639/CWE-200, password
+	 * boundary bypass via the public read routes).
+	 */
+	public function test_public_read_endpoints_deny_anonymous_for_password_protected_post(): void {
+		$post_id = $this->create_liveblog_post( array( 'post_password' => 'secret-3710276' ) );
+		$entry   = $this->insert_entries( 1, array( 'post_id' => $post_id ) )[0];
+
+		foreach ( $this->public_read_urls_for_post( $post_id, (int) $entry->get_id() ) as $url ) {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+
+			$this->assertEquals(
+				404,
+				$response->get_status(),
+				sprintf( 'Expected 404 on %s for a password-protected post', $url )
+			);
+		}
+	}
+
+	/**
+	 * A logged-in subscriber must not read entries for a password-protected post.
+	 *
+	 * `read_post` resolves to the bare `read` capability for published posts, so a
+	 * subscriber would bypass the password boundary if the gate relied on capability
+	 * alone. Access must require the password, not merely being logged in.
+	 */
+	public function test_public_read_endpoints_deny_subscriber_for_password_protected_post(): void {
+		$post_id = $this->create_liveblog_post( array( 'post_password' => 'secret-3710276' ) );
+		$entry   = $this->insert_entries( 1, array( 'post_id' => $post_id ) )[0];
+
+		$subscriber_id = self::factory()->user->create( array( 'role' => 'subscriber' ) );
+		wp_set_current_user( $subscriber_id );
+
+		foreach ( $this->public_read_urls_for_post( $post_id, (int) $entry->get_id() ) as $url ) {
+			$response = $this->server->dispatch( new WP_REST_Request( 'GET', $url ) );
+
+			$this->assertEquals(
+				404,
+				$response->get_status(),
+				sprintf( 'Expected 404 on %s for a logged-in subscriber without the password', $url )
+			);
+		}
+	}
+
+	/**
+	 * Satisfying the post password requirement unlocks the public read routes.
+	 *
+	 * Confirms the gate does not permanently lock out legitimate readers once the password
+	 * boundary is satisfied. The `post_password_required` filter stands in for a visitor who
+	 * has supplied the correct password (the same mechanism WordPress core consults), which
+	 * keeps the test independent of cookie-hashing internals. The permission callback is
+	 * exercised directly so the assertion focuses on the gate rather than the route handler.
+	 */
+	public function test_can_read_liveblog_allows_when_password_satisfied(): void {
+		$post_id = $this->create_liveblog_post( array( 'post_password' => 'secret-3710276' ) );
+		$this->insert_entries( 1, array( 'post_id' => $post_id ) );
+
+		// Without the password satisfied, the gate denies (404).
+		$request = new WP_REST_Request( 'GET', self::ENDPOINT_BASE . '/' . $post_id . '/entry/1' );
+		$request->set_param( 'post_id', $post_id );
+		$this->assertWPError( WPCOM_Liveblog_Rest_Api::can_read_liveblog( $request ) );
+
+		// With the password satisfied, the gate allows.
+		add_filter( 'post_password_required', '__return_false' );
+		$allowed = WPCOM_Liveblog_Rest_Api::can_read_liveblog( $request );
+		remove_filter( 'post_password_required', '__return_false' );
+
+		$this->assertTrue( $allowed );
+	}
+
+	/**
 	 * An editor user can read liveblog entries on a draft post they have permission to read.
 	 */
 	public function test_public_read_endpoints_allow_editor_on_draft_post(): void {

--- a/tests/Integration/SchemaMetadataTest.php
+++ b/tests/Integration/SchemaMetadataTest.php
@@ -309,6 +309,56 @@ final class SchemaMetadataTest extends TestCase {
 	}
 
 	/**
+	 * Test that no entry metadata is emitted for a password-protected post.
+	 *
+	 * WordPress renders the password form (not the content) to visitors who have not
+	 * supplied the password, so the JSON-LD/AMP metadata must not disclose the protected
+	 * entries. Covers HackerOne report #3710276 (Vector 2, structured-data side channel).
+	 */
+	public function test_no_entries_for_password_protected_post_without_password(): void {
+		wp_update_post(
+			array(
+				'ID'            => $this->post_id,
+				'post_password' => 'secret-3710276',
+			)
+		);
+
+		$this->insert_entry( array( 'content' => '<p>Protected entry body</p>' ) );
+
+		$metadata = WPCOM_Liveblog::get_liveblog_metadata( array(), get_post( $this->post_id ) );
+
+		// The filter bails before adding any liveblog metadata, so the passed-in array is
+		// returned untouched: no entry bodies and none of the LiveBlogPosting properties.
+		$this->assertArrayNotHasKey( 'liveBlogUpdate', $metadata );
+		$this->assertArrayNotHasKey( '@type', $metadata );
+	}
+
+	/**
+	 * Test that entry metadata is emitted once the password requirement is satisfied.
+	 *
+	 * The `post_password_required` filter stands in for a visitor who has supplied the
+	 * correct password (the same mechanism WordPress core consults), keeping the test
+	 * independent of cookie-hashing internals.
+	 */
+	public function test_entries_present_for_password_protected_post_with_password(): void {
+		wp_update_post(
+			array(
+				'ID'            => $this->post_id,
+				'post_password' => 'secret-3710276',
+			)
+		);
+
+		$this->insert_entry( array( 'content' => '<p>Protected entry body</p>' ) );
+
+		add_filter( 'post_password_required', '__return_false' );
+		$metadata = WPCOM_Liveblog::get_liveblog_metadata( array(), get_post( $this->post_id ) );
+		remove_filter( 'post_password_required', '__return_false' );
+
+		$this->assertArrayHasKey( 'liveBlogUpdate', $metadata );
+		$this->assertNotEmpty( $metadata['liveBlogUpdate'] );
+	}
+
+	/**
 	 * Insert a liveblog entry.
 	 *
 	 * @param array $args Arguments for entry.


### PR DESCRIPTION
## Summary

This is the 1.12.2 release. It is a single-fix security patch on top of 1.12.1, bringing the one change merged to `develop` since that release to `main`, along with the changelog, translation template, and version bumps that make it a release.

The substance is the fix for HackerOne #3710276 (#910): a password-boundary bypass that survived the earlier REST read-gate hardening. The `can_read_liveblog` permission callback treated `post_status` as the public/private boundary, so a password-protected post — which keeps `post_status = publish` — leaked its entries through the six public read routes. The exposure was wider than anonymous access alone, because `read_post` resolves to the bare `read` capability for published posts, so even a logged-in subscriber could read the entries. The same disclosure existed in the JSON-LD and AMP metadata on the protected parent page. Both paths now consult `post_password_required()`, mirroring core's front-end content gating and honouring the `post_password_required` filter. The change is not breaking, so the changelog needs no upgrade callout.

The release is prepared as three reviewable commits, in the order the release process prescribes: the changelog entry, then the regenerated POT (which picks up the new version header and the shifted line references — no string changes), then the version bump across the places it is advertised: the plugin header and `VERSION` constant, `README.md` stable tag, `package.json`, `package-lock.json`, and `AGENTS.md`. The lockfile version field had drifted to 1.12.0 across the last two releases and is brought back in line here.

## Test plan

- [x] CI green on the release branch.
- [ ] Manual wp-env check that a password-protected liveblog no longer leaks entries via the REST routes or the JSON-LD block, before the tag is pushed.