### PR TITLE
Sync 1.12.2 release back to develop

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Real-time liveblogging plugin for WordPress with a React-based editor and a comm
 |----------|-------|
 | **Main file** | `liveblog.php` |
 | **Text domain** | `liveblog` |
-| **Version** | 1.12.1 |
+| **Version** | 1.12.2 |
 | **Requires PHP** | 7.4+ |
 | **Requires WP** | 6.4+ |
 | **Default branch** | `develop` |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.12.2] - 2026-06-03
+
+### Security
+
+* fix: gate liveblog reads on the post password requirement by @GaryJones in https://github.com/Automattic/liveblog/pull/910 (CWE-639 / CWE-200)
+
 ## [1.12.1] - 2026-06-02
 
 ### Security
@@ -354,6 +360,7 @@ Fixed problems:
 * Initial release
 
 
+[1.12.2]: https://github.com/Automattic/liveblog/compare/1.12.1...1.12.2
 [1.12.1]: https://github.com/Automattic/liveblog/compare/1.12.0...1.12.1
 [1.12.0]: https://github.com/Automattic/liveblog/compare/1.11.1...1.12.0
 [1.11.1]: https://github.com/Automattic/liveblog/compare/1.11.0...1.11.1

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tags: liveblog, live blog, real-time, news, sports
 Requires at least: 6.4  
 Requires PHP: 7.4  
 Tested up to: 6.9  
-Stable tag: 1.12.1  
+Stable tag: 1.12.2  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/languages/liveblog.pot
+++ b/languages/liveblog.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the same license as the Liveblog plugin.
 msgid ""
 msgstr ""
-"Project-Id-Version: Liveblog 1.12.1\n"
+"Project-Id-Version: Liveblog 1.12.2\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/liveblog\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-06-02T12:43:58+00:00\n"
+"POT-Creation-Date: 2026-06-03T13:11:49+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: liveblog\n"
@@ -152,11 +152,11 @@ msgstr ""
 msgid "Error retrieving user"
 msgstr ""
 
-#: classes/class-wpcom-liveblog-rest-api.php:455
+#: classes/class-wpcom-liveblog-rest-api.php:469
 msgid "Liveblog not found."
 msgstr ""
 
-#: classes/class-wpcom-liveblog-rest-api.php:489
+#: classes/class-wpcom-liveblog-rest-api.php:503
 msgid "Sorry, you are not allowed to edit this liveblog."
 msgstr ""
 

--- a/liveblog.php
+++ b/liveblog.php
@@ -3,7 +3,7 @@
  * Plugin Name: Liveblog
  * Plugin URI: http://wordpress.org/extend/plugins/liveblog/
  * Description: Empowers website owners to provide rich and engaging live event coverage to a large, distributed audience.
- * Version:     1.12.1
+ * Version:     1.12.2
  * Requires at least: 6.4
  * Requires PHP: 7.4
  * Author:      WordPress.com VIP, Big Bite Creative and contributors
@@ -33,7 +33,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		 *
 		 * @var string
 		 */
-		const VERSION = '1.12.1';
+		const VERSION = '1.12.2';
 
 		/**
 		 * Rewrites version for flushing rewrite rules.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "liveblog",
-  "version": "1.12.0",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "liveblog",
-      "version": "1.12.0",
+      "version": "1.12.2",
       "dependencies": {
         "@lexical/html": "^0.44.0",
         "@lexical/link": "^0.44.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liveblog",
   "description": "Liveblogging done right. Using WordPress",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "author": "Automattic",
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
## Summary

Routine post-release sync, bringing the 1.12.2 release commits from `main` back into `develop` so the two branches do not drift. The security fix itself (#910) already landed on `develop`; this carries only the release-mechanical changes that were made on the release branch and merged to `main` via #912: the changelog entry, the regenerated translation template, and the version bumps across the plugin header and `VERSION` constant, `README.md`, `package.json`, `package-lock.json`, and `AGENTS.md`.

No functional code changes, so nothing here needs review beyond confirming the version metadata is consistent.