### PR TITLE
Prevent fatal error when previewing unpublished liveblog posts

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -2304,20 +2304,29 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 				$blog_updates[] = json_decode( wp_json_encode( $blog_item ) );
 			}
 
-			$metadata['@context']      = 'https://schema.org';
-			$metadata['@type']         = 'LiveBlogPosting';
-			$metadata['headline']      = get_the_title( $post );
-			$metadata['url']           = get_permalink( $post );
-			$metadata['datePublished'] = get_post_datetime( $post, 'date', 'gmt' )->format( 'c' );
-			$metadata['dateModified']  = get_post_datetime( $post, 'modified', 'gmt' )->format( 'c' );
+			$metadata['@context'] = 'https://schema.org';
+			$metadata['@type']    = 'LiveBlogPosting';
+			$metadata['headline'] = get_the_title( $post );
+			$metadata['url']      = get_permalink( $post );
+			// Unpublished posts (drafts, pending, auto-drafts) store a `0000-00-00 00:00:00`
+			// GMT date, for which get_post_datetime() returns false. Guard against calling
+			// format() on false to avoid a fatal when such a post is previewed.
+			$published_datetime = get_post_datetime( $post, 'date', 'gmt' );
+			if ( false !== $published_datetime ) {
+				$metadata['datePublished'] = $published_datetime->format( 'c' );
 
-			// Add coverage times for LiveBlogPosting (helps with Google's "LIVE" badge).
-			$metadata['coverageStartTime'] = $metadata['datePublished'];
+				// Add coverage times for LiveBlogPosting (helps with Google's "LIVE" badge).
+				$metadata['coverageStartTime'] = $metadata['datePublished'];
+			}
 
-			// Add coverageEndTime only if the liveblog is archived.
-			$liveblog_state = self::get_liveblog_state( $post->ID );
-			if ( 'archive' === $liveblog_state ) {
-				$metadata['coverageEndTime'] = $metadata['dateModified'];
+			$modified_datetime = get_post_datetime( $post, 'modified', 'gmt' );
+			if ( false !== $modified_datetime ) {
+				$metadata['dateModified'] = $modified_datetime->format( 'c' );
+
+				// Add coverageEndTime only if the liveblog is archived.
+				if ( 'archive' === self::get_liveblog_state( $post->ID ) ) {
+					$metadata['coverageEndTime'] = $metadata['dateModified'];
+				}
 			}
 
 			$metadata['liveBlogUpdate'] = $blog_updates;

--- a/tests/Integration/SchemaMetadataTest.php
+++ b/tests/Integration/SchemaMetadataTest.php
@@ -359,6 +359,51 @@ final class SchemaMetadataTest extends TestCase {
 	}
 
 	/**
+	 * Test that metadata generation does not fatal for an unpublished post.
+	 *
+	 * Drafts (and pending/auto-draft posts) store a `0000-00-00 00:00:00` GMT
+	 * date, for which get_post_datetime() returns false. Previously this caused
+	 * a fatal `Call to a member function format() on false` when such a post was
+	 * previewed. See https://github.com/Automattic/liveblog/issues/919.
+	 */
+	public function test_metadata_omits_dates_for_unpublished_post(): void {
+		$draft_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Draft Liveblog',
+				'post_status' => 'draft',
+			)
+		);
+		update_post_meta( $draft_id, WPCOM_Liveblog::KEY, 'enable' );
+
+		// Confirm the fixture reproduces the original conditions: the GMT date is
+		// unavailable, so get_post_datetime() returns false.
+		$this->assertFalse( get_post_datetime( $draft_id, 'date', 'gmt' ) );
+
+		$metadata = WPCOM_Liveblog::get_liveblog_metadata( array(), get_post( $draft_id ) );
+
+		// The metadata is still generated (proving the date code did not fatal)...
+		$this->assertEquals( 'LiveBlogPosting', $metadata['@type'] );
+
+		// ...but the date-derived properties are omitted rather than fatalling.
+		$this->assertArrayNotHasKey( 'datePublished', $metadata );
+		$this->assertArrayNotHasKey( 'dateModified', $metadata );
+		$this->assertArrayNotHasKey( 'coverageStartTime', $metadata );
+	}
+
+	/**
+	 * Test that a published post still includes the date-derived properties.
+	 */
+	public function test_metadata_includes_dates_for_published_post(): void {
+		$this->insert_entry( array( 'content' => '<p>Test entry</p>' ) );
+
+		$metadata = WPCOM_Liveblog::get_liveblog_metadata( array(), get_post( $this->post_id ) );
+
+		$this->assertArrayHasKey( 'datePublished', $metadata );
+		$this->assertArrayHasKey( 'dateModified', $metadata );
+		$this->assertArrayHasKey( 'coverageStartTime', $metadata );
+	}
+
+	/**
 	 * Insert a liveblog entry.
 	 *
 	 * @param array $args Arguments for entry.


### PR DESCRIPTION
## Summary

Viewing an unpublished liveblog post could take the whole page down with a fatal error:

```
PHP Fatal error: Uncaught Error: Call to a member function format() on false in liveblog.php
```

The schema metadata builder derived `datePublished` and `dateModified` by calling `get_post_datetime( $post, …, 'gmt' )->format( 'c' )`. WordPress stores a `0000-00-00 00:00:00` GMT date for drafts, pending and auto-draft posts, and for that value `get_post_datetime()` returns `false`. Calling `format()` on `false` then threw, and because the metadata is printed during `wp_head`, the error surfaced for anyone previewing such a post.

This change looks up each datetime first and only sets the corresponding schema properties (`datePublished`/`coverageStartTime` and `dateModified`/`coverageEndTime`) when a valid object is returned. The date-derived fields are simply omitted when no published date exists yet, which is the correct outcome for a post that has not been published. Behaviour is unchanged for published, private and scheduled posts, all of which carry real GMT dates.

The accompanying integration tests lock in both halves of the contract: a draft post now generates its metadata without fatalling and without the date keys, while a published post continues to expose them.

Fixes #919. Resolves VIPPLUG-24.

## Test plan

- [ ] `composer test:integration` (or the equivalent wp-env run) passes, including the two new `SchemaMetadataTest` cases
- [ ] Preview an unpublished liveblog-enabled post and confirm the page renders without a fatal