### PR TITLE
Prevent fatal error when previewing unpublished liveblog posts (2.x)

### DIFF
--- a/src/php/Application/Presenter/MetadataPresenter.php
+++ b/src/php/Application/Presenter/MetadataPresenter.php
@@ -101,19 +101,30 @@ final class MetadataPresenter {
 
 		$metadata = $existing_metadata;
 
-		$metadata['@context']      = 'https://schema.org';
-		$metadata['@type']         = 'LiveBlogPosting';
-		$metadata['headline']      = get_the_title( $post );
-		$metadata['url']           = get_permalink( $post );
-		$metadata['datePublished'] = get_post_datetime( $post, 'date', 'gmt' )->format( 'c' );
-		$metadata['dateModified']  = get_post_datetime( $post, 'modified', 'gmt' )->format( 'c' );
+		$metadata['@context'] = 'https://schema.org';
+		$metadata['@type']    = 'LiveBlogPosting';
+		$metadata['headline'] = get_the_title( $post );
+		$metadata['url']      = get_permalink( $post );
 
-		// Add coverage times for LiveBlogPosting (helps with Google's "LIVE" badge).
-		$metadata['coverageStartTime'] = $metadata['datePublished'];
+		// Unpublished posts (drafts, pending, auto-drafts) store a `0000-00-00 00:00:00`
+		// GMT date, for which get_post_datetime() returns false. Guard against calling
+		// format() on false to avoid a fatal when such a post is previewed.
+		$published_datetime = get_post_datetime( $post, 'date', 'gmt' );
+		if ( false !== $published_datetime ) {
+			$metadata['datePublished'] = $published_datetime->format( 'c' );
 
-		// Add coverageEndTime only if the liveblog is archived.
-		if ( LiveblogPost::STATE_ARCHIVED === $liveblog_state ) {
-			$metadata['coverageEndTime'] = $metadata['dateModified'];
+			// Add coverage times for LiveBlogPosting (helps with Google's "LIVE" badge).
+			$metadata['coverageStartTime'] = $metadata['datePublished'];
+		}
+
+		$modified_datetime = get_post_datetime( $post, 'modified', 'gmt' );
+		if ( false !== $modified_datetime ) {
+			$metadata['dateModified'] = $modified_datetime->format( 'c' );
+
+			// Add coverageEndTime only if the liveblog is archived.
+			if ( LiveblogPost::STATE_ARCHIVED === $liveblog_state ) {
+				$metadata['coverageEndTime'] = $metadata['dateModified'];
+			}
 		}
 
 		$metadata['liveBlogUpdate'] = $blog_updates;

--- a/tests/Integration/SchemaMetadataTest.php
+++ b/tests/Integration/SchemaMetadataTest.php
@@ -400,6 +400,57 @@ final class SchemaMetadataTest extends IntegrationTestCase {
 	}
 
 	/**
+	 * Test that metadata generation does not fatal for an unpublished post.
+	 *
+	 * Drafts (and pending/auto-draft posts) store a `0000-00-00 00:00:00` GMT
+	 * date, for which get_post_datetime() returns false. Previously this caused
+	 * a fatal `Call to a member function format() on false` when such a post was
+	 * previewed. See https://github.com/Automattic/liveblog/issues/919.
+	 *
+	 * @covers ::generate
+	 */
+	public function test_metadata_omits_dates_for_unpublished_post(): void {
+		$draft_id = self::factory()->post->create(
+			array(
+				'post_title'  => 'Draft Liveblog',
+				'post_status' => 'draft',
+			)
+		);
+		update_post_meta( $draft_id, LiveblogConfiguration::KEY, 'enable' );
+
+		// Confirm the fixture reproduces the original conditions: the GMT date is
+		// unavailable, so get_post_datetime() returns false.
+		$this->assertFalse( get_post_datetime( $draft_id, 'date', 'gmt' ) );
+
+		$metadata_presenter = Container::instance()->metadata_presenter();
+		$metadata           = $metadata_presenter->generate( get_post( $draft_id ), array() );
+
+		// The metadata is still generated (proving the date code did not fatal)...
+		$this->assertEquals( 'LiveBlogPosting', $metadata['@type'] );
+
+		// ...but the date-derived properties are omitted rather than fatalling.
+		$this->assertArrayNotHasKey( 'datePublished', $metadata );
+		$this->assertArrayNotHasKey( 'dateModified', $metadata );
+		$this->assertArrayNotHasKey( 'coverageStartTime', $metadata );
+	}
+
+	/**
+	 * Test that a published post still includes the date-derived properties.
+	 *
+	 * @covers ::generate
+	 */
+	public function test_metadata_includes_dates_for_published_post(): void {
+		$this->insert_entry( array( 'content' => '<p>Test entry</p>' ) );
+
+		$metadata_presenter = Container::instance()->metadata_presenter();
+		$metadata           = $metadata_presenter->generate( get_post( $this->post_id ), array() );
+
+		$this->assertArrayHasKey( 'datePublished', $metadata );
+		$this->assertArrayHasKey( 'dateModified', $metadata );
+		$this->assertArrayHasKey( 'coverageStartTime', $metadata );
+	}
+
+	/**
 	 * Insert a liveblog entry.
 	 *
 	 * @param array $args Arguments for entry.


### PR DESCRIPTION
## Summary

This ports the develop-branch fix in #921 to the 2.x line, which carries the same defect in its refactored form.

Viewing an unpublished liveblog post could take the whole page down with a fatal:

```
PHP Fatal error: Uncaught Error: Call to a member function format() on false
```

In 2.x the schema metadata is assembled by `MetadataPresenter`, which derived `datePublished` and `dateModified` by calling `get_post_datetime( $post, …, 'gmt' )->format( 'c' )`. WordPress stores a `0000-00-00 00:00:00` GMT date for drafts, pending and auto-draft posts, and for that value `get_post_datetime()` returns `false`. Calling `format()` on `false` threw, and because the metadata is printed during `wp_head`, the error surfaced for anyone previewing such a post.

Each datetime is now looked up first, and the corresponding schema properties (`datePublished`/`coverageStartTime` and `dateModified`/`coverageEndTime`) are only set when a valid object is returned. The date-derived fields are omitted when no published date exists yet, which is the correct outcome for a post that has not been published. Behaviour is unchanged for published, private and scheduled posts, which all carry real GMT dates.

The accompanying integration tests mirror those added on develop: a draft post now generates its metadata without fatalling and without the date keys, while a published post continues to expose them.

Since 2.x has not yet shipped, this is a pre-release fix rather than a hotfix. Resolves VIPPLUG-24 for the 2.x line.

## Test plan

- [ ] CI integration suite passes, including the two new `SchemaMetadataTest` cases
- [ ] Preview an unpublished liveblog-enabled post and confirm the page renders without a fatal