### PR TITLE
Lazy-load social SDKs only when an embed is present

### DIFF
--- a/classes/class-wpcom-liveblog-entry-embed-sdks.php
+++ b/classes/class-wpcom-liveblog-entry-embed-sdks.php
@@ -8,7 +8,14 @@
 /**
  * Class WPCOM_Liveblog_Entry_Embed_SDKs
  *
- * As we're render posts in React it requires some SDKs to pulled in on page load
+ * Provider SDKs (Facebook, Twitter/X, Instagram, Reddit) are no longer enqueued
+ * unconditionally on every Liveblog post. Instead, the list of provider SDK URLs
+ * is passed to the front-end app, which lazy-loads each SDK on demand the first
+ * time an entry containing that provider's embed markup is rendered. This avoids
+ * contacting third-party domains when no matching embed is present, and correctly
+ * handles embeds arriving in entries polled after the initial page load.
+ *
+ * @see triggerOembedLoad() in src/react/utils/utils.js for the client-side loader.
  */
 class WPCOM_Liveblog_Entry_Embed_SDKs {
 
@@ -18,7 +25,7 @@ class WPCOM_Liveblog_Entry_Embed_SDKs {
 	 * @var array
 	 */
 	protected static $sdks = array(
-		'facebook'  => 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&amp;version=v2.5',
+		'facebook'  => 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.5',
 		'twitter'   => 'https://platform.twitter.com/widgets.js',
 		'instagram' => 'https://www.instagram.com/embed.js',
 		'reddit'    => 'https://embed.reddit.com/widgets.js',
@@ -29,40 +36,37 @@ class WPCOM_Liveblog_Entry_Embed_SDKs {
 	 * acts as a constructor
 	 */
 	public static function load() {
+		/**
+		 * Filters the list of provider embed SDKs made available to the front-end.
+		 *
+		 * Return an empty array to disable all third-party SDK loading, or remove
+		 * individual providers (by key) to prevent their SDK from ever being loaded.
+		 *
+		 * @param array $sdks Map of provider name => SDK script URL.
+		 */
 		self::$sdks = apply_filters( 'liveblog_embed_sdks', self::$sdks );
 
-		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'enqueue' ) );
-		add_filter( 'script_loader_tag', array( __CLASS__, 'add_async_attribute' ), 10, 2 );
+		add_filter( 'liveblog_settings', array( __CLASS__, 'add_sdks_to_settings' ) );
 	}
 
 	/**
-	 * Loop through provider SDKs and enqueue them
+	 * Expose the provider SDK URLs to the front-end app so it can lazy-load
+	 * each SDK only when a matching embed is actually rendered.
 	 *
-	 * @return void
+	 * @param array $settings The liveblog front-end settings array.
+	 * @return array Settings with the `embed_sdks` map added.
 	 */
-	public static function enqueue() {
-		if ( ! WPCOM_Liveblog::is_viewing_liveblog_post() ) {
-			return;
-		}
-
-		foreach ( self::$sdks as $name => $url ) {
-			// Don't attach version with Reddit JS script file, it will generate 404 error.
-			$version = 'reddit' === $name ? null : WPCOM_Liveblog::VERSION;
-			wp_enqueue_script( $name, esc_url( $url ), array(), $version, false );
-		}
+	public static function add_sdks_to_settings( $settings ) {
+		$settings['embed_sdks'] = self::get_sdks();
+		return $settings;
 	}
 
 	/**
-	 * Set scripts to use async.
+	 * Get the (filtered) list of provider SDK URLs.
 	 *
-	 * @param string $tag    The script tag.
-	 * @param string $handle The script handle.
-	 * @return string Modified script tag.
+	 * @return array Map of provider name => SDK script URL.
 	 */
-	public static function add_async_attribute( $tag, $handle ) {
-		if ( ! in_array( $handle, array_keys( self::$sdks ), true ) ) {
-			return $tag;
-		}
-		return str_replace( ' src', ' async="async" src', $tag );
+	public static function get_sdks() {
+		return self::$sdks;
 	}
 }

--- a/src/react/utils/__tests__/utils.test.js
+++ b/src/react/utils/__tests__/utils.test.js
@@ -49,14 +49,32 @@ describe('utils', () => {
     let mockElement;
     let originalWindow;
 
+    const sdkUrls = {
+      facebook: 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.5',
+      twitter: 'https://platform.twitter.com/widgets.js',
+      instagram: 'https://www.instagram.com/embed.js',
+      reddit: 'https://embed.reddit.com/widgets.js',
+    };
+
+    const injectedScript = name => document.getElementById(`${name}-js`);
+
     beforeEach(() => {
       // Store original window properties
       originalWindow = {
         FB: window.FB,
         twttr: window.twttr,
         instgrm: window.instgrm,
+        liveblog_settings: window.liveblog_settings,
         dispatchEvent: window.dispatchEvent,
       };
+
+      // Provider SDKs are unavailable until explicitly loaded by each test.
+      window.FB = undefined;
+      window.twttr = undefined;
+      window.instgrm = undefined;
+
+      // Expose SDK URLs the way the server-side localisation does.
+      window.liveblog_settings = { embed_sdks: sdkUrls };
 
       // Create a mock DOM element
       mockElement = document.createElement('div');
@@ -70,16 +88,25 @@ describe('utils', () => {
       window.FB = originalWindow.FB;
       window.twttr = originalWindow.twttr;
       window.instgrm = originalWindow.instgrm;
+      window.liveblog_settings = originalWindow.liveblog_settings;
       window.dispatchEvent = originalWindow.dispatchEvent;
+
+      // Remove any SDK scripts injected during a test so state does not leak.
+      ['facebook', 'twitter', 'instagram', 'reddit'].forEach((name) => {
+        const script = injectedScript(name);
+        if (script) script.remove();
+      });
     });
 
-    it('should call FB.XFBML.parse with element when Facebook SDK is available', () => {
+    it('should call FB.XFBML.parse with the element when the SDK is loaded and markup is present', () => {
       const mockParse = jest.fn();
       window.FB = {
         XFBML: {
           parse: mockParse,
         },
       };
+
+      mockElement.innerHTML = '<div class="fb-post" data-href="https://facebook.com/test"></div>';
 
       triggerOembedLoad(mockElement);
 
@@ -87,26 +114,24 @@ describe('utils', () => {
       expect(mockParse).toHaveBeenCalledWith(mockElement);
     });
 
-    it('should not throw when Facebook SDK is not available', () => {
-      window.FB = undefined;
-
-      expect(() => triggerOembedLoad(mockElement)).not.toThrow();
-    });
-
-    it('should handle elements with fb-post class (modern HTML5 format)', () => {
+    it('should not process any provider when no embed markup is present', () => {
       const mockParse = jest.fn();
-      window.FB = {
-        XFBML: {
-          parse: mockParse,
-        },
-      };
-
-      // Add a modern HTML5 Facebook embed
-      mockElement.innerHTML = '<div class="fb-post" data-href="https://facebook.com/test"></div>';
+      window.FB = { XFBML: { parse: mockParse } };
+      window.twttr = { widgets: { load: jest.fn() } };
+      window.instgrm = { Embeds: { process: jest.fn() } };
 
       triggerOembedLoad(mockElement);
 
-      expect(mockParse).toHaveBeenCalledWith(mockElement);
+      expect(mockParse).not.toHaveBeenCalled();
+      expect(window.twttr.widgets.load).not.toHaveBeenCalled();
+      expect(window.instgrm.Embeds.process).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when an SDK is not available', () => {
+      window.FB = undefined;
+      mockElement.innerHTML = '<div class="fb-post"></div>';
+
+      expect(() => triggerOembedLoad(mockElement)).not.toThrow();
     });
 
     it('should handle elements with fb:post (legacy XFBML format)', () => {
@@ -165,6 +190,59 @@ describe('utils', () => {
       triggerOembedLoad(mockElement);
 
       expect(mockProcess).toHaveBeenCalledTimes(1);
+    });
+
+    it('should inject a provider SDK on demand when markup is present but the SDK is not loaded', () => {
+      mockElement.innerHTML = '<blockquote class="twitter-tweet"></blockquote>';
+
+      expect(injectedScript('twitter')).toBeNull();
+
+      triggerOembedLoad(mockElement);
+
+      const script = injectedScript('twitter');
+      expect(script).not.toBeNull();
+      expect(script.src).toBe(sdkUrls.twitter);
+      expect(script.async).toBe(true);
+    });
+
+    it('should not inject a provider SDK when its markup is absent', () => {
+      mockElement.innerHTML = '<blockquote class="twitter-tweet"></blockquote>';
+
+      triggerOembedLoad(mockElement);
+
+      // Only Twitter markup is present, so other SDKs must not be injected.
+      expect(injectedScript('facebook')).toBeNull();
+      expect(injectedScript('instagram')).toBeNull();
+      expect(injectedScript('reddit')).toBeNull();
+      expect(injectedScript('twitter')).not.toBeNull();
+    });
+
+    it('should inject each SDK only once across multiple entries', () => {
+      mockElement.innerHTML = '<blockquote class="twitter-tweet"></blockquote>';
+      triggerOembedLoad(mockElement);
+
+      const anotherEntry = document.createElement('div');
+      anotherEntry.innerHTML = '<blockquote class="twitter-tweet"></blockquote>';
+      triggerOembedLoad(anotherEntry);
+
+      expect(document.querySelectorAll('#twitter-js').length).toBe(1);
+    });
+
+    it('should inject the Reddit SDK on demand for Reddit embeds', () => {
+      mockElement.innerHTML = '<blockquote class="reddit-embed"></blockquote>';
+
+      triggerOembedLoad(mockElement);
+
+      expect(injectedScript('reddit')).not.toBeNull();
+    });
+
+    it('should not inject any SDK when no SDK URLs are configured', () => {
+      window.liveblog_settings = { embed_sdks: {} };
+      mockElement.innerHTML = '<blockquote class="twitter-tweet"></blockquote>';
+
+      triggerOembedLoad(mockElement);
+
+      expect(injectedScript('twitter')).toBeNull();
     });
   });
 });

--- a/src/react/utils/utils.js
+++ b/src/react/utils/utils.js
@@ -327,26 +327,100 @@ export const getPollingPages = (current, next) => {
 };
 
 /**
- * Fires of any oembed triggers need and adds an event listener that
- * can used to extend oembed support.
+ * Per-provider embed handling.
+ *
+ * Each provider declares:
+ *  - hasMarkup: detects whether an entry element contains that provider's embed.
+ *  - isLoaded:  whether the provider SDK is already available on the page.
+ *  - process:   re-parse the given element once the SDK is available (used when
+ *               the SDK was already loaded by an earlier entry).
+ *
+ * When a provider's markup is present but its SDK has not been loaded yet, the
+ * SDK is injected on demand (see loadEmbedSdk). The SDKs auto-process any markup
+ * present in the document when they first load, so we only need to call `process`
+ * for entries rendered after the SDK is already available.
+ */
+export const embedProviders = {
+  facebook: {
+    // Modern HTML5 format (<div class="fb-post">) and legacy XFBML (<fb:post>)
+    // from older cached embeds.
+    hasMarkup: element =>
+      !!element.querySelector('.fb-post, .fb-video, .fb-page, .fb-comments')
+      || element.getElementsByTagName('fb:post').length > 0
+      || element.getElementsByTagName('fb:video').length > 0,
+    isLoaded: () => !!(window.FB && window.FB.XFBML),
+    process: element => window.FB.XFBML.parse(element),
+  },
+  twitter: {
+    hasMarkup: element => !!element.querySelector('.twitter-tweet, .twitter-timeline'),
+    isLoaded: () => !!(window.twttr && window.twttr.widgets),
+    process: (element) => {
+      Array.from(element.querySelectorAll('.twitter-tweet')).forEach((ele) => {
+        window.twttr.widgets.load(ele);
+      });
+    },
+  },
+  instagram: {
+    hasMarkup: element => !!element.querySelector('.instagram-media'),
+    isLoaded: () => !!(window.instgrm && window.instgrm.Embeds),
+    process: () => window.instgrm.Embeds.process(),
+  },
+  reddit: {
+    hasMarkup: element => !!element.querySelector('.reddit-embed, .reddit-card'),
+    // Reddit's widgets.js exposes no reliable re-process API; it scans the
+    // document when it loads, so we only inject it on demand and never re-process.
+    isLoaded: () => false,
+    process: () => {},
+  },
+};
+
+/**
+ * Inject a provider SDK script once. The SDK auto-processes any matching markup
+ * already in the document when it loads. Re-uses the same `${name}-js` handle
+ * WordPress would have used, so the script is only ever injected a single time.
+ *
+ * @param {string} name The provider name (e.g. 'twitter').
+ * @param {string} src  The SDK script URL.
+ */
+export const loadEmbedSdk = (name, src) => {
+  if (document.getElementById(`${name}-js`)) {
+    return;
+  }
+
+  const script = document.createElement('script');
+  script.id = `${name}-js`;
+  script.async = true;
+  script.src = src;
+  document.body.appendChild(script);
+};
+
+/**
+ * Lazy-load provider SDKs and process embeds for a rendered entry element.
+ *
+ * Only loads a provider's SDK when that provider's embed markup is actually
+ * present, and only loads each SDK once. Provider SDK URLs come from the
+ * server-side `liveblog_embed_sdks` filter via window.liveblog_settings.
+ *
+ * @param {HTMLElement} element The rendered entry element to scan.
  */
 export const triggerOembedLoad = (element) => {
-  if (window.instgrm && element.querySelector('.instagram-media')) {
-    window.instgrm.Embeds.process();
-  }
+  const sdks = (window.liveblog_settings && window.liveblog_settings.embed_sdks) || {};
 
-  if (window.twttr && element.querySelector('.twitter-tweet')) {
-    Array.from(element.querySelectorAll('.twitter-tweet')).forEach((ele) => {
-      window.twttr.widgets.load(ele);
-    });
-  }
+  Object.keys(embedProviders).forEach((name) => {
+    const provider = embedProviders[name];
 
-  // Parse Facebook embeds when SDK is available.
-  // Uses element parameter to scope parsing and handles both modern HTML5 format
-  // (<div class="fb-post">) and legacy XFBML format (<fb:post>) from older cached embeds.
-  if (window.FB) {
-    window.FB.XFBML.parse(element);
-  }
+    if (!element || !provider.hasMarkup(element)) {
+      return;
+    }
+
+    if (provider.isLoaded()) {
+      // SDK already on the page: process this newly rendered entry.
+      provider.process(element);
+    } else if (sdks[name]) {
+      // SDK not loaded yet: inject it. It will process existing markup on load.
+      loadEmbedSdk(name, sdks[name]);
+    }
+  });
 
   window.dispatchEvent(new CustomEvent('omembedTrigger'));
 };

--- a/tests/Unit/EntryEmbedSdksTest.php
+++ b/tests/Unit/EntryEmbedSdksTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * Unit tests for the provider embed SDK loader.
+ *
+ * @package Automattic\Liveblog\Tests\Unit
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Tests\Unit;
+
+use Yoast\WPTestUtils\BrainMonkey\TestCase;
+use Brain\Monkey\Filters;
+use WPCOM_Liveblog_Entry_Embed_SDKs;
+
+/**
+ * Embed SDK loader unit test case.
+ */
+final class EntryEmbedSdksTest extends TestCase {
+
+	/**
+	 * The default providers shipped with the plugin.
+	 *
+	 * @var string[]
+	 */
+	private const DEFAULT_PROVIDERS = array( 'facebook', 'twitter', 'instagram', 'reddit' );
+
+	/**
+	 * Test that the default SDK list contains the expected providers.
+	 *
+	 * @covers WPCOM_Liveblog_Entry_Embed_SDKs::get_sdks
+	 */
+	public function test_get_sdks_returns_default_providers(): void {
+		$sdks = WPCOM_Liveblog_Entry_Embed_SDKs::get_sdks();
+
+		$this->assertSame( self::DEFAULT_PROVIDERS, array_keys( $sdks ) );
+
+		foreach ( $sdks as $url ) {
+			$this->assertIsString( $url );
+			$this->assertStringStartsWith( 'https://', $url );
+		}
+	}
+
+	/**
+	 * Test that the Facebook SDK URL uses an un-encoded ampersand so the SDK can
+	 * be injected directly as a script src on the client.
+	 *
+	 * @covers WPCOM_Liveblog_Entry_Embed_SDKs::get_sdks
+	 */
+	public function test_facebook_sdk_url_is_not_html_encoded(): void {
+		$sdks = WPCOM_Liveblog_Entry_Embed_SDKs::get_sdks();
+
+		$this->assertStringNotContainsString( '&amp;', $sdks['facebook'] );
+		$this->assertStringContainsString( 'xfbml=1&version=v2.5', $sdks['facebook'] );
+	}
+
+	/**
+	 * Test that the SDK URLs are exposed to the front-end settings under
+	 * `embed_sdks` so the client can lazy-load them on demand.
+	 *
+	 * @covers WPCOM_Liveblog_Entry_Embed_SDKs::add_sdks_to_settings
+	 */
+	public function test_add_sdks_to_settings_injects_sdk_map(): void {
+		$settings = WPCOM_Liveblog_Entry_Embed_SDKs::add_sdks_to_settings( array( 'existing' => 'value' ) );
+
+		$this->assertArrayHasKey( 'existing', $settings, 'Existing settings should be preserved.' );
+		$this->assertArrayHasKey( 'embed_sdks', $settings );
+		$this->assertSame( WPCOM_Liveblog_Entry_Embed_SDKs::get_sdks(), $settings['embed_sdks'] );
+	}
+
+	/**
+	 * Test that load() applies the `liveblog_embed_sdks` filter and registers the
+	 * settings filter, rather than enqueuing any scripts directly.
+	 *
+	 * @covers WPCOM_Liveblog_Entry_Embed_SDKs::load
+	 */
+	public function test_load_applies_filter_and_registers_settings_hook(): void {
+		Filters\expectApplied( 'liveblog_embed_sdks' )->once();
+		Filters\expectAdded( 'liveblog_settings' )->once();
+
+		WPCOM_Liveblog_Entry_Embed_SDKs::load();
+	}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -98,4 +98,5 @@ if ( $is_integration ) {
 	// Load plugin classes needed for unit tests.
 	require_once dirname( __DIR__ ) . '/classes/class-wpcom-liveblog-entry.php';
 	require_once dirname( __DIR__ ) . '/classes/class-wpcom-liveblog-entry-query.php';
+	require_once dirname( __DIR__ ) . '/classes/class-wpcom-liveblog-entry-embed-sdks.php';
 }


### PR DESCRIPTION
## Summary

Liveblog enqueued the Facebook, Twitter/X, Instagram and Reddit JavaScript SDKs on every Liveblog-enabled post, regardless of whether the post or its entries actually contained an embed from any of those services. As reported in #926, this meant visitors' browsers contacted four third-party domains on every Liveblog page, leaking request data to platforms whose content was never displayed, adding avoidable page-load overhead, and complicating Content Security Policy and consent compliance. A site using a single provider, or no social embeds at all, still paid the cost of all four.

The previous behaviour gated on `is_viewing_liveblog_post()` but then enqueued every SDK in `self::$sdks` unconditionally. The only escape hatch was emptying the list via the `liveblog_embed_sdks` filter, which disables enhanced rendering globally rather than loading only what is needed.

This change moves SDK loading client-side and on demand. The plugin no longer enqueues any SDK directly; instead it exposes the (still filterable) provider URL map to the front-end app via `liveblog_settings`. The React entry renderer already runs `triggerOembedLoad()` on every entry's mount and update, so that became the natural hook: for each provider it detects provider-specific embed markup, and if found either re-processes the entry (when the SDK is already present) or injects the SDK once. Because it runs per entry, it correctly handles embeds arriving in entries polled after the initial page load, not just those present on first render.

The `liveblog_embed_sdks` filter is preserved, so the documented `__return_empty_array` opt-out and per-provider removal continue to work and now also gate lazy loading.

### A known limitation worth a reviewer's eye

Reddit's `widgets.js` exposes no reliable client-side re-process API; it only scans the document when it first loads. A Reddit embed arriving in an entry polled *after* the SDK has already loaded therefore won't auto-render. This is not a regression (Reddit was never re-processed client-side before either), but it is a gap if true live-update parity for Reddit is wanted later.

### Note on the Facebook URL

The default Facebook SDK URL previously carried an HTML-encoded `&amp;` in its hash. That was harmless when passed through `esc_url()` on a server-side enqueue, but would break a client-injected `src`, so it is now stored un-encoded.

## Test plan

- [ ] PHP unit tests: `composer test:unit` (new `EntryEmbedSdksTest` covers the provider list, the un-encoded Facebook URL, settings injection, and that `load()` registers the settings hook rather than enqueuing).
- [ ] JS unit tests: `npm test` (updated `triggerOembedLoad` tests cover on-demand injection, single-injection across entries, and the no-markup / no-config cases).
- [ ] Manual: enable Liveblog on a post with no social embeds and confirm no `connect.facebook.net`, `platform.twitter.com`, `instagram.com` or `embed.reddit.com` requests are made. Add a single tweet and confirm only the Twitter SDK loads, including in a newly published entry.

Fixes #926