### PR TITLE
Lazy-load social SDKs only when an embed is present (2.x)

### DIFF
--- a/src/php/Infrastructure/WordPress/AssetManager.php
+++ b/src/php/Infrastructure/WordPress/AssetManager.php
@@ -30,7 +30,7 @@ final class AssetManager {
 	 * @var array<string, string>
 	 */
 	private const DEFAULT_EMBED_SDKS = array(
-		'facebook'  => 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&amp;version=v2.5',
+		'facebook'  => 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.5',
 		'twitter'   => 'https://platform.twitter.com/widgets.js',
 		'instagram' => 'https://www.instagram.com/embed.js',
 		'reddit'    => 'https://embed.reddit.com/widgets.js',
@@ -303,6 +303,9 @@ final class AssetManager {
 			'endpoint_url'                 => $endpoint_url,
 			'cross_domain'                 => false,
 
+			// Provider SDK URLs, lazy-loaded client-side only when a matching embed is rendered.
+			'embed_sdks'                   => $this->embed_sdks,
+
 			'features'                     => $this->content_filter_registry->get_enabled_features(),
 			'autocomplete'                 => $this->post_scope_autocomplete_urls( $this->content_filter_registry->get_autocomplete_config(), $post_id ),
 			'command_class'                => apply_filters( 'liveblog_command_class', CommandFilter::DEFAULT_CLASS_PREFIX ),
@@ -452,7 +455,10 @@ final class AssetManager {
 	/**
 	 * Initialise embed SDKs with filter support.
 	 *
-	 * Should be called once during plugin initialisation.
+	 * Should be called once during plugin initialisation. The resulting map is
+	 * exposed to the front-end app (see build_frontend_settings), which
+	 * lazy-loads each SDK only when an entry containing a matching embed is
+	 * rendered, rather than enqueuing every SDK on every liveblog post.
 	 *
 	 * @return void
 	 */
@@ -460,43 +466,21 @@ final class AssetManager {
 		/**
 		 * Filters the social embed SDKs to load on liveblog posts.
 		 *
+		 * Return an empty array to disable all third-party SDK loading, or
+		 * remove individual providers (by handle) to prevent their SDK from
+		 * ever being loaded.
+		 *
 		 * @param array<string, string> $sdks Map of handle => URL.
 		 */
 		$this->embed_sdks = apply_filters( 'liveblog_embed_sdks', self::DEFAULT_EMBED_SDKS );
 	}
 
 	/**
-	 * Enqueue social embed SDKs on liveblog posts.
+	 * Get the (filtered) list of provider SDK URLs.
 	 *
-	 * As entries are rendered in React, social embeds require their SDKs
-	 * to be loaded on page load rather than dynamically.
-	 *
-	 * @return void
+	 * @return array<string, string> Map of handle => URL.
 	 */
-	public function enqueue_embed_sdks(): void {
-		if ( ! LiveblogPost::is_viewing_liveblog_post() ) {
-			return;
-		}
-
-		foreach ( $this->embed_sdks as $handle => $url ) {
-			// Reddit's JS fails with version query string - returns 404.
-			$version = 'reddit' === $handle ? null : LiveblogConfiguration::VERSION;
-			wp_enqueue_script( $handle, esc_url( $url ), array(), $version, false );
-		}
-	}
-
-	/**
-	 * Add async attribute to embed SDK scripts.
-	 *
-	 * @param string $tag    The script tag HTML.
-	 * @param string $handle The script handle.
-	 * @return string Modified script tag.
-	 */
-	public function add_async_to_embed_sdks( string $tag, string $handle ): string {
-		if ( ! array_key_exists( $handle, $this->embed_sdks ) ) {
-			return $tag;
-		}
-
-		return str_replace( ' src', ' async="async" src', $tag );
+	public function get_embed_sdks(): array {
+		return $this->embed_sdks;
 	}
 }

--- a/src/php/Infrastructure/WordPress/PluginBootstrapper.php
+++ b/src/php/Infrastructure/WordPress/PluginBootstrapper.php
@@ -470,15 +470,13 @@ final class PluginBootstrapper {
 		$metadata_presenter = $this->container->metadata_presenter();
 		$template_renderer  = $this->container->template_renderer();
 
-		// Initialise embed SDKs (applies filter for customisation).
+		// Initialise embed SDKs (applies filter for customisation). The SDK URL
+		// map is passed to the front-end, which lazy-loads each SDK on demand
+		// only when a matching embed is rendered, rather than enqueuing them all.
 		$asset_manager->init_embed_sdks();
 
 		// Enqueue frontend scripts (uses named method so AMP can remove it).
 		add_action( 'wp_enqueue_scripts', array( $asset_manager, 'maybe_enqueue_frontend_scripts' ) );
-
-		// Enqueue social embed SDKs (Facebook, Twitter, Instagram, Reddit).
-		add_action( 'wp_enqueue_scripts', array( $asset_manager, 'enqueue_embed_sdks' ) );
-		add_filter( 'script_loader_tag', array( $asset_manager, 'add_async_to_embed_sdks' ), 10, 2 );
 
 		// Print liveblog metadata in head.
 		add_action(

--- a/src/react/utils/__tests__/utils.test.js
+++ b/src/react/utils/__tests__/utils.test.js
@@ -49,14 +49,32 @@ describe('utils', () => {
     let mockElement;
     let originalWindow;
 
+    const sdkUrls = {
+      facebook: 'https://connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.5',
+      twitter: 'https://platform.twitter.com/widgets.js',
+      instagram: 'https://www.instagram.com/embed.js',
+      reddit: 'https://embed.reddit.com/widgets.js',
+    };
+
+    const injectedScript = name => document.getElementById(`${name}-js`);
+
     beforeEach(() => {
       // Store original window properties
       originalWindow = {
         FB: window.FB,
         twttr: window.twttr,
         instgrm: window.instgrm,
+        liveblog_settings: window.liveblog_settings,
         dispatchEvent: window.dispatchEvent,
       };
+
+      // Provider SDKs are unavailable until explicitly loaded by each test.
+      window.FB = undefined;
+      window.twttr = undefined;
+      window.instgrm = undefined;
+
+      // Expose SDK URLs the way the server-side localisation does.
+      window.liveblog_settings = { embed_sdks: sdkUrls };
 
       // Create a mock DOM element
       mockElement = document.createElement('div');
@@ -70,16 +88,25 @@ describe('utils', () => {
       window.FB = originalWindow.FB;
       window.twttr = originalWindow.twttr;
       window.instgrm = originalWindow.instgrm;
+      window.liveblog_settings = originalWindow.liveblog_settings;
       window.dispatchEvent = originalWindow.dispatchEvent;
+
+      // Remove any SDK scripts injected during a test so state does not leak.
+      ['facebook', 'twitter', 'instagram', 'reddit'].forEach((name) => {
+        const script = injectedScript(name);
+        if (script) script.remove();
+      });
     });
 
-    it('should call FB.XFBML.parse with element when Facebook SDK is available', () => {
+    it('should call FB.XFBML.parse with the element when the SDK is loaded and markup is present', () => {
       const mockParse = jest.fn();
       window.FB = {
         XFBML: {
           parse: mockParse,
         },
       };
+
+      mockElement.innerHTML = '<div class="fb-post" data-href="https://facebook.com/test"></div>';
 
       triggerOembedLoad(mockElement);
 
@@ -87,26 +114,24 @@ describe('utils', () => {
       expect(mockParse).toHaveBeenCalledWith(mockElement);
     });
 
-    it('should not throw when Facebook SDK is not available', () => {
-      window.FB = undefined;
-
-      expect(() => triggerOembedLoad(mockElement)).not.toThrow();
-    });
-
-    it('should handle elements with fb-post class (modern HTML5 format)', () => {
+    it('should not process any provider when no embed markup is present', () => {
       const mockParse = jest.fn();
-      window.FB = {
-        XFBML: {
-          parse: mockParse,
-        },
-      };
-
-      // Add a modern HTML5 Facebook embed
-      mockElement.innerHTML = '<div class="fb-post" data-href="https://facebook.com/test"></div>';
+      window.FB = { XFBML: { parse: mockParse } };
+      window.twttr = { widgets: { load: jest.fn() } };
+      window.instgrm = { Embeds: { process: jest.fn() } };
 
       triggerOembedLoad(mockElement);
 
-      expect(mockParse).toHaveBeenCalledWith(mockElement);
+      expect(mockParse).not.toHaveBeenCalled();
+      expect(window.twttr.widgets.load).not.toHaveBeenCalled();
+      expect(window.instgrm.Embeds.process).not.toHaveBeenCalled();
+    });
+
+    it('should not throw when an SDK is not available', () => {
+      window.FB = undefined;
+      mockElement.innerHTML = '<div class="fb-post"></div>';
+
+      expect(() => triggerOembedLoad(mockElement)).not.toThrow();
     });
 
     it('should handle elements with fb:post (legacy XFBML format)', () => {
@@ -165,6 +190,59 @@ describe('utils', () => {
       triggerOembedLoad(mockElement);
 
       expect(mockProcess).toHaveBeenCalledTimes(1);
+    });
+
+    it('should inject a provider SDK on demand when markup is present but the SDK is not loaded', () => {
+      mockElement.innerHTML = '<blockquote class="twitter-tweet"></blockquote>';
+
+      expect(injectedScript('twitter')).toBeNull();
+
+      triggerOembedLoad(mockElement);
+
+      const script = injectedScript('twitter');
+      expect(script).not.toBeNull();
+      expect(script.src).toBe(sdkUrls.twitter);
+      expect(script.async).toBe(true);
+    });
+
+    it('should not inject a provider SDK when its markup is absent', () => {
+      mockElement.innerHTML = '<blockquote class="twitter-tweet"></blockquote>';
+
+      triggerOembedLoad(mockElement);
+
+      // Only Twitter markup is present, so other SDKs must not be injected.
+      expect(injectedScript('facebook')).toBeNull();
+      expect(injectedScript('instagram')).toBeNull();
+      expect(injectedScript('reddit')).toBeNull();
+      expect(injectedScript('twitter')).not.toBeNull();
+    });
+
+    it('should inject each SDK only once across multiple entries', () => {
+      mockElement.innerHTML = '<blockquote class="twitter-tweet"></blockquote>';
+      triggerOembedLoad(mockElement);
+
+      const anotherEntry = document.createElement('div');
+      anotherEntry.innerHTML = '<blockquote class="twitter-tweet"></blockquote>';
+      triggerOembedLoad(anotherEntry);
+
+      expect(document.querySelectorAll('#twitter-js').length).toBe(1);
+    });
+
+    it('should inject the Reddit SDK on demand for Reddit embeds', () => {
+      mockElement.innerHTML = '<blockquote class="reddit-embed"></blockquote>';
+
+      triggerOembedLoad(mockElement);
+
+      expect(injectedScript('reddit')).not.toBeNull();
+    });
+
+    it('should not inject any SDK when no SDK URLs are configured', () => {
+      window.liveblog_settings = { embed_sdks: {} };
+      mockElement.innerHTML = '<blockquote class="twitter-tweet"></blockquote>';
+
+      triggerOembedLoad(mockElement);
+
+      expect(injectedScript('twitter')).toBeNull();
     });
   });
 });

--- a/src/react/utils/utils.js
+++ b/src/react/utils/utils.js
@@ -327,26 +327,100 @@ export const getPollingPages = (current, next) => {
 };
 
 /**
- * Fires of any oembed triggers need and adds an event listener that
- * can used to extend oembed support.
+ * Per-provider embed handling.
+ *
+ * Each provider declares:
+ *  - hasMarkup: detects whether an entry element contains that provider's embed.
+ *  - isLoaded:  whether the provider SDK is already available on the page.
+ *  - process:   re-parse the given element once the SDK is available (used when
+ *               the SDK was already loaded by an earlier entry).
+ *
+ * When a provider's markup is present but its SDK has not been loaded yet, the
+ * SDK is injected on demand (see loadEmbedSdk). The SDKs auto-process any markup
+ * present in the document when they first load, so we only need to call `process`
+ * for entries rendered after the SDK is already available.
+ */
+export const embedProviders = {
+  facebook: {
+    // Modern HTML5 format (<div class="fb-post">) and legacy XFBML (<fb:post>)
+    // from older cached embeds.
+    hasMarkup: element =>
+      !!element.querySelector('.fb-post, .fb-video, .fb-page, .fb-comments')
+      || element.getElementsByTagName('fb:post').length > 0
+      || element.getElementsByTagName('fb:video').length > 0,
+    isLoaded: () => !!(window.FB && window.FB.XFBML),
+    process: element => window.FB.XFBML.parse(element),
+  },
+  twitter: {
+    hasMarkup: element => !!element.querySelector('.twitter-tweet, .twitter-timeline'),
+    isLoaded: () => !!(window.twttr && window.twttr.widgets),
+    process: (element) => {
+      Array.from(element.querySelectorAll('.twitter-tweet')).forEach((ele) => {
+        window.twttr.widgets.load(ele);
+      });
+    },
+  },
+  instagram: {
+    hasMarkup: element => !!element.querySelector('.instagram-media'),
+    isLoaded: () => !!(window.instgrm && window.instgrm.Embeds),
+    process: () => window.instgrm.Embeds.process(),
+  },
+  reddit: {
+    hasMarkup: element => !!element.querySelector('.reddit-embed, .reddit-card'),
+    // Reddit's widgets.js exposes no reliable re-process API; it scans the
+    // document when it loads, so we only inject it on demand and never re-process.
+    isLoaded: () => false,
+    process: () => {},
+  },
+};
+
+/**
+ * Inject a provider SDK script once. The SDK auto-processes any matching markup
+ * already in the document when it loads. Re-uses the same `${name}-js` handle
+ * WordPress would have used, so the script is only ever injected a single time.
+ *
+ * @param {string} name The provider name (e.g. 'twitter').
+ * @param {string} src  The SDK script URL.
+ */
+export const loadEmbedSdk = (name, src) => {
+  if (document.getElementById(`${name}-js`)) {
+    return;
+  }
+
+  const script = document.createElement('script');
+  script.id = `${name}-js`;
+  script.async = true;
+  script.src = src;
+  document.body.appendChild(script);
+};
+
+/**
+ * Lazy-load provider SDKs and process embeds for a rendered entry element.
+ *
+ * Only loads a provider's SDK when that provider's embed markup is actually
+ * present, and only loads each SDK once. Provider SDK URLs come from the
+ * server-side `liveblog_embed_sdks` filter via window.liveblog_settings.
+ *
+ * @param {HTMLElement} element The rendered entry element to scan.
  */
 export const triggerOembedLoad = (element) => {
-  if (window.instgrm && element.querySelector('.instagram-media')) {
-    window.instgrm.Embeds.process();
-  }
+  const sdks = (window.liveblog_settings && window.liveblog_settings.embed_sdks) || {};
 
-  if (window.twttr && element.querySelector('.twitter-tweet')) {
-    Array.from(element.querySelectorAll('.twitter-tweet')).forEach((ele) => {
-      window.twttr.widgets.load(ele);
-    });
-  }
+  Object.keys(embedProviders).forEach((name) => {
+    const provider = embedProviders[name];
 
-  // Parse Facebook embeds when SDK is available.
-  // Uses element parameter to scope parsing and handles both modern HTML5 format
-  // (<div class="fb-post">) and legacy XFBML format (<fb:post>) from older cached embeds.
-  if (window.FB) {
-    window.FB.XFBML.parse(element);
-  }
+    if (!element || !provider.hasMarkup(element)) {
+      return;
+    }
+
+    if (provider.isLoaded()) {
+      // SDK already on the page: process this newly rendered entry.
+      provider.process(element);
+    } else if (sdks[name]) {
+      // SDK not loaded yet: inject it. It will process existing markup on load.
+      loadEmbedSdk(name, sdks[name]);
+    }
+  });
 
   window.dispatchEvent(new CustomEvent('omembedTrigger'));
 };

--- a/tests/Integration/EmbedSdksTest.php
+++ b/tests/Integration/EmbedSdksTest.php
@@ -16,6 +16,10 @@ use Yoast\WPTestUtils\WPIntegration\TestCase;
 /**
  * Tests for social embed SDK loading functionality.
  *
+ * Provider SDKs are no longer enqueued on every liveblog post. Instead the
+ * (filtered) SDK URL map is passed to the front-end app, which lazy-loads each
+ * SDK on demand only when a matching embed is rendered.
+ *
  * @coversDefaultClass \Automattic\Liveblog\Infrastructure\WordPress\AssetManager
  */
 final class EmbedSdksTest extends TestCase {
@@ -49,51 +53,87 @@ final class EmbedSdksTest extends TestCase {
 	}
 
 	/**
-	 * Test that embed SDKs are enqueued on liveblog posts.
+	 * Get the data localised onto the main liveblog front-end script.
 	 *
-	 * @covers ::enqueue_embed_sdks
+	 * @return string The `liveblog_settings` JavaScript data string.
 	 */
-	public function test_embed_sdks_enqueued_on_liveblog_post(): void {
-		// Set up as viewing a liveblog post.
+	private function get_localised_settings(): string {
+		$data = wp_scripts()->get_data( LiveblogConfiguration::KEY, 'data' );
+
+		return is_string( $data ) ? $data : '';
+	}
+
+	/**
+	 * Test that provider SDKs are not enqueued on liveblog posts.
+	 *
+	 * This is the behaviour change: SDKs must no longer be loaded unconditionally
+	 * on every liveblog post.
+	 *
+	 * @covers ::maybe_enqueue_frontend_scripts
+	 */
+	public function test_embed_sdks_not_enqueued_on_liveblog_post(): void {
 		$this->go_to( get_permalink( $this->post_id ) );
 
 		$asset_manager = Container::instance()->asset_manager();
 		$asset_manager->init_embed_sdks();
-		$asset_manager->enqueue_embed_sdks();
-
-		$this->assertTrue( wp_script_is( 'facebook', 'enqueued' ) );
-		$this->assertTrue( wp_script_is( 'twitter', 'enqueued' ) );
-		$this->assertTrue( wp_script_is( 'instagram', 'enqueued' ) );
-		$this->assertTrue( wp_script_is( 'reddit', 'enqueued' ) );
-	}
-
-	/**
-	 * Test that embed SDKs are not enqueued on non-liveblog posts.
-	 *
-	 * @covers ::enqueue_embed_sdks
-	 */
-	public function test_embed_sdks_not_enqueued_on_regular_post(): void {
-		$regular_post = self::factory()->post->create();
-		$this->go_to( get_permalink( $regular_post ) );
-
-		$asset_manager = Container::instance()->asset_manager();
-		$asset_manager->init_embed_sdks();
-		$asset_manager->enqueue_embed_sdks();
+		$asset_manager->maybe_enqueue_frontend_scripts();
 
 		$this->assertFalse( wp_script_is( 'facebook', 'enqueued' ) );
 		$this->assertFalse( wp_script_is( 'twitter', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'instagram', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'reddit', 'enqueued' ) );
 	}
 
 	/**
-	 * Test that the liveblog_embed_sdks filter can customise SDKs.
+	 * Test that the SDK URL map is exposed to the front-end settings so the
+	 * client can lazy-load each SDK on demand.
 	 *
-	 * @covers ::init_embed_sdks
-	 * @covers ::enqueue_embed_sdks
+	 * @covers ::maybe_enqueue_frontend_scripts
 	 */
-	public function test_embed_sdks_filter_customises_sdks(): void {
+	public function test_embed_sdks_exposed_in_frontend_settings(): void {
 		$this->go_to( get_permalink( $this->post_id ) );
 
-		// Filter to only load Twitter SDK.
+		$asset_manager = Container::instance()->asset_manager();
+		$asset_manager->init_embed_sdks();
+		$asset_manager->maybe_enqueue_frontend_scripts();
+
+		$settings = $this->get_localised_settings();
+
+		$this->assertStringContainsString( 'embed_sdks', $settings );
+		$this->assertStringContainsString( 'connect.facebook.net', $settings );
+		$this->assertStringContainsString( 'platform.twitter.com', $settings );
+		$this->assertStringContainsString( 'instagram.com', $settings );
+		$this->assertStringContainsString( 'embed.reddit.com', $settings );
+	}
+
+	/**
+	 * Test that the default SDK list contains the expected providers and that
+	 * the Facebook URL is not HTML-encoded (so it works as a client-side src).
+	 *
+	 * @covers ::init_embed_sdks
+	 * @covers ::get_embed_sdks
+	 */
+	public function test_get_embed_sdks_returns_defaults(): void {
+		$asset_manager = Container::instance()->asset_manager();
+		$asset_manager->init_embed_sdks();
+
+		$sdks = $asset_manager->get_embed_sdks();
+
+		$this->assertSame(
+			array( 'facebook', 'twitter', 'instagram', 'reddit' ),
+			array_keys( $sdks )
+		);
+		$this->assertStringNotContainsString( '&amp;', $sdks['facebook'] );
+		$this->assertStringContainsString( 'xfbml=1&version=v2.5', $sdks['facebook'] );
+	}
+
+	/**
+	 * Test that the liveblog_embed_sdks filter can customise the SDK map.
+	 *
+	 * @covers ::init_embed_sdks
+	 * @covers ::get_embed_sdks
+	 */
+	public function test_embed_sdks_filter_customises_sdks(): void {
 		add_filter(
 			'liveblog_embed_sdks',
 			function () {
@@ -103,41 +143,25 @@ final class EmbedSdksTest extends TestCase {
 
 		$asset_manager = Container::instance()->asset_manager();
 		$asset_manager->init_embed_sdks();
-		$asset_manager->enqueue_embed_sdks();
 
-		$this->assertTrue( wp_script_is( 'twitter', 'enqueued' ) );
-		$this->assertFalse( wp_script_is( 'facebook', 'enqueued' ) );
-		$this->assertFalse( wp_script_is( 'instagram', 'enqueued' ) );
+		$this->assertSame(
+			array( 'twitter' => 'https://platform.twitter.com/widgets.js' ),
+			$asset_manager->get_embed_sdks()
+		);
 	}
 
 	/**
-	 * Test that async attribute is added to embed SDK scripts.
+	 * Test that the liveblog_embed_sdks filter can disable all SDK loading.
 	 *
-	 * @covers ::add_async_to_embed_sdks
+	 * @covers ::init_embed_sdks
+	 * @covers ::get_embed_sdks
 	 */
-	public function test_async_attribute_added_to_embed_scripts(): void {
+	public function test_embed_sdks_filter_can_disable_all(): void {
+		add_filter( 'liveblog_embed_sdks', '__return_empty_array' );
+
 		$asset_manager = Container::instance()->asset_manager();
 		$asset_manager->init_embed_sdks();
 
-		$tag    = '<script src="https://platform.twitter.com/widgets.js"></script>';
-		$result = $asset_manager->add_async_to_embed_sdks( $tag, 'twitter' );
-
-		$this->assertStringContainsString( 'async="async"', $result );
-	}
-
-	/**
-	 * Test that async attribute is not added to non-embed scripts.
-	 *
-	 * @covers ::add_async_to_embed_sdks
-	 */
-	public function test_async_attribute_not_added_to_other_scripts(): void {
-		$asset_manager = Container::instance()->asset_manager();
-		$asset_manager->init_embed_sdks();
-
-		$tag    = '<script src="https://example.com/other.js"></script>';
-		$result = $asset_manager->add_async_to_embed_sdks( $tag, 'some-other-script' );
-
-		$this->assertStringNotContainsString( 'async', $result );
-		$this->assertSame( $tag, $result );
+		$this->assertSame( array(), $asset_manager->get_embed_sdks() );
 	}
 }


### PR DESCRIPTION
## Summary

Liveblog enqueued the Facebook, Twitter/X, Instagram and Reddit JavaScript SDKs on every Liveblog-enabled post, regardless of whether the post or its entries actually contained an embed from any of those services. As reported in #926, this meant visitors' browsers contacted four third-party domains on every Liveblog page, leaking request data to platforms whose content was never displayed, adding avoidable page-load overhead, and complicating Content Security Policy and consent compliance. A site using a single provider, or no social embeds at all, still paid the cost of all four.

This is the backport of #928 (merged to `develop`) onto the 2.x architecture. The behaviour and front-end loader are identical; only the PHP wiring differs to fit 2.x.

On 2.x the SDK logic lives in `AssetManager`. Rather than enqueuing every SDK on `wp_enqueue_scripts`, the plugin now passes the (still filterable) provider URL map to the front-end app through `liveblog_settings`. The React entry renderer already runs `triggerOembedLoad()` on every entry's mount and update, so that became the natural hook: for each provider it detects provider-specific embed markup, and if found either re-processes the entry (when the SDK is already present) or injects the SDK once. Because it runs per entry, it correctly handles embeds arriving in entries polled after the initial page load, not just those present on first render.

The now-unused `enqueue_embed_sdks()` and `add_async_to_embed_sdks()` methods and their hook registrations in `PluginBootstrapper` have been removed; `init_embed_sdks()` is retained, as it applies the `liveblog_embed_sdks` filter and populates the map now consumed by the front-end. The filter's `__return_empty_array` opt-out and per-provider removal continue to work and now also gate lazy loading.

### A known limitation worth a reviewer's eye

Reddit's `widgets.js` exposes no reliable client-side re-process API; it only scans the document when it first loads. A Reddit embed arriving in an entry polled *after* the SDK has already loaded therefore won't auto-render. This is not a regression (Reddit was never re-processed client-side before either), but it is a gap if true live-update parity for Reddit is wanted later.

### Note on the Facebook URL

The default Facebook SDK URL previously carried an HTML-encoded `&amp;` in its hash. That was harmless when passed through `esc_url()` on a server-side enqueue, but would break a client-injected `src`, so it is now stored un-encoded.

## Test plan

- [ ] Integration tests: `composer test:integration` (rewritten `EmbedSdksTest` asserts the SDKs are no longer enqueued on a liveblog post and that the SDK map is exposed in the localised front-end settings, plus filter customisation and the empty-array opt-out). Verified locally: 5 tests, 14 assertions passing.
- [ ] JS unit tests: `npm test` (updated `triggerOembedLoad` tests cover on-demand injection, single-injection across entries, and the no-markup / no-config cases). Verified locally: 16 tests passing.
- [ ] Manual: enable Liveblog on a post with no social embeds and confirm no `connect.facebook.net`, `platform.twitter.com`, `instagram.com` or `embed.reddit.com` requests are made. Add a single tweet and confirm only the Twitter SDK loads, including in a newly published entry.

Fixes #926