### PR TITLE
test(epics): add unit tests for redux-observable epics

### DIFF
--- a/src/react/epics/__tests__/api.test.js
+++ b/src/react/epics/__tests__/api.test.js
@@ -1,0 +1,217 @@
+import { lastValueFrom, of, throwError } from 'rxjs';
+import { toArray } from 'rxjs/operators';
+
+jest.mock( '../../services/api', () => ( {
+	getEntries: jest.fn(),
+	createEntry: jest.fn(),
+	updateEntry: jest.fn(),
+	deleteEntry: jest.fn(),
+} ) );
+
+import {
+	getEntries,
+	createEntry,
+	updateEntry,
+	deleteEntry,
+} from '../../services/api';
+
+import {
+	getEntriesEpic,
+	getPaginatedEntriesEpic,
+	createEntryEpic,
+	updateEntryEpic,
+	deleteEntryEpic,
+	getEntriesAfterChangeEpic,
+} from '../api';
+
+import {
+	getEntries as getEntriesAction,
+	getEntriesPaginated,
+	getEntriesSuccess,
+	getEntriesFailed,
+	createEntry as createEntryAction,
+	createEntrySuccess,
+	createEntryFailed,
+	updateEntry as updateEntryAction,
+	updateEntrySuccess,
+	updateEntryFailed,
+	deleteEntry as deleteEntryAction,
+	deleteEntrySuccess,
+	deleteEntryFailed,
+	pollingSuccess,
+} from '../../actions/apiActions';
+import { jumpToEvent } from '../../actions/eventsActions';
+import { scrollToEntry } from '../../actions/userActions';
+import { getScrollToId } from '../../utils/utils';
+
+import apiData from '../../mockData/reducers/api';
+
+const runEpic = ( epic, action, state ) =>
+	lastValueFrom( epic( of( action ), { value: state } ).pipe( toArray() ) );
+
+const baseState = {
+	config: {
+		endpoint_url: 'https://example.com/wp-json/liveblog/v1/123/',
+		cross_domain: false,
+	},
+	api: { entries: {}, newestEntry: false, nonce: 'nonce-123' },
+	pagination: { page: 1 },
+	polling: { entries: {} },
+};
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'getEntriesEpic', () => {
+	it( 'jumps to the event when the action carries a numeric hash', async () => {
+		const emitted = await runEpic(
+			getEntriesEpic,
+			getEntriesAction( 1, '#2977' ),
+			baseState
+		);
+
+		expect( emitted ).toEqual( [ jumpToEvent( '2977' ) ] );
+		expect( getEntries ).not.toHaveBeenCalled();
+	} );
+
+	it( 'fetches entries and emits success when there is no hash', async () => {
+		getEntries.mockReturnValue( of( { response: apiData } ) );
+
+		const emitted = await runEpic(
+			getEntriesEpic,
+			getEntriesAction( 1 ),
+			baseState
+		);
+
+		expect( getEntries ).toHaveBeenCalledWith(
+			1,
+			baseState.config,
+			baseState.api.newestEntry
+		);
+		expect( emitted ).toEqual( [ getEntriesSuccess( apiData, true ) ] );
+	} );
+
+	it( 'emits getEntriesFailed when the request errors', async () => {
+		getEntries.mockReturnValue( throwError( () => new Error( 'boom' ) ) );
+
+		const emitted = await runEpic(
+			getEntriesEpic,
+			getEntriesAction( 1 ),
+			baseState
+		);
+
+		expect( emitted ).toEqual( [ getEntriesFailed() ] );
+	} );
+} );
+
+describe( 'getPaginatedEntriesEpic', () => {
+	it( 'emits success then scrolls to the requested entry', async () => {
+		getEntries.mockReturnValue( of( { response: apiData } ) );
+
+		const emitted = await runEpic(
+			getPaginatedEntriesEpic,
+			getEntriesPaginated( 2, 'first' ),
+			baseState
+		);
+
+		expect( emitted ).toEqual( [
+			getEntriesSuccess( apiData, true ),
+			scrollToEntry( getScrollToId( apiData.entries, 'first' ) ),
+		] );
+	} );
+
+	it( 'emits getEntriesFailed when the request errors', async () => {
+		getEntries.mockReturnValue( throwError( () => new Error( 'boom' ) ) );
+
+		const emitted = await runEpic(
+			getPaginatedEntriesEpic,
+			getEntriesPaginated( 2, 'first' ),
+			baseState
+		);
+
+		expect( emitted ).toEqual( [ getEntriesFailed() ] );
+	} );
+} );
+
+describe.each( [
+	[
+		'createEntryEpic',
+		createEntryEpic,
+		createEntry,
+		createEntryAction,
+		createEntrySuccess,
+		createEntryFailed,
+	],
+	[
+		'updateEntryEpic',
+		updateEntryEpic,
+		updateEntry,
+		updateEntryAction,
+		updateEntrySuccess,
+		updateEntryFailed,
+	],
+	[
+		'deleteEntryEpic',
+		deleteEntryEpic,
+		deleteEntry,
+		deleteEntryAction,
+		deleteEntrySuccess,
+		deleteEntryFailed,
+	],
+] )(
+	'%s',
+	( name, epic, service, actionCreator, successCreator, failedCreator ) => {
+		const payload = { id: '2977', content: 'hi' };
+
+		it( 'calls the service and emits success', async () => {
+			service.mockReturnValue( of( { response: payload } ) );
+
+			const emitted = await runEpic(
+				epic,
+				actionCreator( payload ),
+				baseState
+			);
+
+			expect( service ).toHaveBeenCalledWith(
+				payload,
+				baseState.config,
+				baseState.api.nonce
+			);
+			expect( emitted ).toEqual( [ successCreator( payload ) ] );
+		} );
+
+		it( 'emits the failed action when the request errors', async () => {
+			service.mockReturnValue( throwError( () => new Error( 'boom' ) ) );
+
+			const emitted = await runEpic(
+				epic,
+				actionCreator( payload ),
+				baseState
+			);
+
+			expect( emitted ).toEqual( [ failedCreator() ] );
+		} );
+	}
+);
+
+describe( 'getEntriesAfterChangeEpic', () => {
+	it.each( [
+		[ 'CREATE_ENTRY_SUCCESS', createEntrySuccess ],
+		[ 'UPDATE_ENTRY_SUCCESS', updateEntrySuccess ],
+		[ 'DELETE_ENTRY_SUCCESS', deleteEntrySuccess ],
+	] )(
+		'turns %s into a pollingSuccess with renderNewEntries true',
+		async ( label, actionCreator ) => {
+			const payload = { id: '2977' };
+
+			const emitted = await runEpic(
+				getEntriesAfterChangeEpic,
+				actionCreator( payload ),
+				baseState
+			);
+
+			expect( emitted ).toEqual( [ pollingSuccess( payload, true ) ] );
+		}
+	);
+} );

--- a/src/react/epics/__tests__/polling.test.js
+++ b/src/react/epics/__tests__/polling.test.js
@@ -1,0 +1,171 @@
+import { lastValueFrom, of, throwError } from 'rxjs';
+import { toArray } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+
+jest.mock( '../../services/api', () => ( {
+	polling: jest.fn(),
+	getEntries: jest.fn(),
+} ) );
+
+import { polling as pollingApi, getEntries } from '../../services/api';
+import { startPollingEpic, mergePollingEpic } from '../polling';
+
+import {
+	startPolling,
+	cancelPolling,
+	pollingSuccess,
+	pollingFailed,
+	mergePolling,
+	mergePollingIntoEntries,
+	getEntriesSuccess,
+	getEntriesFailed,
+} from '../../actions/apiActions';
+import { scrollToEntry } from '../../actions/userActions';
+
+import pollingData from '../../mockData/reducers/polling';
+import apiData from '../../mockData/reducers/api';
+
+afterEach( () => {
+	jest.clearAllMocks();
+} );
+
+describe( 'startPollingEpic', () => {
+	const stateValue = {
+		config: { refresh_interval: 1 },
+		api: { entries: {} },
+		pagination: { page: 1 },
+		polling: { entries: {}, newestEntry: { timestamp: 1511882674 } },
+	};
+
+	const run = ( marbles ) => {
+		const testScheduler = new TestScheduler( ( actual, expected ) => {
+			expect( actual ).toEqual( expected );
+		} );
+		testScheduler.run( marbles );
+	};
+
+	// eslint-disable-next-line jest/expect-expect -- assertion happens inside TestScheduler's comparator via expectObservable().toBe()
+	it( 'polls on the configured interval and stops after CANCEL_POLLING', () => {
+		pollingApi.mockReturnValue( of( { response: pollingData } ) );
+
+		run( ( { hot, expectObservable } ) => {
+			// START_POLLING at frame 1, CANCEL_POLLING at frame 2000 (before the
+			// second 1000ms tick at 2001), a trailing no-op action extends the
+			// run window past 2001 so a stray second tick would still show up.
+			const action$ = hot( '-a 1998ms b 999ms c', {
+				a: startPolling(),
+				b: cancelPolling(),
+				c: pollingFailed(),
+			} );
+
+			const output$ = startPollingEpic( action$, { value: stateValue } );
+
+			expectObservable( output$ ).toBe( '1001ms a', {
+				a: pollingSuccess( pollingData, true ),
+			} );
+		} );
+	} );
+
+	// eslint-disable-next-line jest/expect-expect -- assertion happens inside TestScheduler's comparator via expectObservable().toBe()
+	it( 'emits pollingFailed when the request errors', () => {
+		pollingApi.mockReturnValue( throwError( () => new Error( 'boom' ) ) );
+
+		run( ( { hot, expectObservable } ) => {
+			const action$ = hot( '-a 1998ms b', {
+				a: startPolling(),
+				b: cancelPolling(),
+			} );
+
+			const output$ = startPollingEpic( action$, { value: stateValue } );
+
+			expectObservable( output$ ).toBe( '1001ms a', {
+				a: pollingFailed(),
+			} );
+		} );
+	} );
+} );
+
+const runEpic = ( epic, action, state ) =>
+	lastValueFrom( epic( of( action ), { value: state } ).pipe( toArray() ) );
+
+describe( 'mergePollingEpic', () => {
+	const pollingEntry = pollingData.entries[ 0 ];
+
+	it( 'merges polling entries straight in when already on page 1', async () => {
+		const state = {
+			pagination: { page: 1, pages: 1 },
+			polling: {
+				entries: { [ `id_${ pollingEntry.id }` ]: pollingEntry },
+				pages: 1,
+				newestEntry: pollingEntry,
+			},
+			config: {},
+		};
+
+		const emitted = await runEpic(
+			mergePollingEpic,
+			mergePolling(),
+			state
+		);
+
+		expect( emitted ).toEqual( [
+			mergePollingIntoEntries( [ pollingEntry ], 1 ),
+			scrollToEntry( `id_${ pollingEntry.id }` ),
+		] );
+	} );
+
+	it( 're-fetches page 1 and scrolls to the newest entry when not on page 1', async () => {
+		getEntries.mockReturnValue( of( { response: apiData } ) );
+
+		const state = {
+			pagination: { page: 2, pages: 3 },
+			polling: {
+				entries: { [ `id_${ pollingEntry.id }` ]: pollingEntry },
+				pages: 1,
+				newestEntry: pollingEntry,
+			},
+			config: {
+				endpoint_url: 'https://example.com/wp-json/liveblog/v1/123/',
+				cross_domain: false,
+			},
+		};
+
+		const emitted = await runEpic(
+			mergePollingEpic,
+			mergePolling(),
+			state
+		);
+
+		expect( getEntries ).toHaveBeenCalledWith(
+			1,
+			state.config,
+			pollingEntry
+		);
+		expect( emitted ).toEqual( [
+			getEntriesSuccess( apiData, true ),
+			scrollToEntry( `id_${ pollingEntry.id }` ),
+		] );
+	} );
+
+	it( 'emits getEntriesFailed when the re-fetch errors', async () => {
+		getEntries.mockReturnValue( throwError( () => new Error( 'boom' ) ) );
+
+		const state = {
+			pagination: { page: 2, pages: 3 },
+			polling: {
+				entries: { [ `id_${ pollingEntry.id }` ]: pollingEntry },
+				pages: 1,
+				newestEntry: pollingEntry,
+			},
+			config: {},
+		};
+
+		const emitted = await runEpic(
+			mergePollingEpic,
+			mergePolling(),
+			state
+		);
+
+		expect( emitted ).toEqual( [ getEntriesFailed() ] );
+	} );
+} );

--- a/src/react/epics/api.js
+++ b/src/react/epics/api.js
@@ -29,7 +29,7 @@ import { shouldRenderNewEntries, getScrollToId } from '../utils/utils';
 
 import { scrollToEntry } from '../actions/userActions';
 
-const getEntriesEpic = ( action$, state$ ) =>
+export const getEntriesEpic = ( action$, state$ ) =>
 	action$.pipe(
 		ofType( types.GET_ENTRIES ),
 		switchMap( ( { page, hash } ) => {
@@ -66,7 +66,7 @@ const getEntriesEpic = ( action$, state$ ) =>
 		} )
 	);
 
-const getPaginatedEntriesEpic = ( action$, state$ ) =>
+export const getPaginatedEntriesEpic = ( action$, state$ ) =>
 	action$.pipe(
 		ofType( types.GET_ENTRIES_PAGINATED ),
 		switchMap( ( { page, scrollTo } ) =>
@@ -100,7 +100,7 @@ const getPaginatedEntriesEpic = ( action$, state$ ) =>
 		)
 	);
 
-const createEntryEpic = ( action$, state$ ) =>
+export const createEntryEpic = ( action$, state$ ) =>
 	action$.pipe(
 		ofType( types.CREATE_ENTRY ),
 		switchMap( ( { payload } ) =>
@@ -116,7 +116,7 @@ const createEntryEpic = ( action$, state$ ) =>
 		)
 	);
 
-const updateEntryEpic = ( action$, state$ ) =>
+export const updateEntryEpic = ( action$, state$ ) =>
 	action$.pipe(
 		ofType( types.UPDATE_ENTRY ),
 		switchMap( ( { payload } ) =>
@@ -132,7 +132,7 @@ const updateEntryEpic = ( action$, state$ ) =>
 		)
 	);
 
-const deleteEntryEpic = ( action$, state$ ) =>
+export const deleteEntryEpic = ( action$, state$ ) =>
 	action$.pipe(
 		ofType( types.DELETE_ENTRY ),
 		switchMap( ( { payload } ) =>
@@ -148,7 +148,7 @@ const deleteEntryEpic = ( action$, state$ ) =>
 		)
 	);
 
-const getEntriesAfterChangeEpic = ( action$ ) =>
+export const getEntriesAfterChangeEpic = ( action$ ) =>
 	action$.pipe(
 		ofType(
 			types.CREATE_ENTRY_SUCCESS,

--- a/src/react/epics/polling.js
+++ b/src/react/epics/polling.js
@@ -25,7 +25,7 @@ import { scrollToEntry } from '../actions/userActions';
 
 import { shouldRenderNewEntries } from '../utils/utils';
 
-const startPollingEpic = ( action$, state$ ) =>
+export const startPollingEpic = ( action$, state$ ) =>
 	action$.pipe(
 		ofType( types.START_POLLING ),
 		switchMap( () =>
@@ -54,7 +54,7 @@ const startPollingEpic = ( action$, state$ ) =>
 		)
 	);
 
-const mergePollingEpic = ( action$, state$ ) =>
+export const mergePollingEpic = ( action$, state$ ) =>
 	action$.pipe(
 		ofType( types.MERGE_POLLING ),
 		switchMap( () => {


### PR DESCRIPTION
## Summary
Adds unit test coverage for the redux-observable epics in `src/react/epics/`, which had none. Individual epics weren't exported before (only the combined `combineEpics(...)` default), so this also adds named exports to make them testable in isolation — no behavior change.
Fixes #794 (epics part of the scope; reducer tests already existed, component tests are left as a follow-up since they need a rendering lib that isn't installed).

## Changes
### `src/react/epics/api.js` / `src/react/epics/polling.js`
**Before:**
```js
const getEntriesEpic = ( action$, state$ ) => ...
```
**After:**
```js
export const getEntriesEpic = ( action$, state$ ) => ...
```
**Why:** epics could only be reached through the combined default export, so there was no way to drive one in isolation for a test. Same change applied to all 8 epics across both files.

### `src/react/epics/__tests__/api.test.js` (new)
Covers `getEntriesEpic`, `getPaginatedEntriesEpic`, `createEntryEpic`, `updateEntryEpic`, `deleteEntryEpic`, `getEntriesAfterChangeEpic` — success paths, error paths, and the hash-based jump-to-event branch. Services are mocked the same way the existing `services/__tests__/api.test.js` mocks `rxjs/ajax`.

### `src/react/epics/__tests__/polling.test.js` (new)
Covers `startPollingEpic` (interval timing and cancellation, using rxjs `TestScheduler` marble testing since it's timer-based) and `mergePollingEpic` (page-1 merge path vs page-2+ refetch path, plus error handling).

## Testing
**Test 1: new epic tests**
1. `npm test -- src/react/epics/__tests__`
Result: 2 suites, 19 tests, all passing

**Test 2: full suite regression check**
1. `npm test`
Result: 13 suites, 91 tests, all passing

**Test 3: lint**
1. `npm run lint:js`
Result: clean on all files touched by this PR (repo has some pre-existing unrelated jsx-a11y errors in other files, not touched here)

**Test 4: build**
1. `npm run build`
Result: builds fine, confirms the named-export change doesn't break bundling
