### PR TITLE
fix(react): migrate PaginationContainer and PreviewContainer to hooks

### DIFF
--- a/src/react/containers/PaginationContainer.js
+++ b/src/react/containers/PaginationContainer.js
@@ -1,92 +1,80 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
-import { bindActionCreators } from 'redux';
-import { connect } from 'react-redux';
-import * as apiActions from '../actions/apiActions';
-import * as userActions from '../actions/userActions';
+import React from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { __ } from '@wordpress/i18n';
+import { getEntriesPaginated } from '../actions/apiActions';
 
-class PaginationContainer extends Component {
-	render() {
-		const { page, pages, getEntriesPaginated } = this.props;
-
-		const isFirstPage = page === 1;
-		const isLastPage = page === pages;
-
-		return (
-			<div className="liveblog-pagination">
-				<div>
-					<button
-						disabled={ isFirstPage }
-						className={ `liveblog-btn liveblog-pagination-btn liveblog-pagination-first ${
-							isFirstPage && 'liveblog-btn--hide'
-						}` }
-						onClick={ () => getEntriesPaginated( 1, 'first' ) }
-					>
-						First
-					</button>
-					<button
-						disabled={ isFirstPage }
-						className={ `liveblog-btn liveblog-pagination-btn liveblog-pagination-prev ${
-							isFirstPage && 'liveblog-btn--hide'
-						}` }
-						onClick={ () =>
-							getEntriesPaginated( page - 1, 'last' )
-						}
-					>
-						Prev
-					</button>
-				</div>
-				<span className="liveblog-pagination-pages">
-					{ page } of { pages }
-				</span>
-				<div>
-					<button
-						disabled={ isLastPage }
-						className={ `liveblog-btn liveblog-pagination-btn liveblog-pagination-next ${
-							isLastPage && 'liveblog-btn--hide'
-						}` }
-						onClick={ () =>
-							getEntriesPaginated( page + 1, 'first' )
-						}
-					>
-						Next
-					</button>
-					<button
-						disabled={ isLastPage }
-						className={ `liveblog-btn liveblog-pagination-btn liveblog-pagination-last ${
-							isLastPage && 'liveblog-btn--hide'
-						}` }
-						onClick={ () => getEntriesPaginated( pages, 'first' ) }
-					>
-						Last
-					</button>
-				</div>
-			</div>
-		);
-	}
-}
-
-PaginationContainer.propTypes = {
-	page: PropTypes.number,
-	pages: PropTypes.number,
-	getEntriesPaginated: PropTypes.func,
-};
-
-const mapStateToProps = ( state ) => ( {
-	page: state.pagination.page,
-	pages: state.pagination.pages,
+/**
+ * Work out button disabled state from the current page/pages.
+ * @param {number} page
+ * @param {number} pages
+ */
+export const getPaginationState = ( page, pages ) => ( {
+	isFirstPage: page === 1,
+	isLastPage: page === pages,
 } );
 
-const mapDispatchToProps = ( dispatch ) =>
-	bindActionCreators(
-		{
-			...apiActions,
-			...userActions,
-		},
-		dispatch
-	);
+const PaginationContainer = () => {
+	const page = useSelector( ( state ) => state.pagination.page );
+	const pages = useSelector( ( state ) => state.pagination.pages );
+	const dispatch = useDispatch();
 
-export default connect(
-	mapStateToProps,
-	mapDispatchToProps
-)( PaginationContainer );
+	const { isFirstPage, isLastPage } = getPaginationState( page, pages );
+
+	return (
+		<div className="liveblog-pagination">
+			<div>
+				<button
+					disabled={ isFirstPage }
+					className={ `liveblog-btn liveblog-pagination-btn liveblog-pagination-first ${
+						isFirstPage ? 'liveblog-btn--hide' : ''
+					}` }
+					onClick={ () =>
+						dispatch( getEntriesPaginated( 1, 'first' ) )
+					}
+				>
+					{ __( 'First', 'liveblog' ) }
+				</button>
+				<button
+					disabled={ isFirstPage }
+					className={ `liveblog-btn liveblog-pagination-btn liveblog-pagination-prev ${
+						isFirstPage ? 'liveblog-btn--hide' : ''
+					}` }
+					onClick={ () =>
+						dispatch( getEntriesPaginated( page - 1, 'last' ) )
+					}
+				>
+					{ __( 'Prev', 'liveblog' ) }
+				</button>
+			</div>
+			<span className="liveblog-pagination-pages">
+				{ page } of { pages }
+			</span>
+			<div>
+				<button
+					disabled={ isLastPage }
+					className={ `liveblog-btn liveblog-pagination-btn liveblog-pagination-next ${
+						isLastPage ? 'liveblog-btn--hide' : ''
+					}` }
+					onClick={ () =>
+						dispatch( getEntriesPaginated( page + 1, 'first' ) )
+					}
+				>
+					{ __( 'Next', 'liveblog' ) }
+				</button>
+				<button
+					disabled={ isLastPage }
+					className={ `liveblog-btn liveblog-pagination-btn liveblog-pagination-last ${
+						isLastPage ? 'liveblog-btn--hide' : ''
+					}` }
+					onClick={ () =>
+						dispatch( getEntriesPaginated( pages, 'first' ) )
+					}
+				>
+					{ __( 'Last', 'liveblog' ) }
+				</button>
+			</div>
+		</div>
+	);
+};
+
+export default PaginationContainer;

--- a/src/react/containers/PreviewContainer.js
+++ b/src/react/containers/PreviewContainer.js
@@ -1,60 +1,57 @@
-import React, { Component } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import { timeout, map } from 'rxjs/operators';
 
 import { getPreview } from '../services/api';
 import Loader from '../components/Loader';
 
-class PreviewContainer extends Component {
-	constructor( props ) {
-		super( props );
+/**
+ * Pull the rendered HTML out of a preview ajax response.
+ * @param {Object} res
+ */
+export const getResponseHtml = ( res ) => res.response.html;
 
-		this.state = {
-			loading: true,
-			error: false,
-			entryContent: false,
-		};
-	}
+const PreviewContainer = ( { config, getEntryContent } ) => {
+	const [ loading, setLoading ] = useState( true );
+	const [ entryContent, setEntryContent ] = useState( false );
 
-	componentDidMount() {
-		const { config, getEntryContent } = this.props;
+	useEffect( () => {
+		const subscription = getPreview( getEntryContent(), config )
+			.pipe( timeout( 10000 ), map( getResponseHtml ) )
+			.subscribe( {
+				next: ( html ) => {
+					setEntryContent( html );
+					setLoading( false );
+				},
+				error: () => {
+					setEntryContent( false );
+					setLoading( false );
+				},
+			} );
 
-		getPreview( getEntryContent(), config )
-			.pipe(
-				timeout( 10000 ),
-				map( ( res ) => res.response )
-			)
-			.subscribe( ( res ) =>
-				this.setState( {
-					entryContent: res.html,
-					loading: false,
-				} )
-			);
-	}
+		return () => subscription.unsubscribe();
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [] );
 
-	render() {
-		const { entryContent, loading } = this.state;
-
-		if ( loading ) {
-			return (
-				<div className="liveblog-preview">
-					<Loader />
-				</div>
-			);
-		}
-
-		if ( ! entryContent ) {
-			return false;
-		}
-
+	if ( loading ) {
 		return (
-			<div
-				className="liveblog-preview"
-				dangerouslySetInnerHTML={ { __html: entryContent } }
-			/>
+			<div className="liveblog-preview">
+				<Loader />
+			</div>
 		);
 	}
-}
+
+	if ( ! entryContent ) {
+		return false;
+	}
+
+	return (
+		<div
+			className="liveblog-preview"
+			dangerouslySetInnerHTML={ { __html: entryContent } }
+		/>
+	);
+};
 
 PreviewContainer.propTypes = {
 	getEntryContent: PropTypes.func,

--- a/src/react/containers/__tests__/PaginationContainer.test.js
+++ b/src/react/containers/__tests__/PaginationContainer.test.js
@@ -1,0 +1,31 @@
+import { getPaginationState } from '../PaginationContainer';
+
+describe( 'getPaginationState', () => {
+	it( 'flags the first page', () => {
+		expect( getPaginationState( 1, 5 ) ).toEqual( {
+			isFirstPage: true,
+			isLastPage: false,
+		} );
+	} );
+
+	it( 'flags the last page', () => {
+		expect( getPaginationState( 5, 5 ) ).toEqual( {
+			isFirstPage: false,
+			isLastPage: true,
+		} );
+	} );
+
+	it( 'flags a page that is both first and last', () => {
+		expect( getPaginationState( 1, 1 ) ).toEqual( {
+			isFirstPage: true,
+			isLastPage: true,
+		} );
+	} );
+
+	it( 'flags a middle page as neither first nor last', () => {
+		expect( getPaginationState( 3, 5 ) ).toEqual( {
+			isFirstPage: false,
+			isLastPage: false,
+		} );
+	} );
+} );

--- a/src/react/containers/__tests__/PreviewContainer.test.js
+++ b/src/react/containers/__tests__/PreviewContainer.test.js
@@ -1,0 +1,15 @@
+import { getResponseHtml } from '../PreviewContainer';
+
+describe( 'getResponseHtml', () => {
+	it( 'pulls the rendered html out of the ajax response', () => {
+		const res = { response: { html: '<p>Preview</p>' } };
+
+		expect( getResponseHtml( res ) ).toBe( '<p>Preview</p>' );
+	} );
+
+	it( 'returns undefined when the response has no html', () => {
+		const res = { response: {} };
+
+		expect( getResponseHtml( res ) ).toBeUndefined();
+	} );
+} );


### PR DESCRIPTION
## Summary
Converts `PaginationContainer` and `PreviewContainer` from class components to function components using hooks (`useSelector`/`useDispatch`, `useState`/`useEffect`). Part of #796, which lists six components to migrate — this covers the two simplest, per the issue's own "start simple" suggestion. `EventsContainer`, `AppContainer`, `EntryContainer`, and `EditorContainer` are left for follow-up PRs.

## Changes
### PaginationContainer
**Before:**
```js
class PaginationContainer extends Component { ... }
export default connect( mapStateToProps, mapDispatchToProps )( PaginationContainer );
```
**After:**
```js
const PaginationContainer = () => {
	const page = useSelector( ( state ) => state.pagination.page );
	const pages = useSelector( ( state ) => state.pagination.pages );
	const dispatch = useDispatch();
	...
};
export default PaginationContainer;
```
**Why:** mechanical hooks conversion. Also wrapped the First/Prev/Next/Last button labels in `__()` with the `liveblog` text domain (they were plain strings before) and fixed the className template so it no longer interpolates a literal `false` when a button isn't hidden.

### PreviewContainer
**Before:**
```js
componentDidMount() {
	getPreview( ... ).pipe( timeout( 10000 ), map( ( res ) => res.response ) )
		.subscribe( ( res ) => this.setState( { entryContent: res.html, loading: false } ) );
}
```
**After:**
```js
useEffect( () => {
	const subscription = getPreview( ... ).pipe( timeout( 10000 ), map( getResponseHtml ) )
		.subscribe( {
			next: ( html ) => { setEntryContent( html ); setLoading( false ); },
			error: () => { setEntryContent( false ); setLoading( false ); },
		} );
	return () => subscription.unsubscribe();
}, [] );
```
**Why:** hooks conversion, plus two bugs the old class version had:
- the RxJS subscription was never unsubscribed on unmount
- a failed/timed-out preview request left the loading spinner stuck forever with no error handling

## Testing
**Test 1: Pagination button state**
1. `npm test`
2. `PaginationContainer.test.js` covers first/last/middle page button disabled states
Result: 78 tests pass

**Test 2: Preview response parsing**
1. `npm test`
2. `PreviewContainer.test.js` covers the response-to-html extraction used by the effect
Result: passes

**Test 3: Manual**
1. Open a liveblog post with enough entries to paginate, click through First/Prev/Next/Last
2. Open the editor, switch to the Preview tab, confirm it loads and updates on content change
Result: works as expected, no console errors

Also ran `npm run lint:js` (no new errors — pre-existing `jsx-a11y` warnings in unrelated files untouched) and `npm run build` (clean).
