### PR TITLE
chore(build): add TypeScript setup (phase 1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33,10 +33,13 @@
         "rxjs": "^7.8.0"
       },
       "devDependencies": {
+        "@types/react": "^18.3.31",
+        "@types/react-dom": "^18.3.7",
         "@wordpress/i18n": "^6.21.1",
         "@wordpress/scripts": "^32.4.1",
         "sass-module-importer": "^1.4.0",
-        "sass-mq": "^7.0.0"
+        "sass-mq": "^7.0.0",
+        "typescript": "^6.0.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -7656,9 +7659,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "18.3.27",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
-      "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -24514,12 +24517,11 @@
       "license": "MIT"
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -5,10 +5,13 @@
   "author": "Automattic",
   "private": true,
   "devDependencies": {
+    "@types/react": "^18.3.31",
+    "@types/react-dom": "^18.3.7",
     "@wordpress/i18n": "^6.21.1",
     "@wordpress/scripts": "^32.4.1",
     "sass-module-importer": "^1.4.0",
-    "sass-mq": "^7.0.0"
+    "sass-mq": "^7.0.0",
+    "typescript": "^6.0.3"
   },
   "dependencies": {
     "@lexical/html": "^0.45.0",
@@ -40,7 +43,8 @@
     "start": "wp-scripts start",
     "lint:js": "wp-scripts lint-js ./src",
     "lint:css": "wp-scripts lint-style \"src/**/*.scss\"",
-    "test": "wp-scripts test-unit-js"
+    "test": "wp-scripts test-unit-js",
+    "check-types": "tsc --noEmit"
   },
   "overrides": {
     "webpack-dev-server": "^5.2.1"

--- a/src/react/actions/actionTypes.ts
+++ b/src/react/actions/actionTypes.ts
@@ -1,9 +1,12 @@
 /**
  * Convert list of strings and map them to constants.
- * @param {...any} args
+ * @param args Action type names.
  */
-const createTypes = ( ...args ) =>
-	args.reduce( ( obj, item ) => ( { ...obj, [ item ]: item } ), {} );
+const createTypes = ( ...args: string[] ): Record< string, string > =>
+	args.reduce(
+		( obj, item ) => ( { ...obj, [ item ]: item } ),
+		{} as Record< string, string >
+	);
 
 export default createTypes(
 	'LOAD_CONFIG',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+	"compilerOptions": {
+		"target": "ES2020",
+		"module": "ESNext",
+		"moduleResolution": "bundler",
+		"lib": ["ES2020", "DOM"],
+		"jsx": "react-jsx",
+		"allowJs": true,
+		"checkJs": false,
+		"strict": false,
+		"esModuleInterop": true,
+		"skipLibCheck": true,
+		"noEmit": true,
+		"rootDir": "./src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules", "build"]
+}


### PR DESCRIPTION
## Summary
Adds the TypeScript toolchain (phase 1 of issue #797) with one small proof-of-concept file, so later PRs can migrate files incrementally without re-solving tooling.
Fixes #797

## Changes
### package.json
**Before:** no `typescript` dependency, no type-check script.
**After:** added `typescript`, `@types/react`, `@types/react-dom` (pinned to v18 to match the installed `react`/`react-dom`) as devDependencies, and a `check-types` script (`tsc --noEmit`).
**Why:** needed before any `.ts`/`.tsx` file can be authored or type-checked.

### tsconfig.json (new)
**After:**
```json
{
  "compilerOptions": {
    "target": "ES2020",
    "module": "ESNext",
    "moduleResolution": "bundler",
    "lib": ["ES2020", "DOM"],
    "jsx": "react-jsx",
    "allowJs": true,
    "checkJs": false,
    "strict": false,
    "esModuleInterop": true,
    "skipLibCheck": true,
    "noEmit": true,
    "rootDir": "./src"
  },
  "include": ["src/**/*"],
  "exclude": ["node_modules", "build"]
}
```
**Why:** `@wordpress/scripts` (already v32.4.1) already resolves `.ts`/`.tsx` in its webpack and jest config, so this is only needed for editor support and `tsc --noEmit` type-checking. `noEmit` because wp-scripts still does the actual bundling.

### src/react/actions/actionTypes.js → actionTypes.ts
**Before:**
```js
const createTypes = ( ...args ) =>
	args.reduce( ( obj, item ) => ( { ...obj, [ item ]: item } ), {} );
```
**After:**
```ts
const createTypes = ( ...args: string[] ): Record< string, string > =>
	args.reduce(
		( obj, item ) => ( { ...obj, [ item ]: item } ),
		{} as Record< string, string >
	);
```
**Why:** proof that the toolchain works end to end. Picked because it's small, self-contained, and imported through extension-less paths (`from './actionTypes'`), so no call site needed changes.

## Testing
**Test 1: type-check**
1. `npm ci`
2. `npm run check-types`
Result: `TypeScript: No errors found`

**Test 2: build**
1. `npm run build`
Result: builds clean, same output shape as before (actionTypes.ts compiles to the same JS)

**Test 3: unit tests**
1. `npm test`
Result: 11 suites / 72 tests pass, same as before this change

**Test 4: lint**
1. `npx wp-scripts lint-js src/react/actions/actionTypes.ts`
Result: no errors

Note: `npm run lint:js` (full run) currently reports ~377 pre-existing `import/no-unresolved`/`import/named` errors on `develop` too, caused by a broken native binding in `eslint-import-resolver-typescript`'s `unrs-resolver` dep (npm optional-dependency bug, npm/cli#4828). Confirmed present before this change, not introduced by it.

## Not in scope
Typed Redux state, component/container migration, `prop-types` removal, and `strict: true` are later phases of #797, left for follow-up PRs.
