### PR TITLE
test(cli): add integration coverage for wp liveblog fix-archive

### DIFF
--- a/tests/Integration/WpCliFixArchiveTest.php
+++ b/tests/Integration/WpCliFixArchiveTest.php
@@ -1,0 +1,167 @@
+<?php
+/**
+ * Tests for the `wp liveblog fix-archive` WP-CLI command.
+ *
+ * @package Automattic\Liveblog\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Tests\Integration;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+use WPCOM_Liveblog_Entry;
+use WPCOM_Liveblog_WP_CLI;
+
+require_once __DIR__ . '/wp-cli-stub.php';
+
+if ( ! class_exists( 'WPCOM_Liveblog_WP_CLI' ) ) {
+	require_once dirname( __DIR__, 2 ) . '/classes/class-wpcom-liveblog-wp-cli.php';
+}
+
+/**
+ * The fix-archive command test case.
+ */
+final class WpCliFixArchiveTest extends TestCase {
+
+	/**
+	 * Test post ID.
+	 *
+	 * @var int
+	 */
+	private int $post_id;
+
+	/**
+	 * Command instance under test.
+	 *
+	 * @var WPCOM_Liveblog_WP_CLI
+	 */
+	private WPCOM_Liveblog_WP_CLI $command;
+
+	/**
+	 * Set up before each test.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+
+		\WP_CLI::reset();
+
+		$this->command = new WPCOM_Liveblog_WP_CLI();
+		$this->post_id = self::factory()->post->create();
+	}
+
+	/**
+	 * Create a root liveblog entry comment with no comment meta.
+	 *
+	 * The fix_archive() method treats any comment on the post with zero
+	 * commentmeta rows as a "correct"/root entry, so this must stay meta-free.
+	 *
+	 * @param string $content Comment content.
+	 * @return int Comment ID.
+	 */
+	private function create_root_entry( string $content ): int {
+		return self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $this->post_id,
+				'comment_approved' => 'liveblog',
+				'comment_type'     => 'liveblog',
+				'comment_content'  => $content,
+			)
+		);
+	}
+
+	/**
+	 * Create an "edit" ghost comment pointing at $replaces via liveblog_replaces meta.
+	 *
+	 * @param int    $replaces Comment ID this ghost claims to replace.
+	 * @param string $content  Comment content.
+	 * @return int Comment ID.
+	 */
+	private function create_edit_entry( int $replaces, string $content ): int {
+		$comment_id = self::factory()->comment->create(
+			array(
+				'comment_post_ID'  => $this->post_id,
+				'comment_approved' => 'liveblog',
+				'comment_type'     => 'liveblog',
+				'comment_content'  => $content,
+			)
+		);
+		add_comment_meta( $comment_id, WPCOM_Liveblog_Entry::REPLACES_META_KEY, $replaces );
+		return $comment_id;
+	}
+
+	/**
+	 * Build a liveblog with a correctly-pointed edit and a mis-pointed edit.
+	 *
+	 * Mirrors the archived-liveblog corruption fix-archive repairs: a second
+	 * edit whose liveblog_replaces meta points at the first ghost instead of
+	 * collapsing back to the root entry.
+	 *
+	 * @return array{root:int,ghost:int,broken:int} Comment IDs.
+	 */
+	private function create_liveblog_with_broken_replaces(): array {
+		add_post_meta( $this->post_id, 'liveblog', 'enable' );
+
+		$root   = $this->create_root_entry( 'original content' );
+		$ghost  = $this->create_edit_entry( $root, 'first edit' );
+		$broken = $this->create_edit_entry( $ghost, 'second edit' );
+
+		return array(
+			'root'   => $root,
+			'ghost'  => $ghost,
+			'broken' => $broken,
+		);
+	}
+
+	/**
+	 * Test that --dryrun reports intended changes without modifying data.
+	 */
+	public function test_fix_archive_dry_run_does_not_modify_data(): void {
+		$ids = $this->create_liveblog_with_broken_replaces();
+
+		$this->command->fix_archive( array(), array( 'dryrun' => true ) );
+
+		$this->assertSame(
+			(string) $ids['ghost'],
+			get_comment_meta( $ids['broken'], WPCOM_Liveblog_Entry::REPLACES_META_KEY, true ),
+			'Dry run must not touch liveblog_replaces meta.'
+		);
+	}
+
+	/**
+	 * Test that a real run corrects a mis-pointed liveblog_replaces value.
+	 */
+	public function test_fix_archive_corrects_incorrect_replaces_meta(): void {
+		$ids = $this->create_liveblog_with_broken_replaces();
+
+		$this->command->fix_archive( array(), array() );
+
+		$this->assertSame(
+			(string) $ids['root'],
+			get_comment_meta( $ids['broken'], WPCOM_Liveblog_Entry::REPLACES_META_KEY, true ),
+			'fix-archive should repoint the broken edit at the root entry.'
+		);
+		$this->assertTrue( \WP_CLI::$success_called );
+	}
+
+	/**
+	 * Test that no liveblog posts at all completes without error.
+	 */
+	public function test_fix_archive_handles_no_liveblogs_found(): void {
+		$this->command->fix_archive( array(), array() );
+
+		$this->assertTrue( \WP_CLI::$success_called );
+	}
+
+	/**
+	 * Test that a liveblog with no edited entries completes without error.
+	 */
+	public function test_fix_archive_handles_liveblog_with_no_edited_entries(): void {
+		add_post_meta( $this->post_id, 'liveblog', 'enable' );
+		$this->create_root_entry( 'only entry, never edited' );
+
+		$this->command->fix_archive( array(), array() );
+
+		$this->assertTrue( \WP_CLI::$success_called );
+	}
+}

--- a/tests/Integration/wp-cli-stub.php
+++ b/tests/Integration/wp-cli-stub.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Minimal WP_CLI stubs so wp-cli command classes can be loaded and exercised
+ * from PHPUnit, where the real WP-CLI runtime isn't present.
+ *
+ * @package Automattic\Liveblog\Tests\Integration
+ */
+
+// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedClassFound -- Stubs for external WP-CLI classes.
+// phpcs:disable Squiz.Classes.ClassFileName.NoMatch -- Stub file containing multiple classes.
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound -- Stub file containing multiple classes.
+// phpcs:disable Universal.NamingConventions.NoReservedKeywordParameterNames -- Mirrors the real WP_CLI signature.
+
+if ( ! class_exists( 'WP_CLI_Command' ) ) {
+	/**
+	 * Stub for the WP-CLI base command class.
+	 */
+	class WP_CLI_Command {}
+}
+
+if ( ! class_exists( 'WP_CLI' ) ) {
+	/**
+	 * Stub for the WP_CLI static API.
+	 *
+	 * Only implements what `fix_archive()` actually calls. Tracks whether
+	 * success() was reached so tests can assert the command completed
+	 * without a fatal, without needing a full call log.
+	 */
+	class WP_CLI {
+
+		/**
+		 * Whether success() has been called since the last reset().
+		 *
+		 * @var bool
+		 */
+		public static $success_called = false;
+
+		/**
+		 * Reset tracked state between tests.
+		 *
+		 * @return void
+		 */
+		public static function reset() {
+			self::$success_called = false;
+		}
+
+		/**
+		 * Stub for WP_CLI::add_command(). No-op.
+		 *
+		 * @param string $name     Command name.
+		 * @param mixed  $callable Command handler.
+		 * @return void
+		 */
+		public static function add_command( $name, $callable ) {}
+
+		/**
+		 * Stub for WP_CLI::log(). No-op.
+		 *
+		 * @param string $message Message to log.
+		 * @return void
+		 */
+		public static function log( $message ) {}
+
+		/**
+		 * Stub for WP_CLI::success(). Records that it was reached.
+		 *
+		 * @param string $message Message to log.
+		 * @return void
+		 */
+		public static function success( $message ) {
+			self::$success_called = true;
+		}
+
+		/**
+		 * Stub for WP_CLI::colorize(). Returns the string unchanged.
+		 *
+		 * @param string $string String to colorize.
+		 * @return string
+		 */
+		public static function colorize( $string ) {
+			return $string;
+		}
+	}
+}
+
+// phpcs:enable


### PR DESCRIPTION
## Summary
fix-archive had zero automated test coverage. Adds it, in the existing legacy style.
Refs #789

## Investigation on #789

The issue asked for two things: drop the obsolete `readme_for_github` command, and refactor `fix-archive` into a namespaced command + service class with DI and behat tests.

- `readme_for_github` is already gone — removed on develop in `5becaad` (PR #872), the same change that dropped `readme.txt` in favor of a WordPress.org-compatible `README.md`. Nothing to do there.
- The DDD refactor the issue describes already exists, but only on the `2.x` branch (commit `e760e10`: `FixArchiveCommand` + `ArchiveRepairService` under `src/php/`, with DI and unit tests). `develop` is still the flat, legacy static-class style, and per project convention 2.x patterns are backported by hand when needed, not ported wholesale. Not doing that here.
- Checked whether the corruption `fix-archive` repairs (broken `liveblog_replaces` commentmeta + duplicated content after editing an entry twice) is still reachable. PR #297 already closed the supported REST/AJAX path by canonicalizing `entry_id` through `replaces` before it reaches the client. But `validate_entry_belongs_to_post()` still doesn't reject an `entry_id` that is itself an already-replaced ghost comment, so the same corruption stays reachable in principle (stale cached page, direct API caller, future regression). Recommend keeping `fix-archive`, not deprecating it.

So the only real gap left under this issue is missing test coverage, which this PR adds.

## Changes
### tests/Integration/wp-cli-stub.php (new)
Minimal `WP_CLI`/`WP_CLI_Command` stub (`log`, `success`, `colorize`, `add_command`), guarded by `class_exists()`. Needed because the real WP-CLI runtime isn't loaded under PHPUnit, and `class-wpcom-liveblog-wp-cli.php` calls `WP_CLI::add_command()` at file-load time plus `WP_CLI::log()`/`::success()`/`::colorize()` inside `fix_archive()`.

### tests/Integration/WpCliFixArchiveTest.php (new)
Extends the same `Yoast\WPTestUtils\WPIntegration\TestCase` base as `EntryQueryTest.php`. Covers:
- dry run (`--dryrun`) does not modify `liveblog_replaces` meta
- actual run corrects a mis-pointed `liveblog_replaces` value
- no liveblogs at all completes cleanly
- a liveblog with no edited entries completes cleanly

## Testing
**Test 1: PHPCS**
1. `composer cs`
Result: clean on both new files

**Test 2: Lint**
1. `composer lint`
Result: no syntax errors

**Test 3: CodeRabbit**
1. `coderabbit review --agent`
Result: 0 findings

**Test 4: composer test:integration**
Couldn't get a clean local `wp-env` run to verify this locally — repeated transient network failures during the WordPress core git clone / Alpine package install in the wp-env Docker build on this machine, unrelated to this change. Would appreciate a CI run or a maintainer re-run locally to confirm the four new test cases pass.
