### PR TITLE
fix(core): defer plugin load to plugins_loaded hook

### DIFF
--- a/liveblog.php
+++ b/liveblog.php
@@ -2386,7 +2386,10 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 			);
 		}
 	}
-	WPCOM_Liveblog::load();
+
+	// Hooked instead of called directly so that other plugins get a chance to
+	// register their own callbacks (e.g. on `liveblog_features`) before we run.
+	add_action( 'plugins_loaded', array( 'WPCOM_Liveblog', 'load' ), 0 );
 
 	/** Plupload Helpers */
 	if ( ! function_exists( 'wp_convert_hr_to_bytes' ) ) {

--- a/tests/Integration/LiveblogLoadTest.php
+++ b/tests/Integration/LiveblogLoadTest.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * Tests for how the main Liveblog class is loaded.
+ *
+ * @package Automattic\Liveblog\Tests\Integration
+ */
+
+declare( strict_types=1 );
+
+namespace Automattic\Liveblog\Tests\Integration;
+
+use Yoast\WPTestUtils\WPIntegration\TestCase;
+use WPCOM_Liveblog;
+
+/**
+ * Liveblog load test case.
+ */
+final class LiveblogLoadTest extends TestCase {
+
+	/**
+	 * Checks WPCOM_Liveblog::load is hooked to `plugins_loaded` instead of being
+	 * called directly, so other plugins get a chance to register their own
+	 * callbacks (e.g. on `liveblog_features`) first.
+	 *
+	 * @covers WPCOM_Liveblog::load()
+	 */
+	public function test_load_is_hooked_to_plugins_loaded(): void {
+		$priority = has_action( 'plugins_loaded', array( WPCOM_Liveblog::class, 'load' ) );
+
+		$this->assertNotFalse( $priority );
+		$this->assertSame( 0, $priority );
+	}
+}


### PR DESCRIPTION
## Summary
`WPCOM_Liveblog::load()` was called directly at the bottom of `liveblog.php`, so it ran the instant PHP parsed the file, before other plugins had a chance to register callbacks. This meant the `liveblog_features` filter fired too early for a normal `add_filter( 'liveblog_features', ... )` call elsewhere to ever take effect, depending on plugin load order.
Fixes #602

## Changes
### liveblog.php
**Before:**
```php
	}
	WPCOM_Liveblog::load();

	/** Plupload Helpers */
```
**After:**
```php
	}

	// Hooked instead of called directly so that other plugins get a chance to
	// register their own callbacks (e.g. on `liveblog_features`) before we run.
	add_action( 'plugins_loaded', array( 'WPCOM_Liveblog', 'load' ), 0 );

	/** Plupload Helpers */
```
**Why:** hooking onto `plugins_loaded` at priority 0 defers `load()` until after every active plugin has been included, so any plugin's own top-level `add_filter()` call is guaranteed to be registered by the time Liveblog applies its filters. Priority 0 keeps it running as early as possible on that hook, same as before relative to `init`.

### tests/Integration/LiveblogLoadTest.php
New test asserting `WPCOM_Liveblog::load` is registered on `plugins_loaded` at priority `0`. Fails against the old code, where `load()` was never registered as a callback at all.

## Testing
**Test 1: liveblog_features filter now applies**
1. Added a small test plugin with `add_filter( 'liveblog_features', function( $f ) { return array( 'commands', 'emojis', 'authors' ); } );` (no hashtags), activated as a regular plugin.
2. Opened a post with an active liveblog and typed `#something` in the entry composer.
Result: hashtag suggestion no longer triggers, other features (commands/emoji/authors) still work. Before the fix, the filter had no effect regardless of plugin activation order.

**Test 2: automated suite**
- `composer test:unit` — 7/7 passing
- `composer test:integration` (via `wp-env`) — 158/158 passing, including the new `LiveblogLoadTest`
- `composer lint` and `composer cs` clean on changed files
