### PR TITLE
Sync develop version metadata to 1.12.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Real-time liveblogging plugin for WordPress with a React-based editor and a comm
 |----------|-------|
 | **Main file** | `liveblog.php` |
 | **Text domain** | `liveblog` |
-| **Version** | 1.12.1 |
+| **Version** | 1.12.2 |
 | **Requires PHP** | 7.4+ |
 | **Requires WP** | 6.4+ |
 | **Default branch** | `develop` |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tags: liveblog, live blog, real-time, news, sports
 Requires at least: 6.4  
 Requires PHP: 7.4  
 Tested up to: 6.9  
-Stable tag: 1.12.1  
+Stable tag: 1.12.2  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 

--- a/liveblog.php
+++ b/liveblog.php
@@ -3,7 +3,7 @@
  * Plugin Name: Liveblog
  * Plugin URI: http://wordpress.org/extend/plugins/liveblog/
  * Description: Empowers website owners to provide rich and engaging live event coverage to a large, distributed audience.
- * Version:     1.12.1
+ * Version:     1.12.2
  * Requires at least: 6.4
  * Requires PHP: 7.4
  * Author:      WordPress.com VIP, Big Bite Creative and contributors
@@ -33,7 +33,7 @@ if ( ! class_exists( 'WPCOM_Liveblog' ) ) :
 		 *
 		 * @var string
 		 */
-		const VERSION = '1.12.1';
+		const VERSION = '1.12.2';
 
 		/**
 		 * Rewrites version for flushing rewrite rules.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "liveblog",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "liveblog",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "dependencies": {
         "@lexical/html": "^0.45.0",
         "@lexical/link": "^0.45.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "liveblog",
   "description": "Liveblogging done right. Using WordPress",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "author": "Automattic",
   "private": true,
   "devDependencies": {


### PR DESCRIPTION
## Summary

The 1.12.2 release set the plugin's version strings on the `release/1.12.2` branch, but that bump was never merged back into `develop`. As a consequence `develop` has continued to advertise **1.12.1** across every place the version is recorded: the `liveblog.php` plugin header and `VERSION` constant, the `Stable tag` in `README.md`, `package.json`, `package-lock.json`, and `AGENTS.md`. With 46 commits landed since the tag, that understated the code actually present on the branch and left the metadata inconsistent with the latest release.

This realigns those five files with the 1.12.2 tag. It is deliberately a forward-only correction on `develop`'s head rather than a history rewrite across the intervening commits, so no shared history changes and the fix is a single, reviewable commit. The values here mirror exactly what the 1.12.2 release commit applied; the only remaining `1.12.1` string in the tree is the unrelated `axios` dependency constraint, which is left untouched.

No functional code changes — metadata only.