### PR TITLE
Remove dead legacy AJAX permalink endpoints

### DIFF
--- a/src/php/Application/Config/LiveblogConfiguration.php
+++ b/src/php/Application/Config/LiveblogConfiguration.php
@@ -24,7 +24,7 @@ final class LiveblogConfiguration {
 	/**
 	 * Rewrites version for flushing rewrite rules.
 	 */
-	public const REWRITES_VERSION = 1;
+	public const REWRITES_VERSION = 2;
 
 	/**
 	 * Minimum WordPress version required.
@@ -35,11 +35,6 @@ final class LiveblogConfiguration {
 	 * Meta key for liveblog state.
 	 */
 	public const KEY = 'liveblog';
-
-	/**
-	 * URL endpoint for liveblog.
-	 */
-	public const URL_ENDPOINT = 'liveblog';
 
 	/**
 	 * Capability required to edit liveblog entries.

--- a/src/php/Infrastructure/DI/Container.php
+++ b/src/php/Infrastructure/DI/Container.php
@@ -646,7 +646,6 @@ final class Container {
 		if ( null === $this->request_router ) {
 			$this->request_router = new RequestRouter(
 				$this->entry_query_service(),
-				$this->entry_operations(),
 				$this->key_event_service(),
 				$this->content_renderer()
 			);

--- a/src/php/Infrastructure/WordPress/PluginBootstrapper.php
+++ b/src/php/Infrastructure/WordPress/PluginBootstrapper.php
@@ -101,8 +101,6 @@ final class PluginBootstrapper {
 	 */
 	private function init_core(): void {
 		add_action( 'init', array( $this, 'register_post_type_support' ) );
-		add_action( 'init', array( $this, 'add_rewrite_rules' ) );
-		add_action( 'permalink_structure_changed', array( $this, 'add_rewrite_rules' ) );
 		add_action( 'init', array( $this, 'flush_rewrite_rules' ), 1000 );
 
 		// Register image embed handler.
@@ -143,15 +141,6 @@ final class PluginBootstrapper {
 		LiveblogConfiguration::set_auto_archive_days( $auto_archive_days );
 
 		do_action( 'after_liveblog_init' ); // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedHooknameFound -- Legacy hook name.
-	}
-
-	/**
-	 * Add rewrite rules for liveblog endpoints.
-	 *
-	 * @return void
-	 */
-	public function add_rewrite_rules(): void {
-		add_rewrite_endpoint( LiveblogConfiguration::URL_ENDPOINT, EP_PERMALINK );
 	}
 
 	/**

--- a/src/php/Infrastructure/WordPress/RequestRouter.php
+++ b/src/php/Infrastructure/WordPress/RequestRouter.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Request router for liveblog endpoints.
+ * Entry read facade for liveblog endpoints.
  *
  * @package Automattic\Liveblog\Infrastructure\WordPress
  */
@@ -13,14 +13,11 @@ use Automattic\Liveblog\Application\Config\LazyloadConfiguration;
 use Automattic\Liveblog\Application\Config\LiveblogConfiguration;
 use Automattic\Liveblog\Application\Presenter\EntryPresenter;
 use Automattic\Liveblog\Application\Renderer\ContentRendererInterface;
-use Automattic\Liveblog\Application\Service\EntryOperations;
 use Automattic\Liveblog\Application\Service\EntryQueryService;
 use Automattic\Liveblog\Application\Service\KeyEventService;
 
 /**
- * Routes liveblog AJAX requests to appropriate handlers.
- *
- * Handles the non-REST-API legacy endpoints for backwards compatibility.
+ * Builds the JSON-ready entry payloads consumed by the REST API and AMP render path.
  */
 final class RequestRouter {
 
@@ -30,13 +27,6 @@ final class RequestRouter {
 	 * @var EntryQueryService
 	 */
 	private EntryQueryService $entry_query_service;
-
-	/**
-	 * Entry operations service.
-	 *
-	 * @var EntryOperations
-	 */
-	private EntryOperations $entry_operations;
 
 	/**
 	 * Key event service.
@@ -56,64 +46,17 @@ final class RequestRouter {
 	 * Constructor.
 	 *
 	 * @param EntryQueryService        $entry_query_service The entry query service.
-	 * @param EntryOperations          $entry_operations    The entry operations service.
 	 * @param KeyEventService          $key_event_service   The key event service.
 	 * @param ContentRendererInterface $content_renderer    Content renderer used by the entry presenter.
 	 */
 	public function __construct(
 		EntryQueryService $entry_query_service,
-		EntryOperations $entry_operations,
 		KeyEventService $key_event_service,
 		ContentRendererInterface $content_renderer
 	) {
 		$this->entry_query_service = $entry_query_service;
-		$this->entry_operations    = $entry_operations;
 		$this->key_event_service   = $key_event_service;
 		$this->content_renderer    = $content_renderer;
-	}
-
-	/**
-	 * Check if this is an initial page request (not AJAX).
-	 *
-	 * @return bool True if this is an initial page request.
-	 */
-	public function is_initial_page_request(): bool {
-		global $wp_query;
-
-		return ! isset( $wp_query->query_vars[ LiveblogConfiguration::KEY ] );
-	}
-
-	/**
-	 * Check if this is an entries AJAX request.
-	 *
-	 * @return bool True if this is an entries AJAX request.
-	 */
-	public function is_entries_ajax_request(): bool {
-		return (bool) get_query_var( LiveblogConfiguration::URL_ENDPOINT );
-	}
-
-	/**
-	 * Get the AJAX method name for the current request.
-	 *
-	 * @param string $endpoint_suffix The endpoint suffix from the URL.
-	 * @return string The method name to call.
-	 */
-	public function get_ajax_method( string $endpoint_suffix ): string {
-		$suffix_to_method = array(
-			'\d+/\d+'  => 'entries_between',
-			'crud'     => 'crud_entry',
-			'entry'    => 'single_entry',
-			'lazyload' => 'lazyload_entries',
-			'preview'  => 'preview_entry',
-		);
-
-		foreach ( $suffix_to_method as $suffix_re => $method ) {
-			if ( preg_match( "%^$suffix_re/?%", $endpoint_suffix ) ) {
-				return $method;
-			}
-		}
-
-		return 'unknown';
 	}
 
 	/**
@@ -283,16 +226,6 @@ final class RequestRouter {
 	}
 
 	/**
-	 * Format a preview entry.
-	 *
-	 * @param string $content The content to preview.
-	 * @return array The preview response.
-	 */
-	public function preview_entry( string $content ): array {
-		return $this->entry_operations->format_preview( $content );
-	}
-
-	/**
 	 * Get request data for pagination.
 	 *
 	 * @return object Request data with page, last, and id properties.
@@ -303,50 +236,6 @@ final class RequestRouter {
 			'last' => get_query_var( 'liveblog_last', false ),
 			'id'   => get_query_var( 'liveblog_id', false ),
 		);
-	}
-
-	/**
-	 * Parse timestamps from the URL query var.
-	 *
-	 * @return array{0: int, 1: int} Array of [start_timestamp, end_timestamp].
-	 */
-	public function get_timestamps_from_query(): array {
-		$original_timestamps = explode( '/', get_query_var( LiveblogConfiguration::URL_ENDPOINT ) );
-
-		$start_timestamp = isset( $original_timestamps[0] ) ? (int) $original_timestamps[0] : 0;
-		$end_timestamp   = isset( $original_timestamps[1] ) ? (int) $original_timestamps[1] : 0;
-
-		return array( $start_timestamp, $end_timestamp );
-	}
-
-	/**
-	 * Check if the current user can edit liveblog.
-	 *
-	 * @return bool True if user can edit.
-	 */
-	public function current_user_can_edit(): bool {
-		$cap    = LiveblogConfiguration::get_edit_capability();
-		$retval = current_user_can( $cap );
-
-		return (bool) apply_filters( 'liveblog_current_user_can_edit_liveblog', $retval );
-	}
-
-	/**
-	 * Verify the nonce for a request.
-	 *
-	 * @param string $action The nonce action.
-	 * @return bool True if nonce is valid.
-	 */
-	public function verify_nonce( string $action = LiveblogConfiguration::NONCE_ACTION ): bool {
-		$nonce_key = LiveblogConfiguration::NONCE_KEY;
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- This method performs the verification.
-		if ( ! isset( $_REQUEST[ $nonce_key ] ) ) {
-			return false;
-		}
-
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
-		return (bool) wp_verify_nonce( wp_unslash( $_REQUEST[ $nonce_key ] ), $action );
 	}
 
 	/**


### PR DESCRIPTION
## Summary

The front end now talks to the plugin exclusively through the REST API. When the REST-versus-admin-ajax transport duality was dropped, the older permalink-based liveblog endpoints (`<permalink>/liveblog/…`) were left with no client and no dispatcher: the `liveblog` rewrite endpoint was still registered, but nothing ever served JSON from it, and `RequestRouter` still carried the request-handling scaffolding that used to drive it.

This change removes that dead surface. The rewrite endpoint registration and its `init` / `permalink_structure_changed` hooks go, along with the unused `RequestRouter` methods — the `is_*_request` / `get_ajax_method` / `get_timestamps_from_query` predicates and the legacy nonce, capability and preview helpers — none of which had a caller any longer. Retiring the preview helper also orphaned the `EntryOperations` dependency, so `RequestRouter` no longer takes it in its constructor. What remains is an honest read facade: it builds the JSON entry payloads consumed by the REST controller and the AMP render path, and its docblocks now say so.

`URL_ENDPOINT` is removed now that nothing references it, and `REWRITES_VERSION` is bumped so existing installs flush the stale endpoint rewrite rule on upgrade.

The result is 131 lines lighter with no behavioural change to the REST or AMP paths.

## Notes for reviewers

- `RequestRouter::get_entries_between` is retained because the integration tests call it directly, though the REST `/entries` route itself now goes through `EntryQueryService::get_between_timestamps()`. Reconciling that is a sensible follow-up.
- The class is arguably now misnamed (it no longer routes anything), but renaming it touches the container, the REST controller, the AMP integration and the tests, so that is left as a separate change to keep this diff focused.
- `HACKING.md` still describes the 1.x architecture throughout and needs its own documentation pass; it is intentionally untouched here to avoid leaving it half-updated.

## Test plan

- [x] `composer cs` (PHPCS) clean on the changed files
- [x] Unit suite green (190 tests)
- [ ] Integration suite (`RestApiTest` exercises `RequestRouter` via the container) — runs in CI