### PR TITLE
Fix pre-existing NoPaging CS failures in CLI queries

### DIFF
--- a/src/php/Application/Service/ArchiveRepairService.php
+++ b/src/php/Application/Service/ArchiveRepairService.php
@@ -41,7 +41,7 @@ final class ArchiveRepairService implements ArchiveRepairServiceInterface {
 			array(
 				'order'          => 'ASC',
 				'orderby'        => 'ID',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page -- CLI-only repair operation; must process every liveblog post.
 				'meta_key'       => 'liveblog', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Required for finding liveblogs.
 			)
 		);

--- a/src/php/Infrastructure/CLI/ArchiveOldCommand.php
+++ b/src/php/Infrastructure/CLI/ArchiveOldCommand.php
@@ -125,7 +125,7 @@ final class ArchiveOldCommand {
 		$query = new WP_Query(
 			array(
 				'post_type'      => $this->get_supported_post_types(),
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page -- CLI maintenance command; must scan every enabled liveblog to archive inactive ones.
 				'post_status'    => 'any',
 				'meta_key'       => 'liveblog', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Required for finding liveblogs.
 				'meta_value'     => 'enable', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Only enabled liveblogs.

--- a/src/php/Infrastructure/CLI/ListCommand.php
+++ b/src/php/Infrastructure/CLI/ListCommand.php
@@ -67,7 +67,7 @@ final class ListCommand {
 
 		$query_args = array(
 			'post_type'      => $this->get_supported_post_types(),
-			'posts_per_page' => -1,
+			'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page -- CLI command; lists all liveblogs on demand.
 			'post_status'    => 'any',
 			'meta_key'       => 'liveblog', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Required for finding liveblogs.
 			'orderby'        => 'modified',

--- a/src/php/Infrastructure/CLI/StatsCommand.php
+++ b/src/php/Infrastructure/CLI/StatsCommand.php
@@ -158,7 +158,7 @@ final class StatsCommand {
 		$query = new WP_Query(
 			array(
 				'post_type'      => $this->get_supported_post_types(),
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page -- CLI command; counts all liveblogs in the given state (ids only).
 				'post_status'    => 'any',
 				'meta_key'       => 'liveblog', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key -- Required for finding liveblogs.
 				'meta_value'     => $state, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value -- Required for counting by state.


### PR DESCRIPTION
## Summary

The `2.x` CS check ("Basic CS and QA checks") currently fails on four queries that set `posts_per_page => -1`, which the `WordPressVIPMinimum.Performance.NoPaging` sniff prohibits. The failure is pre-existing and unrelated to any feature work: it surfaces on every PR against `2.x` because the coding-standard toolchain is not pinned (there is no committed `composer.lock`), so CI resolves a newer `automattic/vipwpcs` whose `NoPaging` sniff flags these lines even though they passed when the commands were first merged.

All four call sites are maintenance operations rather than web requests. `ArchiveOldCommand`, `ListCommand` and `StatsCommand` run only under WP-CLI, and `ArchiveRepairService::find_liveblog_posts()` is reached solely through the `wp liveblog fix-archive` command. Each legitimately needs to process every liveblog rather than a single page, so the right fix is a justified `phpcs:ignore` on each line — consistent with the inline ignores these same queries already carry for the `SlowDBQuery` sniffs.

This turns the `2.x` baseline green and unblocks other in-flight `2.x` PRs that are currently showing the same red check.

## Test plan

- [x] `composer cs` exits 0 on the full tree
- [x] `php -l` clean on all four files