### PR TITLE
fix: deduplicate pending polling entries by ID

### DIFF
--- a/src/react/epics/polling.js
+++ b/src/react/epics/polling.js
@@ -24,6 +24,7 @@ import { polling as pollingApi, getEntries } from '../services/api';
 import { scrollToEntry } from '../actions/userActions';
 
 import { shouldRenderNewEntries } from '../utils/utils';
+import { filterRenderedNewEntries } from '../utils/polling';
 
 const startPollingEpic = ( action$, state$ ) =>
 	action$.pipe(
@@ -37,16 +38,24 @@ const startPollingEpic = ( action$, state$ ) =>
 						state$.value.config
 					).pipe(
 						timeout( 10000 ),
-						map( ( res ) =>
-							pollingSuccess(
-								res.response,
+						map( ( res ) => {
+							const response = {
+								...res.response,
+								entries: filterRenderedNewEntries(
+									res.response.entries,
+									state$.value.api.entries
+								),
+							};
+
+							return pollingSuccess(
+								response,
 								shouldRenderNewEntries(
 									state$.value.pagination.page,
 									state$.value.api.entries,
 									state$.value.polling.entries
 								)
-							)
-						),
+							);
+						} ),
 						catchError( ( error ) => of( pollingFailed( error ) ) )
 					)
 				)

--- a/src/react/epics/polling.js
+++ b/src/react/epics/polling.js
@@ -24,7 +24,7 @@ import { polling as pollingApi, getEntries } from '../services/api';
 import { scrollToEntry } from '../actions/userActions';
 
 import { shouldRenderNewEntries } from '../utils/utils';
-import { filterRenderedNewEntries } from '../utils/polling';
+import { filterKnownNewEntries } from '../utils/polling';
 
 const startPollingEpic = ( action$, state$ ) =>
 	action$.pipe(
@@ -41,9 +41,10 @@ const startPollingEpic = ( action$, state$ ) =>
 						map( ( res ) => {
 							const response = {
 								...res.response,
-								entries: filterRenderedNewEntries(
+								entries: filterKnownNewEntries(
 									res.response.entries,
-									state$.value.api.entries
+									state$.value.api.entries,
+									state$.value.polling.newestEntry
 								),
 							};
 

--- a/src/react/reducers/__tests__/polling.test.js
+++ b/src/react/reducers/__tests__/polling.test.js
@@ -18,6 +18,13 @@ describe( 'polling reducer', () => {
 			apiData.entries[ 0 ]
 		),
 		entries: shouldRenderNewEntries ? {} : initialState.newestEntry,
+		knownEntryIds: {
+			id_2973: true,
+			id_2974: true,
+			id_2975: true,
+			id_2976: true,
+			id_2977: true,
+		},
 	};
 
 	it( 'should handle GET_ENTRIES_SUCCESS', () => {
@@ -39,6 +46,10 @@ describe( 'polling reducer', () => {
 						( entry ) => entry.type === 'new'
 					)
 			  ),
+		knownEntryIds: {
+			...stateAfterGetEntriesSuccess.knownEntryIds,
+			id_3250: true,
+		},
 		newestEntry: getNewestEntry(
 			stateAfterGetEntriesSuccess.newestEntry,
 			pollingData.entries[ 0 ]
@@ -52,5 +63,60 @@ describe( 'polling reducer', () => {
 				pollingSuccess( pollingData, shouldRenderNewEntries )
 			)
 		).toEqual( stateAfterPollingSuccess );
+	} );
+
+	it( 'deduplicates only the pending queue and still advances polling state', () => {
+		const knownEntry = { id: 100, type: 'new', timestamp: 2000 };
+		const state = {
+			...initialState,
+			newestEntry: { id: 90, type: 'new', timestamp: 1990 },
+			knownEntryIds: { id_100: true },
+		};
+		const payload = {
+			entries: [ knownEntry ],
+			pages: 2,
+		};
+
+		const result = polling( state, pollingSuccess( payload, false ) );
+
+		expect( result.entries ).toEqual( {} );
+		expect( result.newestEntry ).toEqual( knownEntry );
+		expect( result.pages ).toBe( 2 );
+	} );
+
+	it( 'removes only rendered duplicates queued before page loading completes', () => {
+		const state = {
+			...initialState,
+			entries: {
+				id_100: { id: 100, type: 'new', timestamp: 2000 },
+				id_200: { id: 200, type: 'new', timestamp: 2001 },
+			},
+			knownEntryIds: {
+				id_100: true,
+				id_200: true,
+			},
+		};
+		const page = {
+			entries: [ { id: 100, type: 'update', timestamp: 2002 } ],
+			page: 1,
+			pages: 1,
+		};
+
+		const result = polling( state, getEntriesSuccess( page, false ) );
+
+		expect( result.entries ).toEqual( {
+			id_200: { id: 200, type: 'new', timestamp: 2001 },
+		} );
+	} );
+
+	it( 'records locally rendered polling entries when the queue is cleared', () => {
+		const newEntry = { id: 300, type: 'new', timestamp: 2003 };
+		const result = polling(
+			initialState,
+			pollingSuccess( { entries: [ newEntry ] }, true )
+		);
+
+		expect( result.entries ).toEqual( {} );
+		expect( result.knownEntryIds ).toEqual( { id_300: true } );
 	} );
 } );

--- a/src/react/reducers/polling.js
+++ b/src/react/reducers/polling.js
@@ -1,9 +1,16 @@
 import { applyUpdate, getNewestEntry } from '../utils/utils';
+import {
+	filterKnownNewEntries,
+	rememberPolledEntries,
+	rememberRenderedEntries,
+	removeRenderedPendingEntries,
+} from '../utils/polling';
 
 export const initialState = {
 	error: false,
 	newestEntry: false,
 	entries: {},
+	knownEntryIds: {},
 	pages: 1,
 };
 
@@ -17,10 +24,15 @@ export const polling = ( state = initialState, action ) => {
 					? {}
 					: applyUpdate(
 							state.entries,
-							action.payload.entries.filter(
-								( entry ) => entry.type === 'new'
+							filterKnownNewEntries(
+								action.payload.entries,
+								state.knownEntryIds
 							)
 					  ),
+				knownEntryIds: rememberPolledEntries(
+					state.knownEntryIds,
+					action.payload.entries
+				),
 				newestEntry: getNewestEntry(
 					state.newestEntry,
 					action.payload.entries[ action.payload.entries.length - 1 ]
@@ -36,15 +48,27 @@ export const polling = ( state = initialState, action ) => {
 				error: true,
 			};
 
-		case 'GET_ENTRIES_SUCCESS':
+		case 'GET_ENTRIES_SUCCESS': {
+			const knownEntryIds = rememberRenderedEntries(
+				state.knownEntryIds,
+				action.payload.entries
+			);
+
 			return {
 				...state,
 				newestEntry: getNewestEntry(
 					state.newestEntry,
 					action.payload.entries[ 0 ]
 				),
-				entries: action.renderNewEntries ? {} : state.entries,
+				entries: action.renderNewEntries
+					? {}
+					: removeRenderedPendingEntries(
+							state.entries,
+							action.payload.entries
+					  ),
+				knownEntryIds,
 			};
+		}
 
 		case 'MERGE_POLLING_INTO_ENTRIES':
 			return {

--- a/src/react/utils/__tests__/polling.test.js
+++ b/src/react/utils/__tests__/polling.test.js
@@ -1,46 +1,85 @@
-import { filterRenderedNewEntries } from '../polling';
+import { filterKnownNewEntries } from '../polling';
 
-describe( 'filterRenderedNewEntries', () => {
+describe( 'filterKnownNewEntries', () => {
 	const renderedEntries = {
-		id_100: { id: 100, type: 'new' },
+		id_100: { id: 100, type: 'new', timestamp: 2000 },
 	};
+	const newestEntry = { id: 100, type: 'new', timestamp: 2000 };
 
 	it( 'removes new entries that are already rendered', () => {
 		const entries = [
-			{ id: 100, type: 'new' },
-			{ id: 101, type: 'new' },
+			{ id: 100, type: 'new', timestamp: 2000 },
+			{ id: 101, type: 'new', timestamp: 2001 },
 		];
 
-		expect( filterRenderedNewEntries( entries, renderedEntries ) ).toEqual( [
-			{ id: 101, type: 'new' },
+		expect(
+			filterKnownNewEntries( entries, renderedEntries, newestEntry )
+		).toEqual( [ { id: 101, type: 'new', timestamp: 2001 } ] );
+	} );
+
+	it( 'removes older new entries that are outside the current rendered page', () => {
+		const entries = [ { id: 90, type: 'new', timestamp: 1999 } ];
+
+		expect( filterKnownNewEntries( entries, {}, newestEntry ) ).toEqual( [] );
+	} );
+
+	it( 'removes same-second new entries up to the known newest ID', () => {
+		const entries = [
+			{ id: 99, type: 'new', timestamp: 2000 },
+			{ id: 100, type: 'new', timestamp: 2000 },
+			{ id: 101, type: 'new', timestamp: 2000 },
+		];
+
+		expect( filterKnownNewEntries( entries, {}, newestEntry ) ).toEqual( [
+			{ id: 101, type: 'new', timestamp: 2000 },
 		] );
 	} );
 
-	it( 'keeps updates and deletes for rendered entry IDs', () => {
+	it( 'uses an initial config baseline to order same-second IDs', () => {
+		const configBaseline = { id: 100, timestamp: 2000 };
 		const entries = [
-			{ id: 100, type: 'update' },
-			{ id: 100, type: 'delete' },
+			{ id: 99, type: 'new', timestamp: 2000 },
+			{ id: 101, type: 'new', timestamp: 2000 },
 		];
 
-		expect( filterRenderedNewEntries( entries, renderedEntries ) ).toEqual(
+		expect( filterKnownNewEntries( entries, {}, configBaseline ) ).toEqual( [
+			{ id: 101, type: 'new', timestamp: 2000 },
+		] );
+	} );
+
+	it( 'does not order same-second new entries by an update entry ID', () => {
+		const updateBaseline = { id: 50, type: 'update', timestamp: 2000 };
+		const entries = [ { id: 40, type: 'new', timestamp: 2000 } ];
+
+		expect( filterKnownNewEntries( entries, {}, updateBaseline ) ).toEqual(
 			entries
 		);
 	} );
 
-	it( 'keeps a new entry with a different ID', () => {
-		const entries = [ { id: 101, type: 'new', timestamp: 2000 } ];
+	it( 'still removes entries older than an update baseline', () => {
+		const updateBaseline = { id: 50, type: 'update', timestamp: 2000 };
+		const entries = [ { id: 100, type: 'new', timestamp: 1999 } ];
 
-		expect( filterRenderedNewEntries( entries, renderedEntries ) ).toEqual(
-			entries
-		);
+		expect( filterKnownNewEntries( entries, {}, updateBaseline ) ).toEqual( [] );
 	} );
 
-	it( 'returns all entries when nothing is rendered yet', () => {
+	it( 'keeps updates and deletes for known entry IDs', () => {
 		const entries = [
-			{ id: 100, type: 'new' },
-			{ id: 100, type: 'update' },
+			{ id: 100, type: 'update', timestamp: 2001 },
+			{ id: 100, type: 'delete', timestamp: 2002 },
 		];
 
-		expect( filterRenderedNewEntries( entries, {} ) ).toEqual( entries );
+		expect(
+			filterKnownNewEntries( entries, renderedEntries, newestEntry )
+		).toEqual( entries );
+	} );
+
+	it( 'returns all entries when there is no rendered or baseline state', () => {
+		const entries = [
+			{ id: 100, type: 'new', timestamp: 2000 },
+			{ id: 100, type: 'update', timestamp: 2001 },
+		];
+
+		expect( filterKnownNewEntries( entries, {}, false ) ).toEqual( entries );
 	} );
 } );

--- a/src/react/utils/__tests__/polling.test.js
+++ b/src/react/utils/__tests__/polling.test.js
@@ -1,0 +1,46 @@
+import { filterRenderedNewEntries } from '../polling';
+
+describe( 'filterRenderedNewEntries', () => {
+	const renderedEntries = {
+		id_100: { id: 100, type: 'new' },
+	};
+
+	it( 'removes new entries that are already rendered', () => {
+		const entries = [
+			{ id: 100, type: 'new' },
+			{ id: 101, type: 'new' },
+		];
+
+		expect( filterRenderedNewEntries( entries, renderedEntries ) ).toEqual( [
+			{ id: 101, type: 'new' },
+		] );
+	} );
+
+	it( 'keeps updates and deletes for rendered entry IDs', () => {
+		const entries = [
+			{ id: 100, type: 'update' },
+			{ id: 100, type: 'delete' },
+		];
+
+		expect( filterRenderedNewEntries( entries, renderedEntries ) ).toEqual(
+			entries
+		);
+	} );
+
+	it( 'keeps a new entry with a different ID', () => {
+		const entries = [ { id: 101, type: 'new', timestamp: 2000 } ];
+
+		expect( filterRenderedNewEntries( entries, renderedEntries ) ).toEqual(
+			entries
+		);
+	} );
+
+	it( 'returns all entries when nothing is rendered yet', () => {
+		const entries = [
+			{ id: 100, type: 'new' },
+			{ id: 100, type: 'update' },
+		];
+
+		expect( filterRenderedNewEntries( entries, {} ) ).toEqual( entries );
+	} );
+} );

--- a/src/react/utils/__tests__/polling.test.js
+++ b/src/react/utils/__tests__/polling.test.js
@@ -1,0 +1,124 @@
+import {
+	filterKnownNewEntries,
+	rememberPolledEntries,
+	rememberRenderedEntries,
+	removeRenderedPendingEntries,
+} from '../polling';
+
+describe( 'polling entry deduplication', () => {
+	it( 'removes only known new entries', () => {
+		const knownEntryIds = { id_100: true };
+		const entries = [
+			{ id: 100, type: 'new', timestamp: 2000 },
+			{ id: 90, type: 'new', timestamp: 1999 },
+			{ id: 99, type: 'new', timestamp: 2000 },
+			{ id: 100, type: 'update', timestamp: 2001 },
+			{ id: 100, type: 'delete', timestamp: 2002 },
+		];
+
+		expect( filterKnownNewEntries( entries, knownEntryIds ) ).toEqual( [
+			{ id: 90, type: 'new', timestamp: 1999 },
+			{ id: 99, type: 'new', timestamp: 2000 },
+		] );
+	} );
+
+	it( 'deduplicates repeated new IDs within one polling response', () => {
+		const entries = [
+			{ id: 100, type: 'new', timestamp: 2000 },
+			{ id: 100, type: 'new', timestamp: 2000 },
+			{ id: 101, type: 'new', timestamp: 2000 },
+		];
+
+		expect( filterKnownNewEntries( entries, {} ) ).toEqual( [
+			{ id: 100, type: 'new', timestamp: 2000 },
+			{ id: 101, type: 'new', timestamp: 2000 },
+		] );
+	} );
+
+	it( 'remembers updated entries that were rendered by paged loading', () => {
+		const knownEntryIds = rememberRenderedEntries( {}, [
+			{ id: 100, type: 'update', timestamp: 2001 },
+		] );
+
+		expect(
+			filterKnownNewEntries(
+				[ { id: 100, type: 'new', timestamp: 2000 } ],
+				knownEntryIds
+			)
+		).toEqual( [] );
+	} );
+
+	it( 'does not let an unseen polling update suppress a late new entry', () => {
+		const knownEntryIds = rememberPolledEntries( {}, [
+			{ id: 100, type: 'update', timestamp: 2001 },
+		] );
+		const delayedNew = [ { id: 100, type: 'new', timestamp: 2000 } ];
+
+		expect( filterKnownNewEntries( delayedNew, knownEntryIds ) ).toEqual(
+			delayedNew
+		);
+	} );
+
+	it( 'does not let an unseen polling delete suppress a late new entry', () => {
+		const knownEntryIds = rememberPolledEntries( {}, [
+			{ id: 100, type: 'delete', timestamp: 2001 },
+		] );
+		const delayedNew = [ { id: 100, type: 'new', timestamp: 2000 } ];
+
+		expect( filterKnownNewEntries( delayedNew, knownEntryIds ) ).toEqual(
+			delayedNew
+		);
+	} );
+
+	it( 'remembers conclusive polling IDs without mutating the lookup', () => {
+		const knownEntryIds = { id_100: true };
+		const updated = rememberPolledEntries( knownEntryIds, [
+			{ id: 101, type: 'new' },
+			{ id: 102, type: 'update' },
+			{ id: 103, type: 'delete' },
+		] );
+
+		expect( knownEntryIds ).toEqual( { id_100: true } );
+		expect( updated ).toEqual( {
+			id_100: true,
+			id_101: true,
+		} );
+	} );
+
+	it( 'reuses the lookup when polling adds no new IDs', () => {
+		const knownEntryIds = { id_100: true };
+
+		expect(
+			rememberPolledEntries( knownEntryIds, [
+				{ id: 100, type: 'new' },
+				{ id: 101, type: 'update' },
+			] )
+		).toBe( knownEntryIds );
+	} );
+
+	it( 'removes only pending IDs that a page response actually rendered', () => {
+		const pendingEntries = {
+			id_100: { id: 100, type: 'new' },
+			id_200: { id: 200, type: 'new' },
+		};
+
+		expect(
+			removeRenderedPendingEntries( pendingEntries, [
+				{ id: 100, type: 'update' },
+			] )
+		).toEqual( {
+			id_200: { id: 200, type: 'new' },
+		} );
+	} );
+
+	it( 'ignores malformed entries without poisoning the lookup', () => {
+		const knownEntryIds = {};
+
+		expect(
+			rememberRenderedEntries( knownEntryIds, [
+				{ type: 'new', timestamp: 2000 },
+				{ id: 100, type: 'unexpected', timestamp: 2000 },
+			] )
+		).toBe( knownEntryIds );
+	} );
+} );

--- a/src/react/utils/polling.js
+++ b/src/react/utils/polling.js
@@ -1,0 +1,22 @@
+/**
+ * Remove polling entries that are already rendered as new entries.
+ *
+ * Polling URLs are rounded to cache buckets, so a response may include an
+ * entry that the client has already rendered. Updates and deletes must still
+ * pass through because they represent new changes to an existing entry.
+ *
+ * @param {Array}  entries         Polling response entries.
+ * @param {Object} renderedEntries Entries currently rendered by the API reducer.
+ * @return {Array} Polling entries that still need to be processed.
+ */
+export const filterRenderedNewEntries = ( entries, renderedEntries ) =>
+	entries.filter( ( entry ) => {
+		if ( entry.type !== 'new' ) {
+			return true;
+		}
+
+		return ! Object.prototype.hasOwnProperty.call(
+			renderedEntries,
+			`id_${ entry.id }`
+		);
+	} );

--- a/src/react/utils/polling.js
+++ b/src/react/utils/polling.js
@@ -1,22 +1,72 @@
 /**
- * Remove polling entries that are already rendered as new entries.
+ * Remove polling entries that are already known to the client as new entries.
  *
- * Polling URLs are rounded to cache buckets, so a response may include an
- * entry that the client has already rendered. Updates and deletes must still
- * pass through because they represent new changes to an existing entry.
+ * Polling URLs are rounded to cache buckets, so a response may include entries
+ * from before the client's current polling baseline. Updates and deletes must
+ * still pass through because they represent new changes to existing entries.
  *
- * @param {Array}  entries         Polling response entries.
- * @param {Object} renderedEntries Entries currently rendered by the API reducer.
+ * @param {Array}        entries         Polling response entries.
+ * @param {Object}       renderedEntries Entries currently rendered by the API reducer.
+ * @param {Object|false} newestEntry     Newest entry known when polling starts.
  * @return {Array} Polling entries that still need to be processed.
  */
-export const filterRenderedNewEntries = ( entries, renderedEntries ) =>
+export const filterKnownNewEntries = (
+	entries,
+	renderedEntries,
+	newestEntry
+) =>
 	entries.filter( ( entry ) => {
 		if ( entry.type !== 'new' ) {
 			return true;
 		}
 
-		return ! Object.prototype.hasOwnProperty.call(
-			renderedEntries,
-			`id_${ entry.id }`
-		);
+		if (
+			Object.prototype.hasOwnProperty.call(
+				renderedEntries,
+				`id_${ entry.id }`
+			)
+		) {
+			return false;
+		}
+
+		if ( ! newestEntry || ! entry.timestamp || ! newestEntry.timestamp ) {
+			return true;
+		}
+
+		const entryTimestamp = parseInt( entry.timestamp, 10 );
+		const newestTimestamp = parseInt( newestEntry.timestamp, 10 );
+
+		if (
+			! Number.isFinite( entryTimestamp ) ||
+			! Number.isFinite( newestTimestamp )
+		) {
+			return true;
+		}
+
+		if ( entryTimestamp < newestTimestamp ) {
+			return false;
+		}
+
+		if ( entryTimestamp > newestTimestamp ) {
+			return true;
+		}
+
+		const entryId = parseInt( entry.id, 10 );
+		const newestId = parseInt( newestEntry.id, 10 );
+
+		if ( ! Number.isFinite( entryId ) || ! Number.isFinite( newestId ) ) {
+			return true;
+		}
+
+		/*
+		 * A runtime update/delete exposes the replaced entry ID, not the newer
+		 * comment ID, so IDs cannot safely order same-second entries in that case.
+		 * A missing type is the initial config baseline, where latest_entry_id is
+		 * the newest comment ID and can be compared safely.
+		 */
+		if ( newestEntry.type && newestEntry.type !== 'new' ) {
+			return true;
+		}
+
+		return entryId > newestId;
 	} );

--- a/src/react/utils/polling.js
+++ b/src/react/utils/polling.js
@@ -1,0 +1,156 @@
+const getEntryKey = ( entry ) => {
+	if ( ! entry || entry.id === undefined || entry.id === null ) {
+		return false;
+	}
+
+	return `id_${ entry.id }`;
+};
+
+const hasEntryKey = ( lookup, key ) =>
+	Boolean( key ) && Object.prototype.hasOwnProperty.call( lookup, key );
+
+/**
+ * Return polling `new` entries whose logical IDs are not already known.
+ *
+ * Deduplication is deliberately based on entry identity, not timestamp
+ * ordering. Repeated IDs within the same response are also collapsed.
+ *
+ * @param {Array}  entries       Polling response entries.
+ * @param {Object} knownEntryIds Logical entry IDs already known to the client.
+ * @return {Array} New entries that still need to be queued.
+ */
+export const filterKnownNewEntries = ( entries, knownEntryIds = {} ) => {
+	const newIdsInBatch = {};
+
+	return entries.filter( ( entry ) => {
+		if ( entry.type !== 'new' ) {
+			return false;
+		}
+
+		const key = getEntryKey( entry );
+
+		if ( ! key ) {
+			return true;
+		}
+
+		if (
+			hasEntryKey( knownEntryIds, key ) ||
+			hasEntryKey( newIdsInBatch, key )
+		) {
+			return false;
+		}
+
+		newIdsInBatch[ key ] = true;
+		return true;
+	} );
+};
+
+/**
+ * Add selected logical IDs to the known-entry lookup, cloning at most once.
+ *
+ * @param {Object}   knownEntryIds  Logical entry IDs already known to the client.
+ * @param {Array}    entries        Entries received in the current batch.
+ * @param {Function} shouldRemember Whether the entry proves its ID is known.
+ * @return {Object} Updated known-entry ID lookup.
+ */
+const rememberEntryIds = ( knownEntryIds = {}, entries, shouldRemember ) => {
+	let nextKnownEntryIds = knownEntryIds;
+
+	entries.forEach( ( entry ) => {
+		if ( ! shouldRemember( entry ) ) {
+			return;
+		}
+
+		const key = getEntryKey( entry );
+
+		if ( ! key || hasEntryKey( nextKnownEntryIds, key ) ) {
+			return;
+		}
+
+		if ( nextKnownEntryIds === knownEntryIds ) {
+			nextKnownEntryIds = { ...knownEntryIds };
+		}
+
+		nextKnownEntryIds[ key ] = true;
+	} );
+
+	return nextKnownEntryIds;
+};
+
+/**
+ * Remember IDs for entries loaded as a rendered page.
+ *
+ * Paged responses are flattened server-side, so any logical ID present there
+ * is known to the client even when the returned representation is an update of
+ * an older entry.
+ *
+ * @param {Object} knownEntryIds Logical entry IDs already known to the client.
+ * @param {Array}  entries       Entries rendered in the current page.
+ * @return {Object} Updated known-entry ID lookup.
+ */
+export const rememberRenderedEntries = ( knownEntryIds, entries ) =>
+	rememberEntryIds(
+		knownEntryIds,
+		entries,
+		( entry ) => entry.type === 'new' || entry.type === 'update'
+	);
+
+/**
+ * Remember IDs that are conclusive when received through polling.
+ *
+ * Only a `new` entry proves that its logical ID has actually been delivered by
+ * polling. An unseen `update` or `delete` is not used as deduplication evidence,
+ * because the original `new` entry may still arrive later.
+ *
+ * @param {Object} knownEntryIds Logical entry IDs already known to the client.
+ * @param {Array}  entries       Unmodified polling response entries.
+ * @return {Object} Updated known-entry ID lookup.
+ */
+export const rememberPolledEntries = ( knownEntryIds, entries ) =>
+	rememberEntryIds(
+		knownEntryIds,
+		entries,
+		( entry ) => entry.type === 'new'
+	);
+
+/**
+ * Remove pending entries that have since been delivered in a rendered page.
+ *
+ * This closes the race where polling completes before the initial or paginated
+ * GET_ENTRIES request. Only IDs present in that rendered response are removed;
+ * unrelated genuine pending entries remain queued.
+ *
+ * @param {Object} pendingEntries  Pending `new` entries keyed by logical ID.
+ * @param {Array}  renderedEntries Entries returned by the rendered page load.
+ * @return {Object} Updated pending-entry lookup.
+ */
+export const removeRenderedPendingEntries = (
+	pendingEntries,
+	renderedEntries
+) => {
+	let nextPendingEntries = pendingEntries;
+
+	renderedEntries.forEach( ( entry ) => {
+		if (
+			entry.type !== 'new' &&
+			entry.type !== 'update' &&
+			entry.type !== 'delete'
+		) {
+			return;
+		}
+
+		const key = getEntryKey( entry );
+
+		if ( ! key || ! hasEntryKey( nextPendingEntries, key ) ) {
+			return;
+		}
+
+		if ( nextPendingEntries === pendingEntries ) {
+			nextPendingEntries = { ...pendingEntries };
+		}
+
+		delete nextPendingEntries[ key ];
+	} );
+
+	return nextPendingEntries;
+};


### PR DESCRIPTION
## Summary

Prevent cached polling buckets from re-queuing `new` entries whose logical IDs the client already knows about.

The polling start timestamp is intentionally rounded to the refresh-interval bucket for cache efficiency. This can make the requested timestamp range overlap entries already delivered to the client. When new entries are not auto-rendered, a duplicate can enter the pending polling queue and produce a false `1 new entry available` nag.

## Root cause

The start-timestamp bucketing introduced in `99da1326` assumes duplicate polling entries are harmless because entry application is deduplicated by ID.

That is true for rendered API state, but the pending polling queue is separate. A cached `type: "new"` entry can therefore be queued again even though the client already knows that logical entry ID.

There is also a pagination/race variant: rendered page state can change independently of the pending queue, and polling may complete before the initial or paginated page request.

## Fix

Keep the existing polling response, timestamp cursor, pagination, events and cache behavior unchanged.

Deduplication now happens only when building the pending-new queue:

* track logical entry IDs that have actually been delivered to the client
* suppress only `type: "new"` entries whose logical ID is already known
* collapse repeated `new` IDs within the same polling response
* preserve a late, previously unseen `new` entry regardless of timestamp
* do not treat an unseen polling `update` or `delete` as proof that the original `new` was already delivered
* when a page-load response completes after polling, remove from the pending queue only IDs actually present in that rendered response

Paged responses are flattened server-side, so a rendered `update` also establishes that its logical entry ID is known to the client.

The bucketed polling URLs and cache cohorts remain unchanged.

## Tests

Adds unit coverage for:

* known-ID duplicate `new` entries
* repeated IDs within one polling response
* late `new` entries after unseen polling `update`/`delete`
* rendered updated entries
* polling-before-page-load races
* preserving unrelated pending entries
* advancing polling metadata even when a duplicate is not queued
* malformed entries not poisoning the known-ID lookup

## Validation

The original issue was reproduced consistently on a production WordPress liveblog.

Before the fix, the first polling cycle could show `1 new entry available` without any new publication.

After applying equivalent ID-based deduplication:

* no false update nag is shown
* genuine new entries auto-render normally when the latest entry is visible
* genuine new entries correctly produce the update nag when the reader is scrolled away
* loading the pending entry clears the nag without it being re-queued
* a late, previously unseen `new` entry is not silently discarded based on timestamp ordering
